### PR TITLE
fix: Allow authenticated users to query for `visibile_to_public:false` fairs

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19349,6 +19349,9 @@ type Query {
     near: Near
     sort: FairSorts
     status: EventStatus
+
+    # Search term to match against fair names
+    term: String
   ): FairConnection
 
   # A Feature
@@ -25147,6 +25150,9 @@ type Viewer {
     near: Near
     sort: FairSorts
     status: EventStatus
+
+    # Search term to match against fair names
+    term: String
   ): FairConnection
 
   # A Feature

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19350,7 +19350,7 @@ type Query {
     sort: FairSorts
     status: EventStatus
 
-    # Search term to match against fair names
+    # Search term to match against fair names for authenticated users
     term: String
   ): FairConnection
 
@@ -25151,7 +25151,7 @@ type Viewer {
     sort: FairSorts
     status: EventStatus
 
-    # Search term to match against fair names
+    # Search term to match against fair names for authenticated users
     term: String
   ): FairConnection
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -756,6 +756,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    matchFairsLoader: gravityLoader("match/fairs", {}, { headers: true }),
     matchUsersLoader: gravityLoader("match/users", {}, { headers: true }),
     mergeArtistLoader: gravityLoader("artists/merge", {}, { method: "POST" }),
     meAlertLoader: gravityLoader((id) => `me/alert/${id}`),

--- a/src/schema/v2/__tests__/fairsConnection.test.ts
+++ b/src/schema/v2/__tests__/fairsConnection.test.ts
@@ -14,6 +14,20 @@ describe("fairsConnection", () => {
       }
     }
   `
+
+  const queryWithTerm = gql`
+    {
+      fairsConnection(first: 5, term: "art") {
+        totalCount
+        edges {
+          node {
+            name
+          }
+        }
+      }
+    }
+  `
+
   const fairsLoader = jest.fn(() =>
     Promise.resolve({
       body: [{ name: "Example Fair" }],
@@ -21,21 +35,61 @@ describe("fairsConnection", () => {
     })
   )
 
+  const matchFairsLoader = jest.fn(() =>
+    Promise.resolve({
+      body: [{ name: "Art Basel" }],
+      headers: { "x-total-count": "1" },
+    })
+  )
+
   afterEach(() => {
     fairsLoader.mockClear()
+    matchFairsLoader.mockClear()
   })
 
   it("returns a connection", async () => {
-    const { fairsConnection } = await runQuery(query, { fairsLoader })
+    const { fairsConnection } = await runQuery(query, {
+      unauthenticatedLoaders: { fairsLoader },
+    })
 
     expect(fairsConnection.totalCount).toBe(1)
     expect(fairsConnection.edges).toEqual([{ node: { name: "Example Fair" } }])
   })
 
   it("passes args to gravity", async () => {
-    await runQuery(query, { fairsLoader })
+    await runQuery(query, {
+      unauthenticatedLoaders: { fairsLoader },
+    })
 
     expect(fairsLoader).toBeCalledTimes(1)
     expect(fairsLoader).toBeCalledWith({ page: 1, size: 5, total_count: true })
+  })
+
+  it("uses matchFairsLoader when term is provided and user is authenticated", async () => {
+    const { fairsConnection } = await runQuery(queryWithTerm, {
+      unauthenticatedLoaders: { fairsLoader },
+      authenticatedLoaders: { matchFairsLoader },
+    })
+
+    expect(fairsConnection.totalCount).toBe(1)
+    expect(fairsConnection.edges).toEqual([{ node: { name: "Art Basel" } }])
+    expect(matchFairsLoader).toBeCalledTimes(1)
+    expect(matchFairsLoader).toBeCalledWith({
+      term: "art",
+      page: 1,
+      size: 5,
+      total_count: true,
+    })
+    expect(fairsLoader).not.toBeCalled()
+  })
+
+  it("throws error when term is provided but user is not authenticated", async () => {
+    await expect(
+      runQuery(queryWithTerm, {
+        unauthenticatedLoaders: { fairsLoader },
+      })
+    ).rejects.toThrow(
+      "You need to pass a X-Access-Token header to perform this action"
+    )
   })
 })

--- a/src/schema/v2/fairs.ts
+++ b/src/schema/v2/fairs.ts
@@ -126,15 +126,13 @@ export const fairsConnection: GraphQLFieldConfig<
   resolve: async (
     _root,
     args,
-    {
-      unauthenticatedLoaders: { fairsLoader },
-      authenticatedLoaders: { matchFairsLoader },
-    }
+    { unauthenticatedLoaders: { fairsLoader }, authenticatedLoaders }
   ) => {
     const { size, offset, page } = convertConnectionArgsToGravityArgs(args)
 
     // Use matchFairsLoader when term is provided
     if (args.term) {
+      const matchFairsLoader = authenticatedLoaders?.matchFairsLoader
       if (!matchFairsLoader)
         throw new Error(
           "You need to pass a X-Access-Token header to perform this action"


### PR DESCRIPTION
Stemming off this PR: https://github.com/artsy/metaphysics/pull/6842

Diagnosing from @lidimayra:

> It looks like the older version relied on the specific match endpoint for fairs ([ref](https://github.com/artsy/volt/blob/36dac6f61cb29b38458922257ddb122f1c25ca08/app/controllers/partner_shows_controller.rb#L33)).
> The new one relies on the generic match ([ref](https://github.com/artsy/volt/blob/36dac6f61cb29b38458922257ddb122f1c25ca08/app/javascript/components/AutocompleteInputs/FairAutocomplete.tsx#L250)).
> When switching from one to the other, we ended up losing the automatic access we had to non-public data if the request came from a user with special permissions ([ref](https://github.com/artsy/gravity/blob/a2f8ddd7960d2da26710f10a67c3da16989f8d32/app/api/v1/match_endpoint.rb#L79-L80)).


We need to support this endpoint, and allow authenticated partners to be able to search for `published: false` fairs
See details [here](https://artsy.slack.com/archives/C07PRTJSD6G/p1750698231171439)

I've hooked into the `fairsConnection` and allow it to accept a `term` for authenticated users only to [hit this endpoint](https://github.com/artsy/gravity/blob/main/app/api/v1/match_endpoint.rb#L72-L84)


Query structure will look like:
```graphql
{
  fairsConnection(term: "ART ASIA DELHI 2025", first: 15) {
    edges {
      node {
        isPublished
        name
        internalID
      }
    }
  }
}
```

<img width="970" alt="Screenshot 2025-06-24 at 3 01 55 PM" src="https://github.com/user-attachments/assets/d932326e-e5d0-4108-bc5c-62a0c727624e" />

## Next steps
- Adjust volt to use the above instead of [matchConnection](https://github.com/artsy/volt/blob/main/app/javascript/components/AutocompleteInputs/FairAutocomplete.tsx#L247-L253)


cc @artsy/amber-devs 
