### PR TITLE
chore: AMBER-1735 - artwork import preferences

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3179,7 +3179,8 @@ type ArtworkImport implements Node {
     timezone: String
   ): String
   createdBy: ArtworkImportCreatedBy
-  currency: String
+  currency: String!
+  dimensionMetric: String!
   fileName: String!
 
   # A globally unique ID.

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -274,7 +274,11 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ created_by }) => created_by,
     },
     currency: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    dimensionMetric: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ dimension_metric }) => dimension_metric,
     },
     fileName: {
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
Partially solves [AMBER-1735]

Ensure that we are displaying the dimension metric as this will be used on the front end as each Artwork Import has their own denormalised currency and measurement.

cc: @artsy/amber-devs 

[AMBER-1735]: https://artsyproduct.atlassian.net/browse/AMBER-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ