### PR TITLE
feat(EMI-2577): add artworkOrEditionSet for orders

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13807,6 +13807,7 @@ enum LengthUnitPreference {
 # A line item in an order
 type LineItem {
   artwork: Artwork
+  artworkOrEditionSet: ArtworkOrEditionSetType
   artworkVersion: ArtworkVersion
   currencyCode: String!
 

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -20,6 +20,7 @@ import { PricingBreakdownLines } from "./PricingBreakdownLines"
 import { OrderJSON } from "./exchangeJson"
 import { PaymentMethodUnion } from "schema/v2/payment_method_union"
 import { DeliveryInfo } from "./DeliveryInfo"
+import { ArtworkOrEditionSetType } from "schema/v2/artworkOrEditionSet"
 
 const OrderModeEnum = new GraphQLEnumType({
   name: "OrderModeEnum",
@@ -194,6 +195,32 @@ const LineItemType = new GraphQLObjectType<any, ResolverContext>({
       type: ArtworkType,
       resolve: ({ artwork_id }, _args, { artworkLoader }) => {
         return artworkLoader(artwork_id)
+      },
+    },
+    artworkOrEditionSet: {
+      type: ArtworkOrEditionSetType,
+      resolve: async (
+        { artwork_id, edition_set_id },
+        _args,
+        { artworkLoader }
+      ) => {
+        if (artwork_id && edition_set_id) {
+          const artwork = await artworkLoader(artwork_id)
+          if (artwork && artwork.edition_sets) {
+            const editionSet = artwork.edition_sets.find(
+              (es) => es.id === edition_set_id
+            )
+            if (editionSet) {
+              return { ...editionSet, __typename: "EditionSet" }
+            }
+          }
+        } else if (artwork_id) {
+          const artwork = await artworkLoader(artwork_id)
+          if (artwork) {
+            return { ...artwork, __typename: "Artwork" }
+          }
+        }
+        return null
       },
     },
     artworkVersion: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2577

We'd like to display the correct artwork/edition set price or dimensions in the order details page. This allows access to edition set info through an order's line item.

<img width="1020" alt="Screenshot 2025-06-25 at 10 32 41" src="https://github.com/user-attachments/assets/0091ca61-8275-4a8c-9f2e-2673a42ee46d" />
<img width="1020" alt="Screenshot 2025-06-25 at 10 32 50" src="https://github.com/user-attachments/assets/231cb2d1-86d0-44bb-bd63-6d93b77e4943" />
