### PR TITLE
feat: add discoveryCategoriesConnection query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10641,6 +10641,38 @@ type DisableSecondFactorPayload {
   secondFactorOrErrors: SecondFactorOrErrorsUnion!
 }
 
+# A connection to a list of items.
+type DiscoveryCategoriesConnectionConnection {
+  # A list of edges.
+  edges: [DiscoveryCategoriesConnectionEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type DiscoveryCategoriesConnectionEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: DiscoveryCategory
+}
+
+# A category for discovering and browsing art
+type DiscoveryCategory {
+  # The ID of the category
+  categoryID: String!
+
+  # The URL of the image representing this category
+  imageUrl: String
+
+  # The display title of the category
+  title: String!
+}
+
 input DislikeArtworkInput {
   artworkID: String!
   clientMutationId: String
@@ -19342,6 +19374,14 @@ type Query {
     osWeights: [Float] = [0.6, 0.4]
   ): ArtworkConnection
 
+  # A connection of discovery categories for browsing art
+  discoveryCategoriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): DiscoveryCategoriesConnectionConnection
+
   # Discovery Marketing Collections for personalized recommendations
   discoveryMarketingCollections(
     after: String
@@ -25138,6 +25178,14 @@ type Viewer {
     # Weights for the KNN and MLT query
     osWeights: [Float] = [0.6, 0.4]
   ): ArtworkConnection
+
+  # A connection of discovery categories for browsing art
+  discoveryCategoriesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): DiscoveryCategoriesConnectionConnection
 
   # Discovery Marketing Collections for personalized recommendations
   discoveryMarketingCollections(

--- a/src/schema/v2/__tests__/discoveryCategoriesConnection.test.ts
+++ b/src/schema/v2/__tests__/discoveryCategoriesConnection.test.ts
@@ -1,0 +1,104 @@
+import { runQuery } from "schema/v2/test/utils"
+
+describe("discoveryCategoriesConnection", () => {
+  it("returns a connection of discovery categories", async () => {
+    const query = `
+      {
+        discoveryCategoriesConnection(first: 10) {
+          edges {
+            node {
+              title
+              categoryID
+              imageUrl
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query)
+    expect(result.discoveryCategoriesConnection).toBeDefined()
+    expect(result.discoveryCategoriesConnection.edges).toHaveLength(6)
+
+    const categories = result.discoveryCategoriesConnection.edges.map(
+      (edge: any) => edge.node
+    )
+
+    expect(categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: "Medium",
+          categoryID: "Medium",
+        }),
+        expect.objectContaining({
+          title: "Movement",
+          categoryID: "Movement",
+        }),
+        expect.objectContaining({
+          title: "Size",
+          categoryID: "Collect by Size",
+        }),
+        expect.objectContaining({
+          title: "Color",
+          categoryID: "Collect by Color",
+        }),
+        expect.objectContaining({
+          title: "Price",
+          categoryID: "Collect by Price",
+        }),
+        expect.objectContaining({
+          title: "Gallery",
+          categoryID: "Gallery",
+        }),
+      ])
+    )
+  })
+
+  it("returns categories with images", async () => {
+    const query = `
+      {
+        discoveryCategoriesConnection(first: 1) {
+          edges {
+            node {
+              title
+              imageUrl
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query)
+    const firstCategory = result.discoveryCategoriesConnection.edges[0].node
+
+    expect(firstCategory.imageUrl).toBeDefined()
+    expect(firstCategory.imageUrl).toMatch(
+      /^https:\/\/files\.artsy\.net\/images/
+    )
+  })
+
+  it("supports pagination", async () => {
+    const query = `
+      {
+        discoveryCategoriesConnection(first: 3) {
+          edges {
+            node {
+              title
+            }
+          }
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+          }
+        }
+      }
+    `
+
+    const result = await runQuery(query)
+    expect(result.discoveryCategoriesConnection.edges).toHaveLength(3)
+    expect(result.discoveryCategoriesConnection.pageInfo.hasNextPage).toBe(true)
+    expect(result.discoveryCategoriesConnection.pageInfo.hasPreviousPage).toBe(
+      false
+    )
+  })
+})

--- a/src/schema/v2/discoveryCategoriesConnection.ts
+++ b/src/schema/v2/discoveryCategoriesConnection.ts
@@ -1,0 +1,75 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { connectionFromArray } from "graphql-relay"
+import { marketingCollectionCategories } from "lib/marketingCollectionCategories"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+import { connectionWithCursorInfo } from "schema/v2/fields/pagination"
+
+const orderedCategoryKeys = [
+  "Medium",
+  "Movement",
+  "Collect by Size",
+  "Collect by Color",
+  "Collect by Price",
+  "Gallery",
+]
+
+export type DiscoveryCategory = {
+  categoryID: string
+  imageUrl: string
+  title: string
+}
+
+export const DiscoveryCategoryType = new GraphQLObjectType<
+  DiscoveryCategory,
+  ResolverContext
+>({
+  name: "DiscoveryCategory",
+  description: "A category for discovering and browsing art",
+  fields: {
+    categoryID: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "The ID of the category",
+    },
+    imageUrl: {
+      type: GraphQLString,
+      description: "The URL of the image representing this category",
+    },
+    title: {
+      type: GraphQLNonNull(GraphQLString),
+      description: "The display title of the category",
+    },
+  },
+})
+
+const DiscoveryCategoriesConnectionType = connectionWithCursorInfo({
+  nodeType: DiscoveryCategoryType,
+  name: "DiscoveryCategoriesConnection",
+}).connectionType
+
+export const discoveryCategoriesConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description: "A connection of discovery categories for browsing art",
+  type: DiscoveryCategoriesConnectionType,
+  args: pageable({}),
+  resolve: (_parent, args: CursorPageable) => {
+    const cards = orderedCategoryKeys.map((key) => {
+      const category = marketingCollectionCategories[key]
+
+      return {
+        categoryID: category.id,
+        imageUrl: category.imageUrl,
+        title: category.title,
+      }
+    })
+
+    return connectionFromArray(cards, args)
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -217,6 +217,7 @@ import { createPartnerOfferMutation } from "./createPartnerOfferMutation"
 import { createAlertMutation } from "./Alerts/createAlertMutation"
 import { updateAlertMutation } from "./Alerts/updateAlertMutation"
 import { deleteAlertMutation } from "./Alerts/deleteAlertMutation"
+import { discoveryCategoriesConnection } from "./discoveryCategoriesConnection"
 import { ArtworkResult } from "./artworkResult"
 import { updateMeCollectionsMutation } from "./me/updateCollectionsMutation"
 import { CreateSaleAgreementMutation } from "./SaleAgreements/createSaleAgreementMutation"
@@ -379,6 +380,7 @@ const rootFields = {
   creditCard: CreditCard,
   curatedTrendingArtists: CuratedTrendingArtists,
   discoverArtworks: DiscoverArtworks,
+  discoveryCategoriesConnection,
   departments,
   external: externalField,
   fair: Fair,


### PR DESCRIPTION
This PR adds a new query named `discoveryCategoriesConnection` that serves a list of categories that can be used to link to marketing collections by passing a category name to the `marketingCollections` query.

This used to be a queryable section in the `homeView` query, but now it has been brought to the top level since it will be requested outside of the home feed.