### PR TITLE
fix: remove deprecationReason from partnerBio arg

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1695,9 +1695,8 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   biographyBlurb(
     format: Format
 
-    # If true, will return featured bio over Artsy one.
+    # DEPRECATED: Artsy bios are always returned over featured bios.
     partnerBio: Boolean = true
-      @deprecated(reason: "Artsy bios are always returned over featured bios.")
   ): ArtistBlurb
   birthday: String
   blurb(format: Format): String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -443,10 +443,9 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         args: {
           partnerBio: {
             type: GraphQLBoolean,
-            description: "If true, will return featured bio over Artsy one.",
+            description:
+              "DEPRECATED: Artsy bios are always returned over featured bios.",
             defaultValue: true,
-            deprecationReason:
-              "Artsy bios are always returned over featured bios.",
           },
           ...markdown().args,
         },


### PR DESCRIPTION
This PR removes the `@deprecationReason` annotation from the `partnerBio` arg on the `biographyBlurb` of an `artist` because it was blocking a Force deployment https://github.com/artsy/force/pull/15781.

```
Directive "deprecated" may not be used on ARGUMENT_DEFINITION.
```

I moved the deprecation reason to the `@description` annotation until Force can be updated to support that annotation.