### PR TITLE
fix(DIA-1308): include credit in formatted partner bio text

### DIFF
--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -68,6 +68,7 @@ import {
 } from "../marketingCollections"
 import { ArtistSeriesConnectionType } from "../artistSeries"
 import { SEO_EXPERIMENT_ARTISTS } from "schema/v2/seoExperimentArtists"
+import config from "config"
 
 // Manually curated list of artist id's who has verified auction lots that can be
 // returned, when queried for via `recordsTrusted: true`.
@@ -494,8 +495,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
 
             // Return the featured partner bio if one exists
             if (biography && biography.length) {
+              // Append the credit to the text so it can be formatted
+              const creditedBiography = `${biography}\n\n_Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.slug})_`
+
               return {
-                text: formatMarkdownValue(biography, format),
+                text: formatMarkdownValue(creditedBiography, format),
                 credit: `Submitted by ${partner.name}`,
                 partner_id: partner.id,
                 partner: partner,


### PR DESCRIPTION
This PR includes the "Submitted by ..." credit line in the `text` that is returned with a `biographyBlurb` when the bio was supplied by a partner.

This change was made so that the credit-line could be formatted consistently with the biography text when it is displayed by clients. Without this change, each client would need to match the formatting that was being returned by Metaphysics, which could lead to confusion and different styles in the future.