### PR TITLE
fix(DIA-1308): remove partner slug from biographyBlurb

### DIFF
--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -471,7 +471,6 @@ describe("Artist type", () => {
             partner: {
               name: "Catty Partner",
               id: "catty-partner",
-              slug: "catty-partner",
             },
           },
         ])
@@ -509,7 +508,6 @@ describe("Artist type", () => {
             partner: {
               name: "Gallery Example",
               id: "gallery-example",
-              slug: "gallery-example",
             },
           },
         ])

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -496,7 +496,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             // Return the featured partner bio if one exists
             if (biography && biography.length) {
               // Append the credit to the text so it can be formatted
-              const creditedBiography = `${biography}\n\n_Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.slug})_`
+              const creditedBiography = `${biography}\n\n_Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.id})_`
 
               return {
                 text: formatMarkdownValue(creditedBiography, format),


### PR DESCRIPTION
I made a mistake in #6860 and assumed that a partner record would include a slug. Instead, the ID is sufficient.