### PR TITLE
docs: minor updates to home view examples

### DIFF
--- a/src/schema/v2/homeView/sectionTypes/_ExampleSectionType.ts
+++ b/src/schema/v2/homeView/sectionTypes/_ExampleSectionType.ts
@@ -1,4 +1,4 @@
-import { GraphQLBoolean, GraphQLNonNull, GraphQLObjectType } from "graphql"
+import { GraphQLObjectType } from "graphql"
 import { pageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 import { artworkConnection } from "../../artwork"
@@ -61,10 +61,6 @@ export const HomeViewExampleSectionType = new GraphQLObjectType<
      * type of connection. (The `args` and `resolve` attributes here are
      * generally just boilerplate.)
      */
-    trackItemImpressions: {
-      type: new GraphQLNonNull(GraphQLBoolean),
-      resolve: (parent) => !!parent.trackItemImpressions,
-    },
     artworksConnection: {
       type: artworkConnection.connectionType,
       args: pageable({}),

--- a/src/schema/v2/homeView/sections/_ExampleSection.ts
+++ b/src/schema/v2/homeView/sections/_ExampleSection.ts
@@ -241,9 +241,11 @@ export const ExampleSection: HomeViewSection = {
 
   /*
    * Whether the section should track item impressions.
+   * (This is currently valid only for sections that return artworks,
+   * i.e. HomeViewArtworksSection)
    *
    */
-  trackItemImpressions: true,
+  trackItemImpressions: false,
 
   /*
    * Arbitrary logic to determine whether this section should be displayed.


### PR DESCRIPTION
In the interest of keeping the home view schema and docs as tightly scoped to real-world usage as possible I've made a couple of minor tweaks here.

- Defaulting `trackItemImpressions` to `false`, since we only want to opt into the extra analytics traffic deliberately

- Removing the `trackItemImpressions` implementation from the example section type, since as of now it only pertains to _artwork_ section types, which have already been implemented nicely  in https://github.com/artsy/metaphysics/pull/6872. My feeling is that we can expand this capability to other section types as needed, rather than preemptively.