### PR TITLE
fix(EMI-2448): propagate exchange processing errors from submit mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16720,6 +16720,8 @@ type OrderMutationError {
   mutationError: ExchangeError!
 }
 
+union OrderMutationResponse = OrderMutationError | OrderMutationSuccess
+
 type OrderMutationSuccess {
   order: Order!
 }
@@ -21475,10 +21477,6 @@ type Services {
   convection: ConvectionService!
   metaphysics: MetaphysicsService!
 }
-
-union SetOrderFulfillmentOptionResponse =
-    OrderMutationError
-  | OrderMutationSuccess
 
 # Shipping line
 type ShippingLine {
@@ -26472,7 +26470,7 @@ input setOrderFulfillmentOptionInput {
 
 type setOrderFulfillmentOptionPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 enum sort {
@@ -26504,7 +26502,7 @@ input submitOrderInput {
 
 type submitOrderPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 input unsetOrderFulfillmentOptionInput {
@@ -26516,7 +26514,7 @@ input unsetOrderFulfillmentOptionInput {
 
 type unsetOrderFulfillmentOptionPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 input unsetOrderPaymentMethodInput {
@@ -26528,7 +26526,7 @@ input unsetOrderPaymentMethodInput {
 
 type unsetOrderPaymentMethodPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 input updateAlertInput {
@@ -26642,7 +26640,7 @@ input updateOrderInput {
 
 type updateOrderPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 input updateOrderShippingAddressInput {
@@ -26680,7 +26678,7 @@ input updateOrderShippingAddressInput {
 
 type updateOrderShippingAddressPayload {
   clientMutationId: String
-  orderOrError: SetOrderFulfillmentOptionResponse
+  orderOrError: OrderMutationResponse
 }
 
 input updatePurchaseInput {

--- a/src/schema/v2/order/exchangeErrorHandling.ts
+++ b/src/schema/v2/order/exchangeErrorHandling.ts
@@ -3,16 +3,17 @@ import { ORDER_MUTATION_FLAGS } from "./types/sharedOrderTypes"
 type ExchangeError = Error & {
   statusCode: number
   body?: {
-    message: string
+    message?: string
     code: string
   }
 }
+
 export const handleExchangeError = (error: ExchangeError) => {
   let errorProperties: { message: string; code: string }
 
   if (error.statusCode === 422 && typeof error.body === "object") {
     errorProperties = {
-      message: error.body.message,
+      message: error.body.message || "An error occurred",
       code: error.body.code,
     }
   } else {
@@ -21,8 +22,10 @@ export const handleExchangeError = (error: ExchangeError) => {
       code: "internal_error",
     }
   }
+
   return {
     ...errorProperties,
     _type: ORDER_MUTATION_FLAGS.ERROR,
+    __typename: "OrderMutationError",
   }
 }

--- a/src/schema/v2/order/submitOrderMutation.ts
+++ b/src/schema/v2/order/submitOrderMutation.ts
@@ -5,6 +5,7 @@ import {
 } from "./types/sharedOrderTypes"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
+import { handleExchangeError } from "./exchangeErrorHandling"
 
 interface Input {
   id: string
@@ -41,9 +42,10 @@ export const submitOrderMutation = mutationWithClientMutationId<
       const submittedOrder = await meOrderSubmitLoader(input.id, payload)
 
       submittedOrder._type = ORDER_MUTATION_FLAGS.SUCCESS // Set the type for the response
+      submittedOrder.__typename = "OrderMutationSuccess"
       return submittedOrder
     } catch (error) {
-      return { message: error.message, _type: ORDER_MUTATION_FLAGS.ERROR }
+      return handleExchangeError(error)
     }
   },
 })

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -532,12 +532,12 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
 })
 
 export const ORDER_MUTATION_FLAGS = {
-  SUCCESS: "SuccessType",
-  ERROR: "ErrorType",
+  SUCCESS: "ExchangeSuccessType",
+  ERROR: "ExchangeErrorType",
 } as const
 
 export const OrderMutationResponseType = new GraphQLUnionType({
-  name: "SetOrderFulfillmentOptionResponse",
+  name: "OrderMutationResponse",
   types: [SuccessType, ErrorType],
   resolveType: (data) => {
     const result =


### PR DESCRIPTION
This PR is of type **FIX**.

Relates to [EMI-2448]

Exchange error handling and transformation into graphql schema error types was implemented at the same time as our `submitOrderMutation` causing us to not do it for that case. As a result we are getting generic errors from these responses.

**Breaking change** in the process of doing this I noticed one type name was too specific so I changed it. I'm not sure if it is safe to merge as is (assuming we don't reference its typename specifically). We can revert it and fix it some other way if necessary.

Paired with @rquartararo for the main fix.

[EMI-2448]: https://artsyproduct.atlassian.net/browse/EMI-2448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ