### PR TITLE
feat(DIA-1363): add categorySlug to marketingCollectionCategories

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10669,6 +10669,9 @@ type DiscoveryCategory {
   # The URL of the image representing this category
   imageUrl: String
 
+  # The slug of the category
+  slug: String
+
   # The display title of the category
   title: String!
 }
@@ -19609,6 +19612,7 @@ type Query {
     artistID: String
     before: String
     category: String
+    categorySlug: String
     first: Int
     isFeaturedArtistContent: Boolean
     last: Int
@@ -25411,6 +25415,7 @@ type Viewer {
     artistID: String
     before: String
     category: String
+    categorySlug: String
     first: Int
     isFeaturedArtistContent: Boolean
     last: Int

--- a/src/lib/marketingCollectionCategories.ts
+++ b/src/lib/marketingCollectionCategories.ts
@@ -1,6 +1,7 @@
 export const marketingCollectionCategories = {
   Medium: {
     id: "Medium",
+    slug: "medium",
     title: "Medium",
     imageUrl:
       "https://files.artsy.net/images/collections-mediums-category.jpeg",
@@ -19,6 +20,7 @@ export const marketingCollectionCategories = {
   },
   Movement: {
     id: "Movement",
+    slug: "movement",
     title: "Movement",
     imageUrl:
       "https://files.artsy.net/images/collections-movement-category.jpeg",
@@ -37,6 +39,7 @@ export const marketingCollectionCategories = {
   },
   "Collect by Size": {
     id: "Collect by Size",
+    slug: "collect-by-size",
     title: "Size",
     imageUrl: "https://files.artsy.net/images/collections-size-category.jpeg",
     sortedCollectionSlugs: [
@@ -47,6 +50,7 @@ export const marketingCollectionCategories = {
   },
   "Collect by Color": {
     id: "Collect by Color",
+    slug: "collect-by-color",
     title: "Color",
     imageUrl: "https://files.artsy.net/images/collections-color-category.png",
     sortedCollectionSlugs: [
@@ -63,6 +67,7 @@ export const marketingCollectionCategories = {
   },
   "Collect by Price": {
     id: "Collect by Price",
+    slug: "collect-by-price",
     title: "Price",
     imageUrl: "https://files.artsy.net/images/collections-price-category.jpeg",
     sortedCollectionSlugs: [
@@ -77,6 +82,7 @@ export const marketingCollectionCategories = {
   },
   Gallery: {
     id: "Gallery",
+    slug: "gallery",
     title: "Gallery",
     imageUrl:
       "https://files.artsy.net/images/collections-gallery-category.jpeg",

--- a/src/schema/v2/discoveryCategoriesConnection.ts
+++ b/src/schema/v2/discoveryCategoriesConnection.ts
@@ -22,6 +22,7 @@ const orderedCategoryKeys = [
 export type DiscoveryCategory = {
   category: string
   imageUrl: string
+  slug: string
   title: string
 }
 
@@ -39,6 +40,10 @@ export const DiscoveryCategoryType = new GraphQLObjectType<
     imageUrl: {
       type: GraphQLString,
       description: "The URL of the image representing this category",
+    },
+    slug: {
+      type: GraphQLString,
+      description: "The slug of the category",
     },
     title: {
       type: GraphQLNonNull(GraphQLString),
@@ -66,6 +71,7 @@ export const discoveryCategoriesConnection: GraphQLFieldConfig<
       return {
         category: category.id,
         imageUrl: category.imageUrl,
+        slug: category.slug,
         title: category.title,
       }
     })

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -312,6 +312,9 @@ export const MarketingCollections: GraphQLFieldConfig<void, ResolverContext> = {
     category: {
       type: GraphQLString,
     },
+    categorySlug: {
+      type: GraphQLString,
+    },
     sort: {
       type: MarketingCollectionsSorts,
     },
@@ -326,19 +329,29 @@ export const MarketingCollections: GraphQLFieldConfig<void, ResolverContext> = {
     const { size } = convertConnectionArgsToGravityArgs(args)
     // Enable curated sorting
     if (args.sort === MARKETING_COLLECTIONS_SORTS.CURATED.value) {
-      if (!args.category) {
-        throw new Error("Category is required for CURATED sort.")
+      if (!args.category && !args.categorySlug) {
+        throw new Error("Category or slug is required for CURATED sort.")
       }
 
       const category = args.category
+      const categorySlug = args.categorySlug
 
-      if (!marketingCollectionCategories[category]) {
-        throw new Error(`No curated sort available for category: ${category}`)
+      const marketingCollectionCategory = category
+        ? marketingCollectionCategories[category]
+        : Object.values(marketingCollectionCategories).find(
+            (c) => c.slug === categorySlug
+          )
+
+      if (!marketingCollectionCategory) {
+        throw new Error(
+          `No curated sort available for category: ${category} or slug: ${categorySlug}`
+        )
       }
 
-      args.slugs = marketingCollectionCategories[category].sortedCollectionSlugs
+      args.slugs = marketingCollectionCategory.sortedCollectionSlugs
 
       delete args.category
+      delete args.categorySlug
       delete args.sort
     }
 


### PR DESCRIPTION
This PR adds a `slug` field to the existing marketing collection categories so that clients (aka. Eigen) can pass an identifier that doesn't include spaces.

Currently categories are identified by their `category`, which includes spaces (ie. "Collect by Size") which seems to be causing problems with prefetching in Eigen. By adding a `slug` field without spaces, I hope that those problems disappear, and we can avoid decoding params that are being passed through Eigen's routing.

cc: @artsy/diamond-devs 