### PR TITLE
refactor(DIA-1308): deprecate partnerBio arg to biographyBlurb

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1697,6 +1697,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
 
     # If true, will return featured bio over Artsy one.
     partnerBio: Boolean = true
+      @deprecated(reason: "Artsy bios are always returned over featured bios.")
   ): ArtistBlurb
   birthday: String
   blurb(format: Format): String

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable promise/always-return */
-import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { runQuery } from "schema/v2/test/utils"
 import config from "config"
 
 describe("Artist type", () => {
@@ -419,161 +419,110 @@ describe("Artist type", () => {
     })
   })
   describe("biographyBlurb", () => {
-    it("returns the blurb if present", () => {
-      artist.blurb = "catty blurb"
-      const query = `
-        {
-          artist(id: "foo-bar") {
-            blurb
-          }
-        }
-      `
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            blurb: "catty blurb",
+    describe("when artsy blurb exists", () => {
+      it("returns the artsy blurb", () => {
+        artist.blurb = "artsy blurb"
+        const partnerArtists = Promise.resolve([
+          {
+            biography: "new catty bio",
+            partner: {
+              name: "Catty Partner",
+              id: "catty-partner",
+            },
           },
-        })
-      })
-    })
-  })
-  describe("biographyBlurb", () => {
-    describe("with partnerBio set to true", () => {
-      describe("with a featured partner bio", () => {
-        beforeEach(() => {
-          const partnerArtists = Promise.resolve([
-            {
-              biography: "new catty bio",
-              partner: {
-                name: "Catty Partner",
-                id: "catty-partner",
+        ])
+        context.partnerArtistsForArtistLoader = sinon
+          .stub()
+          .withArgs(artist.id)
+          .returns(partnerArtists)
+
+        const query = `
+          {
+            artist(id: "foo-bar") {
+              biographyBlurb(format: HTML) {
+                text
+                credit
+                partnerID
+              }
+            }
+          }
+        `
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artist: {
+              biographyBlurb: {
+                text: "<p>artsy blurb</p>\n",
+                credit: null,
+                partnerID: null,
               },
             },
-          ])
-          context.partnerArtistsForArtistLoader = sinon
-            .stub()
-            .withArgs(artist.id)
-            .returns(partnerArtists)
-        })
-        afterEach(() => {
-          const query = `
-            {
-              artist(id: "foo-bar") {
-                biographyBlurb(partnerBio: true, format: HTML) {
-                  text
-                  credit
-                  partnerID
-                }
-              }
-            }
-          `
-          return runQuery(query, context).then((data) => {
-            expect(data).toEqual({
-              artist: {
-                biographyBlurb: {
-                  text: "<p>new catty bio</p>\n",
-                  credit: "Submitted by Catty Partner",
-                  partnerID: "catty-partner",
-                },
-              },
-            })
-          })
-        })
-        it("returns the featured partner bio without an artsy blurb", () => {})
-        it("returns the featured partner bio with an artsy blurb", () => {
-          artist.blurb = "artsy blurb"
-        })
-      })
-      describe("without a featured partner bio", () => {
-        it("returns the artsy blurb if there is no featured partner bio", () => {
-          context.partnerArtistsForArtistLoader = sinon
-            .stub()
-            .returns(Promise.resolve([]))
-          artist.blurb = "artsy blurb"
-          const query = `
-            {
-              artist(id: "foo-bar") {
-                biographyBlurb(partnerBio: true) {
-                  text
-                  credit
-                  partnerID
-                }
-              }
-            }
-          `
-          return runQuery(query, context).then((data) => {
-            expect(data).toEqual({
-              artist: {
-                biographyBlurb: {
-                  text: "artsy blurb",
-                  credit: null,
-                  partnerID: null,
-                },
-              },
-            })
           })
         })
       })
     })
-    it("returns the blurb if present", () => {
-      artist.blurb = "catty blurb"
-      const query = `
-        {
-          artist(id: "foo-bar") {
-            biographyBlurb(partnerBio: false) {
-              text
-              credit
-              partnerID
-            }
-          }
-        }
-      `
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            biographyBlurb: {
-              text: "catty blurb",
-              credit: null,
-              partnerID: null,
+
+    describe("when no artsy blurb exists", () => {
+      it("returns the partner bio if available", () => {
+        const partnerArtists = Promise.resolve([
+          {
+            biography: "new catty bio",
+            partner: {
+              name: "Catty Partner",
+              id: "catty-partner",
             },
           },
+        ])
+        context.partnerArtistsForArtistLoader = sinon
+          .stub()
+          .withArgs(artist.id)
+          .returns(partnerArtists)
+
+        const query = `
+          {
+            artist(id: "foo-bar") {
+              biographyBlurb(format: HTML) {
+                text
+                credit
+                partnerID
+              }
+            }
+          }
+        `
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artist: {
+              biographyBlurb: {
+                text: "<p>new catty bio</p>\n",
+                credit: "Submitted by Catty Partner",
+                partnerID: "catty-partner",
+              },
+            },
+          })
         })
       })
-    })
-    it("returns the featured bio if there is no Artsy one", () => {
-      const partnerArtists = Promise.resolve([
-        {
-          biography: "new catty bio",
-          partner: {
-            name: "Catty Partner",
-            id: "catty-partner",
-          },
-        },
-      ])
-      context.partnerArtistsForArtistLoader = sinon
-        .stub()
-        .withArgs(artist.id)
-        .returns(partnerArtists)
-      const query = `
-        {
-          artist(id: "foo-bar") {
-            biographyBlurb {
-              text
-              credit
-              partnerID
+
+      it("returns null when no partner bio exists", () => {
+        context.partnerArtistsForArtistLoader = sinon
+          .stub()
+          .returns(Promise.resolve([]))
+
+        const query = `
+          {
+            artist(id: "foo-bar") {
+              biographyBlurb {
+                text
+                credit
+                partnerID
+              }
             }
           }
-        }
-      `
-      return runQuery(query, context).then((data) => {
-        expect(data).toEqual({
-          artist: {
-            biographyBlurb: {
-              text: "new catty bio",
-              credit: "Submitted by Catty Partner",
-              partnerID: "catty-partner",
+        `
+        return runQuery(query, context).then((data) => {
+          expect(data).toEqual({
+            artist: {
+              biographyBlurb: null,
             },
-          },
+          })
         })
       })
     })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -444,6 +444,8 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLBoolean,
             description: "If true, will return featured bio over Artsy one.",
             defaultValue: true,
+            deprecationReason:
+              "Artsy bios are always returned over featured bios.",
           },
           ...markdown().args,
         },
@@ -474,15 +476,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         }),
         resolve: async (
           { blurb, id },
-          { format, partnerBio },
+          { format },
           { partnerArtistsForArtistLoader }
         ) => {
-          if (!partnerBio && blurb && blurb.length) {
+          if (blurb && blurb.length) {
             return { text: formatMarkdownValue(blurb, format) }
-          }
-
-          if (!partnerBio) {
-            return null
           }
 
           // Favor partner bio...
@@ -504,7 +502,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           }
 
           // Fall back to the default bio
-          return { text: formatMarkdownValue(blurb, format) }
+          return null
         },
       },
       birthday: { type: GraphQLString },


### PR DESCRIPTION
This PR deprecates the `partnerBio` argument that could be passed to an artist's `biographyBlurb` field. The intention of this was that it would prefer partner-supplied bios over Artsy-supplied ones, but in practice it was never used.

A side-effect of this change is that (featured) partner-supplied bios will now be returned for artists that have no Artsy-supplied one. Before this change, those were only returned when `partnerBio` was true.

cc: @artsy/diamond-devs 