### PR TITLE
feat: add artwork caption

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2623,6 +2623,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Can a user request a lot conditions report for this artwork?
   canRequestLotConditionsReport: Boolean
 
+  # This field is intended for use exclusively on the individual Artwork page for alt tags
+  caption: String
+
   # Represents the "**medium type**", such as _Painting_. (This field is also commonly referred to as just "medium", but should not be confused with the artwork attribute called `medium`.)
   category: String @deprecated(reason: "Prefer to use `mediumType`.")
 

--- a/src/lib/loaders/loaders_with_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_with_authentication/vortex.ts
@@ -100,6 +100,11 @@ export default (accessToken, opts) => {
     ),
     auctionUserSegmentationLoader: vortexLoader("auction_user_segmentation"),
     userPricePreferenceLoader: vortexLoader("user_price_preference"),
+    artworkCaptionsLoader: vortexLoader(
+      "artwork_captions",
+      {},
+      { requestThrottleMs: 86400000 } // 1 day throttle
+    ),
   }
 }
 

--- a/src/lib/loaders/loaders_without_authentication/vortex.ts
+++ b/src/lib/loaders/loaders_without_authentication/vortex.ts
@@ -23,5 +23,10 @@ export default (opts) => {
     auctionLotRecommendationsLoader: vortexLoader(
       "auction_lot_recommendations"
     ),
+    artworkCaptionsLoader: vortexLoader(
+      "artwork_captions",
+      {},
+      { requestThrottleMs: 86400000 } // 1 day throttle
+    ),
   }
 }

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -5822,3 +5822,139 @@ describe("Artwork type", () => {
     })
   })
 })
+
+describe("Artwork caption field", () => {
+  const query = gql`
+    {
+      artwork(id: "percy-z-cat-artwork") {
+        caption
+      }
+    }
+  `
+
+  const mockArtwork = {
+    _id: "percy-z-cat-artwork-database-id",
+    id: "percy-z-cat-artwork",
+    title: "Percy and Fiby: A Cat Tale",
+  }
+
+  describe("with unauthenticated context", () => {
+    it("returns caption when artworkCaptionsLoader succeeds", async () => {
+      const artworkCaptionsLoader = jest.fn(() =>
+        Promise.resolve({
+          data: {
+            caption: "This is a beautiful artwork caption",
+          },
+        })
+      )
+
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        unauthenticatedLoaders: {
+          artworkCaptionsLoader,
+        },
+        artworkCaptionsLoader,
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(artworkCaptionsLoader).toHaveBeenCalledWith({
+        artwork_id: mockArtwork._id,
+      })
+      expect(data).toEqual({
+        artwork: {
+          caption: "This is a beautiful artwork caption",
+        },
+      })
+    })
+
+    it("returns null when caption data is null", async () => {
+      const artworkCaptionsLoader = jest.fn(() =>
+        Promise.resolve({
+          data: {
+            caption: null,
+          },
+        })
+      )
+
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        unauthenticatedLoaders: {
+          artworkCaptionsLoader,
+        },
+        artworkCaptionsLoader,
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          caption: null,
+        },
+      })
+    })
+
+    it("returns null when artworkCaptionsLoader is not available", async () => {
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        unauthenticatedLoaders: {},
+        artworkCaptionsLoader: null,
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          caption: null,
+        },
+      })
+    })
+  })
+
+  describe("with authenticated context", () => {
+    it("returns caption when artworkCaptionsLoader succeeds", async () => {
+      const artworkCaptionsLoader = jest.fn(() =>
+        Promise.resolve({
+          data: {
+            caption: "This is an authenticated artwork caption",
+          },
+        })
+      )
+
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        authenticatedLoaders: {
+          artworkCaptionsLoader,
+        },
+        artworkCaptionsLoader,
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(artworkCaptionsLoader).toHaveBeenCalledWith({
+        artwork_id: mockArtwork._id,
+      })
+      expect(data).toEqual({
+        artwork: {
+          caption: "This is an authenticated artwork caption",
+        },
+      })
+    })
+
+    it("returns null when artworkCaptionsLoader is not available", async () => {
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        authenticatedLoaders: {},
+        artworkCaptionsLoader: null,
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          caption: null,
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -409,6 +409,22 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         description: "The location of the artwork in My Collection",
       },
       availability: { type: GraphQLString },
+      caption: {
+        // This field is intended for use exclusively on the individual Artwork page for alt tags
+        // Do not use this field in any other context, like artwork rails
+        type: GraphQLString,
+        description:
+          "This field is intended for use exclusively on the individual Artwork page for alt tags",
+        resolve: ({ _id }, _options, { artworkCaptionsLoader }) => {
+          if (!artworkCaptionsLoader) return null
+
+          return artworkCaptionsLoader({
+            artwork_id: _id,
+          }).then(({ data }) => {
+            return data?.caption
+          })
+        },
+      },
       category: {
         type: GraphQLString,
         deprecationReason: "Prefer to use `mediumType`.",


### PR DESCRIPTION
This PR introduces a new caption field to the Artwork type, intended for use for alt tags only. 

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/b97d1737-35ea-4d44-a037-31e736589032" />



This is a follow-up for https://github.com/artsy/vortex/pull/713

Next steps: 
- [ ] Create a feature flag on Force

/cc @artsy/diamond-devs 