### PR TITLE
fix: add null safety to artwork literature/provenance/signature fields

### DIFF
--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1174,8 +1174,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           )
         },
       },
-      literature: markdown(({ literature }) =>
-        literature.replace(/^literature:\s+/i, "")
+      literature: markdown(
+        ({ literature }) => literature?.replace(/^literature:\s+/i, "") || ""
       ),
       listingOptions,
       location: {
@@ -1603,8 +1603,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
-      provenance: markdown(({ provenance }) =>
-        provenance.replace(/^provenance:\s+/i, "")
+      provenance: markdown(
+        ({ provenance }) => provenance?.replace(/^provenance:\s+/i, "") || ""
       ),
       publisher: markdown(),
       realizedPrice: {
@@ -1755,8 +1755,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               })
             : [],
       },
-      signature: markdown(({ signature }) =>
-        signature.replace(/^signature:\s+/i, "")
+      signature: markdown(
+        ({ signature }) => signature?.replace(/^signature:\s+/i, "") || ""
       ),
       signatureDetails: {
         type: GraphQLString,


### PR DESCRIPTION
Attempt to resolve ongoing TypeError observed [here](https://app.datadoghq.com/apm/traces?query=env%3Aproduction%20operation_name%3Agraphql.execute%20resource_name%3A%22query%20AuctionArtworkFilterQuery%28%24input%3AFilterArtworksInput%2C%24saleID%3AString%21%29%7Bviewer%7B...AuctionArtworkFilter_viewer_1rdGPv%7D%7Dfragment%20ArtworkFilterArtworkGrid_filtered_artworks%20on%20FilterArtworksConnection%7Bedges%7Bnode%7Bid%7D%7Did%20pageCursors%7B...Pagination_pageCursors%7DpageInfo%7BendCursor%20hasNextPage%7D...ArtworkGrid_artworks%7Dfragment%20ArtworkFilter_viewer_2VV6jB%20on%20Viewer%7BartworksConnection%28input%3A%24input%29%7Bcounts%7Btotal%28format%3A%5C%22%5C%22%29%7Did...ArtworkFilterArtworkGrid_filtered_artworks%7D%7Dfragment%20ArtworkGrid_artworks%20on%20ArtworkConnectionInterface%7B__typename%20edges%7B__typename%20node%7Bhref%20id%20image%28includeAll%3Afalse%29%7BaspectRatio%7Dimages%28includeAll%3Atrue%29%7BaspectRatio%20isDefault%20url%28version%3A%5B%5D%29%7DinternalID%20slug...Details_artwork%7D...on%20Node%7B__typename%20id%7D%7D%7Dfragment%20AuctionArtworkFilter_viewer_1rdGPv%20on%20Viewer%7Bsale%28id%3A%24saleID%29%7BfeaturedKeywords%20id%7D...ArtworkFilter_viewer_2VV6jB%7Dfragment%20Details_artwork%20on%20Artwork%7BadditionalInformation%20artist%28shallow%3Atrue%29%7Bid%20targetSupply%7BisP1%7D%7DartistNames%20artists%28shallow%3Atrue%29%7Bhref%20id%20name%7DattributionClass%7Bname%7DcollectingInstitution%20conditionDescription%7Bdetails%7DculturalMaker%20date%20dimensions%7Bcm%20in%7Dhref%20internalID%20marketPriceInsights%7BdemandRank%7Dmedium%20mediumType%7Bname%7Dpartner%28shallow%3Atrue%29%7Bhref%20id%20name%7Dprovenance%28format%3AMARKDOWN%29sale%7BendAt%20id%20isAuction%20isClosed%20liveStartAt%20startAt%7DsaleArtwork%7Bcounts%7BbidderPositions%7DcurrentBid%7Bcents%20display%7DendAt%20endedAt%20estimate%20formattedEndDateTime%20highestBid%7Bcents%20display%7Did%20lotID%20lotLabel%20openingBid%7Bcents%20display%7Dreserve%7Bcents%20display%7Dsymbol%7DsaleMessage%20title%7Dfragment%20Pagination_pageCursors%20on%20PageCursors%7Baround%7Bcursor%20isCurrent%20page%7Dfirst%7Bcursor%20isCurrent%20page%7Dlast%7Bcursor%20isCurrent%20page%7Dprevious%7Bcursor%20page%7D%7D%22%20service%3Ametaphysics.graphql&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=service_map&historicalData=true&messageDisplay=inline&shouldShowLegend=true&sort=time&spanID=2475968615306205873&spanType=all&spanViewType=errors&storage=hot&timeHint=1751053646665&trace=AwAAAZey7jtJ7e_1ngAAABhBWmV5N2tDX0FBRDVGUjl0YWQwX0d2WkYAAAAkMDE5N2IyZjItMmZiMS00OTM5LWJkZjEtNjRhY2Q4N2ZhYThiAAG_iw&traceID=685ef54b0000000045f6bc9e76754961&view=spans&start=1749844441380&end=1751054041380&paused=false) and [here](https://my.papertrailapp.com/groups/3675843/events?q=program%3Ametaphysics-web+%22reading+%27replace%27%22)

Added optional chaining `?.` and fallback empty strings `|| ""` to safely handle undefined values before calling `.replace()` method. The `markdown()` helper has built-in [null safety](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/fields/markdown.ts#L49), but it only applies after the custom transformation function runs.

I couldn't repro this locally but the stacktrace in datadog points to the `signature` field:
```
TypeError: Cannot read properties of undefined (reading 'replace')
    at /app/build/src/schema/v2/artwork/index.js:1760:24
    at resolve (/app/build/src/schema/v2/fields/markdown.js:48:26)
    at resolveField (/app/node_modules/graphql/execution/execute.js:464:18)
    at executeFields (/app/node_modules/graphql/execution/execute.js:292:18)
    at collectAndExecuteSubfields (/app/node_modules/graphql/execution/execute.js:748:10)
    at completeObjectValue (/app/node_modules/graphql/execution/execute.js:738:10)
    at completeValue (/app/node_modules/graphql/execution/execute.js:590:12)
    at resolveField (/app/node_modules/graphql/execution/execute.js:472:19)
    at executeFields (/app/node_modules/graphql/execution/execute.js:292:18)
    at collectAndExecuteSubfields (/app/node_modules/graphql/execution/execute.js:748:10)
```