### PR TITLE
feat: add trackItemImpressions to HomeViewSectionArtworks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12967,6 +12967,7 @@ type HomeViewSectionArtworks implements HomeViewSectionGeneric & Node {
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String
+  enableItemsImpressionTracking: Boolean!
 
   # A globally unique ID.
   id: ID!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -12967,7 +12967,6 @@ type HomeViewSectionArtworks implements HomeViewSectionGeneric & Node {
 
   # [Analytics] `context module` analytics value for this section, as defined in our schema (artsy/cohesion)
   contextModule: String
-  enableItemsImpressionTracking: Boolean!
 
   # A globally unique ID.
   id: ID!
@@ -12977,6 +12976,7 @@ type HomeViewSectionArtworks implements HomeViewSectionGeneric & Node {
 
   # [Analytics] `owner type` analytics value for this scetion when displayed in a standalone UI, as defined in our schema (artsy/cohesion)
   ownerType: String
+  trackItemImpressions: Boolean!
 }
 
 # An auction results section in the home view

--- a/src/schema/v2/homeView/sectionTypes/Artworks.ts
+++ b/src/schema/v2/homeView/sectionTypes/Artworks.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType } from "graphql"
+import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../../artwork"
@@ -7,6 +7,11 @@ import { NodeInterface } from "../../object_identification"
 import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
 import { standardSectionFields } from "./GenericSectionInterface"
+import { HomeViewSection } from "../sections"
+
+export interface HomeViewArtworksSection extends HomeViewSection {
+  enableItemsImpressionTracking?: boolean
+}
 
 export const HomeViewArtworksSectionType = new GraphQLObjectType<
   any,
@@ -18,6 +23,10 @@ export const HomeViewArtworksSectionType = new GraphQLObjectType<
   fields: {
     ...standardSectionFields,
 
+    enableItemsImpressionTracking: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: (parent) => !!parent.enableItemsImpressionTracking,
+    },
     artworksConnection: {
       type: artworkConnection.connectionType,
       args: pageable({}),

--- a/src/schema/v2/homeView/sectionTypes/Artworks.ts
+++ b/src/schema/v2/homeView/sectionTypes/Artworks.ts
@@ -10,11 +10,11 @@ import { standardSectionFields } from "./GenericSectionInterface"
 import { HomeViewSection } from "../sections"
 
 export interface HomeViewArtworksSection extends HomeViewSection {
-  enableItemsImpressionTracking?: boolean
+  trackItemImpressions?: boolean
 }
 
 export const HomeViewArtworksSectionType = new GraphQLObjectType<
-  any,
+  HomeViewArtworksSection,
   ResolverContext
 >({
   name: HomeViewSectionTypeNames.HomeViewSectionArtworks,
@@ -23,9 +23,9 @@ export const HomeViewArtworksSectionType = new GraphQLObjectType<
   fields: {
     ...standardSectionFields,
 
-    enableItemsImpressionTracking: {
+    trackItemImpressions: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      resolve: (parent) => !!parent.enableItemsImpressionTracking,
+      resolve: (parent) => !!parent.trackItemImpressions,
     },
     artworksConnection: {
       type: artworkConnection.connectionType,

--- a/src/schema/v2/homeView/sectionTypes/_ExampleSectionType.ts
+++ b/src/schema/v2/homeView/sectionTypes/_ExampleSectionType.ts
@@ -1,12 +1,14 @@
-import { GraphQLObjectType } from "graphql"
+import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../../artwork"
 import { emptyConnection } from "../../fields/pagination"
 import { NodeInterface } from "../../object_identification"
-import { HomeViewGenericSectionInterface } from "./GenericSectionInterface"
+import {
+  HomeViewGenericSectionInterface,
+  standardSectionFields,
+} from "./GenericSectionInterface"
 import { HomeViewSectionTypeNames } from "./names"
-import { standardSectionFields } from "./GenericSectionInterface"
 
 /*
  * A section type in the home view is specified declaratively
@@ -50,13 +52,19 @@ export const HomeViewExampleSectionType = new GraphQLObjectType<
 
     /**
      * This is where you define the field that is used to access this
-     * section type's data. It will typically be a connection over an existing
-     * MP data type.
+     * section type's data.
      *
-     * Usually you will need to define the connection name itself, and the
+     * This can be either a new field that is used only within the home view,
+     * or, most of the time, a connection over an existing MP data type.
+     *
+     * In the latter case, you will need to define the connection name itself, and the
      * type of connection. (The `args` and `resolve` attributes here are
      * generally just boilerplate.)
      */
+    trackItemImpressions: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: (parent) => !!parent.trackItemImpressions,
+    },
     artworksConnection: {
       type: artworkConnection.connectionType,
       args: pageable({}),

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -19,7 +19,7 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   },
   ownerType: OwnerType.newWorksForYou,
   requiresAuthentication: true,
-  enableItemsImpressionTracking: true,
+  trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
     const variant = getExperimentVariant("onyx_nwfy-price-affinity-test", {
       userId: context.userID,

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -1,11 +1,11 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { HomeViewSection } from "."
-import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
-import { HomeViewSectionTypeNames } from "../sectionTypes/names"
-import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
 import { getExperimentVariant } from "lib/featureFlags"
+import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
+import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
+import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
+import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 
-export const NewWorksForYou: HomeViewSection = {
+export const NewWorksForYou: HomeViewArtworksSection = {
   id: "home-view-section-new-works-for-you",
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.newWorksForYouRail,
@@ -19,7 +19,7 @@ export const NewWorksForYou: HomeViewSection = {
   },
   ownerType: OwnerType.newWorksForYou,
   requiresAuthentication: true,
-
+  enableItemsImpressionTracking: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
     const variant = getExperimentVariant("onyx_nwfy-price-affinity-test", {
       userId: context.userID,

--- a/src/schema/v2/homeView/sections/_ExampleSection.ts
+++ b/src/schema/v2/homeView/sections/_ExampleSection.ts
@@ -240,6 +240,12 @@ export const ExampleSection: HomeViewSection = {
   requiresAuthentication: false,
 
   /*
+   * Whether the section should track item impressions.
+   *
+   */
+  trackItemImpressions: true,
+
+  /*
    * Arbitrary logic to determine whether this section should be displayed.
    *
    * Intended for considering any logic beyond the standard checks

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -31,7 +31,7 @@ describe("NewWorksForYou", () => {
               }
             }
             ... on HomeViewSectionArtworks {
-              enableItemsImpressionTracking
+              trackItemImpressions
             }
           }
         }
@@ -59,9 +59,9 @@ describe("NewWorksForYou", () => {
           "title": "New Works for You",
         },
         "contextModule": "newWorksForYouRail",
-        "enableItemsImpressionTracking": true,
         "internalID": "home-view-section-new-works-for-you",
         "ownerType": "newWorksForYou",
+        "trackItemImpressions": true,
       }
     `)
   })

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -30,6 +30,9 @@ describe("NewWorksForYou", () => {
                 }
               }
             }
+            ... on HomeViewSectionArtworks {
+              enableItemsImpressionTracking
+            }
           }
         }
       }
@@ -56,6 +59,7 @@ describe("NewWorksForYou", () => {
           "title": "New Works for You",
         },
         "contextModule": "newWorksForYouRail",
+        "enableItemsImpressionTracking": true,
         "internalID": "home-view-section-new-works-for-you",
         "ownerType": "newWorksForYou",
       }


### PR DESCRIPTION
Solves [ONYX-1780]


This PR adds `enableItemsImpressionTracking` to artwork sections
| section with enableItemsImpressionTracking disabled | section with enableItemsImpressionTracking enabled |
|--------|--------|
| <img width="1148" alt="Screenshot 2025-07-02 at 10 45 51" src="https://github.com/user-attachments/assets/e37aa901-220f-4c77-90ad-305264b8e312" /> | <img width="1153" alt="Screenshot 2025-07-02 at 10 46 05" src="https://github.com/user-attachments/assets/fe0a1d40-935a-4e32-9dda-363a386dfa72" /> | 


[ONYX-1780]: https://artsyproduct.atlassian.net/browse/ONYX-1780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ