### PR TITLE
refactor: rename discoveryMarketingCollections

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19382,8 +19382,8 @@ type Query {
     last: Int
   ): DiscoveryCategoriesConnectionConnection
 
-  # Discovery Marketing Collections for personalized recommendations
-  discoveryMarketingCollections(
+  # Discovery collections for personalized recommendations
+  discoveryCollections(
     after: String
     before: String
     first: Int
@@ -25187,8 +25187,8 @@ type Viewer {
     last: Int
   ): DiscoveryCategoriesConnectionConnection
 
-  # Discovery Marketing Collections for personalized recommendations
-  discoveryMarketingCollections(
+  # Discovery collections for personalized recommendations
+  discoveryCollections(
     after: String
     before: String
     first: Int

--- a/src/schema/v2/__tests__/marketingCollections.test.ts
+++ b/src/schema/v2/__tests__/marketingCollections.test.ts
@@ -241,7 +241,7 @@ describe("MarketingCollections", () => {
     )
   })
 
-  it("returns discovery marketing collections", async () => {
+  it("returns discovery collections", async () => {
     const discoveryCollectionsData = [
       {
         slug: "most-loved",
@@ -255,7 +255,7 @@ describe("MarketingCollections", () => {
 
     const query = gql`
       {
-        discoveryMarketingCollections(size: 2) {
+        discoveryCollections(size: 2) {
           slug
           title
         }
@@ -274,11 +274,11 @@ describe("MarketingCollections", () => {
     const data = await runQuery(query, context)
 
     expect(data).toEqual({
-      discoveryMarketingCollections: discoveryCollectionsData,
+      discoveryCollections: discoveryCollectionsData,
     })
   })
 
-  it("filters out null and undefined collections from discovery marketing collections", async () => {
+  it("filters out null and undefined collections from discovery collections", async () => {
     const discoveryCollectionsDataWithNulls = [
       {
         slug: "most-loved",
@@ -298,7 +298,7 @@ describe("MarketingCollections", () => {
 
     const query = gql`
       {
-        discoveryMarketingCollections {
+        discoveryCollections {
           slug
           title
         }
@@ -316,7 +316,7 @@ describe("MarketingCollections", () => {
 
     // Should only return the valid collections, filtering out null/undefined
     expect(data).toEqual({
-      discoveryMarketingCollections: [
+      discoveryCollections: [
         {
           slug: "most-loved",
           title: "Most Loved",

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -409,13 +409,9 @@ export const CuratedMarketingCollections: GraphQLFieldConfig<
   },
 }
 
-export const DiscoveryMarketingCollections: GraphQLFieldConfig<
-  void,
-  ResolverContext
-> = {
+export const DiscoveryCollections: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLList(new GraphQLNonNull(MarketingCollectionType)),
-  description:
-    "Discovery Marketing Collections for personalized recommendations",
+  description: "Discovery collections for personalized recommendations",
   args: pageable({
     size: {
       type: GraphQLInt,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -228,7 +228,7 @@ import {
   MarketingCollection,
   MarketingCollections,
   CuratedMarketingCollections,
-  DiscoveryMarketingCollections,
+  DiscoveryCollections,
 } from "./marketingCollections"
 import { MarketingCategories } from "./marketingCategories"
 import { createCareerHighlightMutation } from "./careerHighlight/createCareerHighlightMutation"
@@ -414,7 +414,7 @@ const rootFields = {
   marketingCollection: MarketingCollection,
   marketingCollections: MarketingCollections,
   curatedMarketingCollections: CuratedMarketingCollections,
-  discoveryMarketingCollections: DiscoveryMarketingCollections,
+  discoveryCollections: DiscoveryCollections,
   marketingCategories: MarketingCategories,
   me: Me,
   node: ObjectIdentification.NodeField,


### PR DESCRIPTION
This PR renames `discoveryMarketingCollections` to `discoveryCollections` because I felt like it was too long, and I wanted to make it resemble `discoverCategoriesConnection`.

cc: @artsy/diamond-devs 