### PR TITLE
fix(AMBER-1714): Create new field to hit /match/fairs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17262,6 +17262,19 @@ type Partner implements Node {
     page: Int
     size: Int
   ): PartnerAlertHitsConnection
+
+  # Retrieve partner fairs for search
+  partnerFairConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+
+    # Search term for fairs
+    term: String
+  ): PartnerFairConnection
   partnerPageEligible: Boolean
   partnerType: String
   profile: Profile
@@ -17982,6 +17995,26 @@ type PartnerEngagementCounts {
   ): Int!
   followedArtists: Int!
   savedArtworks: Int!
+}
+
+# A connection to a list of items.
+type PartnerFairConnection {
+  # A list of edges.
+  edges: [PartnerFairEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerFairEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Fair
 }
 
 type PartnerInquiryRequest {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17267,13 +17267,20 @@ type Partner implements Node {
   partnerFairConnection(
     after: String
     before: String
+
+    # Exclude these MongoDB ids from results
+    excludeIDs: [String]
     first: Int
     last: Int
+
+    # Page to retrieve. Default: 1.
     page: Int
+
+    # Maximum number of items to retrieve. Default: 5.
     size: Int
 
-    # Search term for fairs
-    term: String
+    # Your search term
+    term: String!
   ): PartnerFairConnection
   partnerPageEligible: Boolean
   partnerType: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17263,7 +17263,7 @@ type Partner implements Node {
     size: Int
   ): PartnerAlertHitsConnection
 
-  # Retrieve partner fairs for search
+  # A connection of fairs for a partner.
   partnerFairConnection(
     after: String
     before: String
@@ -17272,12 +17272,6 @@ type Partner implements Node {
     excludeIDs: [String]
     first: Int
     last: Int
-
-    # Page to retrieve. Default: 1.
-    page: Int
-
-    # Maximum number of items to retrieve. Default: 5.
-    size: Int
 
     # Your search term
     term: String!

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -757,6 +757,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
+    partnerFairLoader: gravityLoader("match/fairs", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     meAlertLoader: gravityLoader((id) => `me/alert/${id}`),
     meAlertsLoader: gravityLoader("me/alerts", {}, { headers: true }),

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -757,7 +757,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
-    partnerFairLoader: gravityLoader("match/fairs", {}, { headers: true }),
+    matchFairsLoader: gravityLoader("match/fairs", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     meAlertLoader: gravityLoader((id) => `me/alert/${id}`),
     meAlertsLoader: gravityLoader("me/alerts", {}, { headers: true }),

--- a/src/schema/v2/partner/__tests__/partnerFairConnection.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerFairConnection.test.ts
@@ -1,0 +1,287 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("PartnerFairConnection", () => {
+  let context
+  let partnerData
+  let fairsResponse
+
+  beforeEach(() => {
+    partnerData = {
+      _id: "partner-id",
+      id: "test-partner",
+      slug: "test-partner",
+      name: "Test Partner",
+      type: "Gallery",
+    }
+
+    fairsResponse = {
+      body: [
+        {
+          _id: "fair-1",
+          id: "fair-1",
+          name: "Art Fair 1",
+          slug: "art-fair-1",
+        },
+        {
+          _id: "fair-2",
+          id: "fair-2",
+          name: "Art Fair 2",
+          slug: "art-fair-2",
+        },
+      ],
+      headers: {
+        "x-total-count": "2",
+      },
+    }
+
+    context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      matchFairsLoader: jest.fn().mockResolvedValue(fairsResponse),
+    }
+  })
+
+  it("returns partner fair connection with required term parameter", async () => {
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art") {
+            totalCount
+            edges {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        partnerFairConnection: {
+          totalCount: 2,
+          edges: [
+            {
+              node: {
+                id: "fair-1",
+                name: "Art Fair 1",
+                slug: "art-fair-1",
+              },
+            },
+            {
+              node: {
+                id: "fair-2",
+                name: "Art Fair 2",
+                slug: "art-fair-2",
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    expect(context.matchFairsLoader).toHaveBeenCalledWith({
+      size: 5,
+      offset: 0,
+      total_count: true,
+      term: "art",
+      exclude_ids: undefined,
+    })
+  })
+
+  it("supports pagination parameters", async () => {
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art", page: 2, size: 10) {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(context.matchFairsLoader).toHaveBeenCalledWith({
+      size: 10,
+      offset: 10,
+      total_count: true,
+      term: "art",
+      exclude_ids: undefined,
+    })
+  })
+
+  it("supports excludeIDs parameter", async () => {
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art", excludeIDs: ["fair-1", "fair-3"]) {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(context.matchFairsLoader).toHaveBeenCalledWith({
+      size: 5,
+      offset: 0,
+      total_count: true,
+      term: "art",
+      exclude_ids: ["fair-1", "fair-3"],
+    })
+  })
+
+  it("returns null when matchFairsLoader is not available", async () => {
+    context.matchFairsLoader = null
+
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art") {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        partnerFairConnection: null,
+      },
+    })
+  })
+
+  it("handles empty results", async () => {
+    context.matchFairsLoader.mockResolvedValue({
+      body: [],
+      headers: {
+        "x-total-count": "0",
+      },
+    })
+
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "nonexistent") {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        partnerFairConnection: {
+          totalCount: 0,
+          edges: [],
+        },
+      },
+    })
+  })
+
+  it("requires term parameter", async () => {
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query, context)
+
+    expect(result.errors).toBeDefined()
+    expect(result.errors[0].message).toContain("term")
+  })
+
+  it("handles loader errors gracefully", async () => {
+    context.matchFairsLoader.mockRejectedValue(new Error("API Error"))
+
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art") {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query, context)
+
+    expect(result.errors).toBeDefined()
+    expect(result.errors[0].message).toContain("API Error")
+  })
+
+  it("parses total count from headers correctly", async () => {
+    context.matchFairsLoader.mockResolvedValue({
+      body: [],
+      headers: {
+        "x-total-count": "42",
+      },
+    })
+
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art") {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.partner.partnerFairConnection.totalCount).toBe(42)
+  })
+
+  it("defaults total count to 0 when header is missing", async () => {
+    context.matchFairsLoader.mockResolvedValue({
+      body: [],
+      headers: {},
+    })
+
+    const query = gql`
+      {
+        partner(id: "test-partner") {
+          partnerFairConnection(term: "art") {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.partner.partnerFairConnection.totalCount).toBe(0)
+  })
+})

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -50,6 +50,7 @@ import { setVersion } from "schema/v2/image/normalize"
 import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
+import { PartnerFairConnection } from "./partnerFairConnection"
 import { AlertType, PartnerAlertsEdgeFields } from "../Alerts"
 import {
   ArtworkVisibility,
@@ -1294,6 +1295,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       showsSearchConnection: partnerShowsMatchConnection,
+      partnerFairConnection: PartnerFairConnection,
       type: {
         type: GraphQLString,
         resolve: ({ name, type }) => {

--- a/src/schema/v2/partner/partnerFairConnection.ts
+++ b/src/schema/v2/partner/partnerFairConnection.ts
@@ -36,20 +36,25 @@ export const PartnerFairConnection: GraphQLFieldConfig<
       description: "Exclude these MongoDB ids from results",
     },
   }),
-  resolve: async (_root, { excludeIDs, ...args }, { matchFairsLoader }) => {
+  resolve: async (
+    _root,
+    { excludeIDs, term, ...args },
+    { matchFairsLoader }
+  ) => {
     if (!matchFairsLoader) {
       return null
     }
+    console.log(excludeIDs, term, args)
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-    const gravityOptions = {
-      size,
-      offset,
-      total_count: true,
-      term: args.term,
-      exclude_ids: excludeIDs,
-    }
-    const { body, headers } = await matchFairsLoader(gravityOptions)
+    const gravityArgs: {
+      page: number
+      size: number
+      total_count: boolean
+      term?: string
+      id?: string[]
+    } = { page, size, term, total_count: true }
+    const { body, headers } = await matchFairsLoader(gravityArgs)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return paginationResolver({

--- a/src/schema/v2/partner/partnerFairConnection.ts
+++ b/src/schema/v2/partner/partnerFairConnection.ts
@@ -30,8 +30,8 @@ export const PartnerFairConnection: GraphQLFieldConfig<
       type: GraphQLInt,
     },
   }),
-  resolve: async (_root, args, { partnerFairLoader }) => {
-    if (!partnerFairLoader) {
+  resolve: async (_root, args, { matchFairsLoader }) => {
+    if (!matchFairsLoader) {
       return null
     }
 
@@ -42,7 +42,7 @@ export const PartnerFairConnection: GraphQLFieldConfig<
       total_count: true,
       term: args.term,
     }
-    const { body, headers } = await partnerFairLoader(gravityOptions)
+    const { body, headers } = await matchFairsLoader(gravityOptions)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return paginationResolver({

--- a/src/schema/v2/partner/partnerFairConnection.ts
+++ b/src/schema/v2/partner/partnerFairConnection.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLInt, GraphQLNonNull, GraphQLList } from "graphql"
+import { GraphQLString, GraphQLNonNull, GraphQLList } from "graphql"
 import { ResolverContext } from "types/graphql"
 import {
   connectionWithCursorInfo,
@@ -10,51 +10,37 @@ import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { FairType } from "schema/v2/fair"
 
 export const PartnerFairConnection: GraphQLFieldConfig<
-  void,
+  { id: string },
   ResolverContext
 > = {
   type: connectionWithCursorInfo({
     name: "PartnerFair",
     nodeType: FairType,
   }).connectionType,
-  description: "Retrieve partner fairs for search",
+  description: "A connection of fairs for a partner.",
   args: pageable({
     term: {
       type: new GraphQLNonNull(GraphQLString),
       description: "Your search term",
-    },
-    page: {
-      type: GraphQLInt,
-      description: "Page to retrieve. Default: 1.",
-    },
-    size: {
-      type: GraphQLInt,
-      description: "Maximum number of items to retrieve. Default: 5.",
     },
     excludeIDs: {
       type: new GraphQLList(GraphQLString),
       description: "Exclude these MongoDB ids from results",
     },
   }),
-  resolve: async (
-    _root,
-    { excludeIDs, term, ...args },
-    { matchFairsLoader }
-  ) => {
-    if (!matchFairsLoader) {
-      return null
-    }
-    console.log(excludeIDs, term, args)
+  resolve: async (_, args, { matchFairsLoader }) => {
+    if (!matchFairsLoader) return null
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
-    const gravityArgs: {
-      page: number
-      size: number
-      total_count: boolean
-      term?: string
-      id?: string[]
-    } = { page, size, term, total_count: true }
-    const { body, headers } = await matchFairsLoader(gravityArgs)
+
+    const { body, headers } = await matchFairsLoader({
+      page,
+      size,
+      total_count: true,
+      term: args.term,
+      exclude_ids: args.excludeIDs,
+    })
+
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
     return paginationResolver({

--- a/src/schema/v2/partner/partnerFairConnection.ts
+++ b/src/schema/v2/partner/partnerFairConnection.ts
@@ -1,4 +1,4 @@
-import { GraphQLString, GraphQLInt } from "graphql"
+import { GraphQLString, GraphQLInt, GraphQLNonNull, GraphQLList } from "graphql"
 import { ResolverContext } from "types/graphql"
 import {
   connectionWithCursorInfo,
@@ -20,17 +20,23 @@ export const PartnerFairConnection: GraphQLFieldConfig<
   description: "Retrieve partner fairs for search",
   args: pageable({
     term: {
-      type: GraphQLString,
-      description: "Search term for fairs",
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Your search term",
     },
     page: {
       type: GraphQLInt,
+      description: "Page to retrieve. Default: 1.",
     },
     size: {
       type: GraphQLInt,
+      description: "Maximum number of items to retrieve. Default: 5.",
+    },
+    excludeIDs: {
+      type: new GraphQLList(GraphQLString),
+      description: "Exclude these MongoDB ids from results",
     },
   }),
-  resolve: async (_root, args, { matchFairsLoader }) => {
+  resolve: async (_root, { excludeIDs, ...args }, { matchFairsLoader }) => {
     if (!matchFairsLoader) {
       return null
     }
@@ -41,6 +47,7 @@ export const PartnerFairConnection: GraphQLFieldConfig<
       offset,
       total_count: true,
       term: args.term,
+      exclude_ids: excludeIDs,
     }
     const { body, headers } = await matchFairsLoader(gravityOptions)
     const totalCount = parseInt(headers["x-total-count"] || "0", 10)

--- a/src/schema/v2/partner/partnerFairConnection.ts
+++ b/src/schema/v2/partner/partnerFairConnection.ts
@@ -1,0 +1,57 @@
+import { GraphQLString, GraphQLInt } from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
+import { GraphQLFieldConfig } from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { FairType } from "schema/v2/fair"
+
+export const PartnerFairConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: connectionWithCursorInfo({
+    name: "PartnerFair",
+    nodeType: FairType,
+  }).connectionType,
+  description: "Retrieve partner fairs for search",
+  args: pageable({
+    term: {
+      type: GraphQLString,
+      description: "Search term for fairs",
+    },
+    page: {
+      type: GraphQLInt,
+    },
+    size: {
+      type: GraphQLInt,
+    },
+  }),
+  resolve: async (_root, args, { partnerFairLoader }) => {
+    if (!partnerFairLoader) {
+      return null
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const gravityOptions = {
+      size,
+      offset,
+      total_count: true,
+      term: args.term,
+    }
+    const { body, headers } = await partnerFairLoader(gravityOptions)
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}


### PR DESCRIPTION
attempts to fix https://artsyproduct.atlassian.net/browse/AMBER-1714

🐛 Partners are no longer able to search for fairs that are not live yet

Partners need to do this in order to create their fair booths _prior_ to the fairs release to the public internet so we've added an authenticated loader for partners to hit to search for fairs at `/match/fairs`

⚠️ Heads up, I did try to get the `matchConnection` to work for an authenticated user but that got too futsy, thinking this scoped to partner might be a nice separation of concerns



Query structure will look something like this
<img width="1293" alt="Screenshot 2025-06-24 at 11 56 11 AM" src="https://github.com/user-attachments/assets/82018b0b-7ab0-458a-a4d1-a688deb8527a" />

