### PR TITLE
chore(AMBER-1724): Allow price adjustment for Batch Edits

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4578,6 +4578,9 @@ input BulkUpdateArtworksMetadataInput {
   # Whether the artworks must be listed as Make Offer
   offer: Boolean
 
+  # Adjusts the artworks' prices according to the value passed (percentage).
+  priceAdjustment: Int
+
   # The price for the artworks
   priceListed: Float
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -15,6 +15,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
             category: "Painting"
             ecommerce: true
             offer: false
+            priceAdjustment: -5
             priceListed: 1000
             published: true
           }
@@ -73,6 +74,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           category: "Painting",
           ecommerce: true,
           offer: false,
+          price_adjustment: -5,
           price_listed: 1000,
           published: true,
         },

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -26,6 +26,7 @@ interface Input {
     locationId?: string
     category?: string
     offer: boolean
+    priceAdjustment?: number
     priceListed?: number
     published?: boolean
   }
@@ -62,6 +63,11 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     ecommerce: {
       type: GraphQLBoolean,
       description: "Whether the artworks must be listed as Purchase",
+    },
+    priceAdjustment: {
+      type: GraphQLInt,
+      description:
+        "Adjusts the artworks' prices according to the value passed (percentage).",
     },
     priceListed: {
       type: GraphQLFloat,
@@ -215,6 +221,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         domestic_shipping_fee_cents: metadata.domesticShippingFeeCents,
         location_id: metadata.locationId,
         category: metadata.category,
+        price_adjustment: metadata.priceAdjustment,
         price_listed: metadata.priceListed,
         published: metadata.published,
         offer: metadata.offer,


### PR DESCRIPTION
[AMBER-1724]

This PR relies on https://github.com/artsy/gravity/pull/19071

It allows the `priceAdjustment` arg to be passed to the bulk metadata update mutation. When passed, it applies the adjustment to the artwork / edition sets prices, min prices and max prices

cc @artsy/amber-devs 