### PR TITLE
fix: Remove default values for page, size arguments for partnerArtworksMat…

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17145,9 +17145,9 @@ type Partner implements Node {
     before: String
     first: Int
     last: Int
-    page: Int = 1
+    page: Int
     query: String!
-    size: Int = 10
+    size: Int
   ): ArtworkConnection
   cached: Int
   categories: [PartnerCategory]

--- a/src/schema/v2/partner/PartnerMatch.ts
+++ b/src/schema/v2/partner/PartnerMatch.ts
@@ -54,8 +54,8 @@ export const partnerArtworksMatchConnection: GraphQLFieldConfig<
     query: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    size: { type: GraphQLInt, defaultValue: 10 },
-    page: { type: GraphQLInt, defaultValue: 1 },
+    size: { type: GraphQLInt },
+    page: { type: GraphQLInt },
   }),
   resolve: async (
     { id },
@@ -63,6 +63,13 @@ export const partnerArtworksMatchConnection: GraphQLFieldConfig<
     { partnerSearchArtworksLoader }
   ) => {
     if (!partnerSearchArtworksLoader) return null
+
+    // Apply defaults only if new Relay cursor fields aren't present
+    // for backwards compatibility with Folio
+    if (!args.first && !args.after) {
+      args.size = args.size || 10
+      args.page = args.page || 1
+    }
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 


### PR DESCRIPTION
…chConnection

Exposed as part of this [PR](https://github.com/artsy/volt/pull/9406)

Removing the defaults to `page` and `size` and only applying them if no cursor arguments are present
Having a default of `page=1` at the arg level was overriding my cursor arguments when trying to paginate 
and `offset` was always being set to `0` when trying to paginate on the volt side

Ex:
```
/match/partner/gagosian/artworks?offset=0&size=10&term=cecily&total_count=true
```

So I was only able to see the first page of data always!


This new fork will:
- Backwards compatibility for old clients (Folio): If neither `first` nor `after` are present, it applies the old defaults
- For relay backed clients: If `first` or `after` are present, it lets `convertConnectionArgsToGravityArgs()` handle the Relay cursor logic
 


cc @artsy/amber-devs 


