### PR TITLE
fix: add commas to price buckets quick links

### DIFF
--- a/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
+++ b/src/schema/v2/homeView/helpers/__tests__/priceBucketBasedOnPricePreference.test.ts
@@ -33,7 +33,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "500-1000",
       min: 500,
       max: 1000,
-      text: "Art Under $1000",
+      text: "Art Under $1,000",
     })
   })
 
@@ -42,7 +42,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "500-1000",
       min: 500,
       max: 1000,
-      text: "Art Under $1000",
+      text: "Art Under $1,000",
     })
   })
 
@@ -51,7 +51,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "500-1000",
       min: 500,
       max: 1000,
-      text: "Art Under $1000",
+      text: "Art Under $1,000",
     })
   })
 
@@ -60,7 +60,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "1000-2500",
       min: 1000,
       max: 2500,
-      text: "Art Under $2500",
+      text: "Art Under $2,500",
     })
   })
 
@@ -69,7 +69,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "1000-2500",
       min: 1000,
       max: 2500,
-      text: "Art Under $2500",
+      text: "Art Under $2,500",
     })
   })
 
@@ -78,7 +78,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "2500-5000",
       min: 2500,
       max: 5000,
-      text: "Art Under $5000",
+      text: "Art Under $5,000",
     })
   })
 
@@ -87,7 +87,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "2500-5000",
       min: 2500,
       max: 5000,
-      text: "Art Under $5000",
+      text: "Art Under $5,000",
     })
   })
 
@@ -96,7 +96,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "5000-10000",
       min: 5000,
       max: 10000,
-      text: "Art Under $10000",
+      text: "Art Under $10,000",
     })
   })
 
@@ -105,7 +105,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "5000-10000",
       min: 5000,
       max: 10000,
-      text: "Art Under $10000",
+      text: "Art Under $10,000",
     })
   })
 
@@ -114,7 +114,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "10000-25000",
       min: 10000,
       max: 25000,
-      text: "Art Under $25000",
+      text: "Art Under $25,000",
     })
   })
 
@@ -123,7 +123,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "10000-25000",
       min: 10000,
       max: 25000,
-      text: "Art Under $25000",
+      text: "Art Under $25,000",
     })
   })
 
@@ -132,7 +132,7 @@ describe("priceBucketBasedOnPricePreference", () => {
       priceRange: "25000-*",
       min: 25000,
       max: Number.POSITIVE_INFINITY,
-      text: "Art Above $25000",
+      text: "Art Above $25,000",
     })
   })
 })

--- a/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
+++ b/src/schema/v2/homeView/helpers/priceBucketBasedOnPricePreference.ts
@@ -2,26 +2,26 @@ export const priceBucketBasedOnPricePreference = (pricePreference: number) => {
   // Price buckets are aligned with the dropdown options on the website's top menu's dropdown
   const priceBuckets = [
     { priceRange: "0-500", min: 0, max: 500, text: "Art Under $500" },
-    { priceRange: "500-1000", min: 500, max: 1000, text: "Art Under $1000" },
-    { priceRange: "1000-2500", min: 1000, max: 2500, text: "Art Under $2500" },
-    { priceRange: "2500-5000", min: 2500, max: 5000, text: "Art Under $5000" },
+    { priceRange: "500-1000", min: 500, max: 1000, text: "Art Under $1,000" },
+    { priceRange: "1000-2500", min: 1000, max: 2500, text: "Art Under $2,500" },
+    { priceRange: "2500-5000", min: 2500, max: 5000, text: "Art Under $5,000" },
     {
       priceRange: "5000-10000",
       min: 5000,
       max: 10000,
-      text: "Art Under $10000",
+      text: "Art Under $10,000",
     },
     {
       priceRange: "10000-25000",
       min: 10000,
       max: 25000,
-      text: "Art Under $25000",
+      text: "Art Under $25,000",
     },
     {
       priceRange: "25000-*",
       min: 25000,
       max: Number.POSITIVE_INFINITY,
-      text: "Art Above $25000",
+      text: "Art Above $25,000",
     },
   ]
 

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -281,7 +281,7 @@ describe("QuickLinks", () => {
 
         expect(homeView.section.navigationPills).toContainEqual(
           expect.objectContaining({
-            title: "Art Under $2500",
+            title: "Art Under $2,500",
             href: "/collect?price_range=1000-2500",
           })
         )


### PR DESCRIPTION
Per Mel's request here: https://artsy.slack.com/archives/C05EQL4R5N0/p1750844542822889

> Could we add a comma in the price for the quicklink pills? It’s a bit hard to read with so many zeros, and this format aligns with the rest of the app