### PR TITLE
fix: format biographyBlurb text and credit separately

### DIFF
--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -492,11 +492,11 @@ describe("Artist type", () => {
         `
         return runQuery(query, context).then((data) => {
           expect(data.artist.biographyBlurb.text).toContain("new catty bio")
-          expect(data.artist.biographyBlurb.text).toContain("Submitted by")
-          expect(data.artist.biographyBlurb.text).toContain("Catty Partner")
-          expect(data.artist.biographyBlurb.credit).toBe(
-            "Submitted by Catty Partner"
+          expect(data.artist.biographyBlurb.credit).toContain("Submitted by")
+          expect(data.artist.biographyBlurb.credit).toContain(
+            "https://www.artsy.net/partner/catty-partner"
           )
+          expect(data.artist.biographyBlurb.credit).toContain("Catty Partner")
           expect(data.artist.biographyBlurb.partnerID).toBe("catty-partner")
         })
       })
@@ -533,6 +533,7 @@ describe("Artist type", () => {
             artist(id: "foo-bar") {
               biographyBlurb(format: MARKDOWN) {
                 text
+                credit
               }
             }
           }
@@ -546,15 +547,14 @@ describe("Artist type", () => {
           expect(htmlData.artist.biographyBlurb.text).toContain(
             "This is a great artist biography."
           )
-          expect(htmlData.artist.biographyBlurb.text).toContain("Submitted by")
-          expect(htmlData.artist.biographyBlurb.text).toContain(
+          expect(htmlData.artist.biographyBlurb.credit).toContain(
+            "Submitted by"
+          )
+          expect(htmlData.artist.biographyBlurb.credit).toContain(
+            "https://www.artsy.net/partner/gallery-example"
+          )
+          expect(htmlData.artist.biographyBlurb.credit).toContain(
             "Gallery Example"
-          )
-          expect(htmlData.artist.biographyBlurb.text).toContain(
-            'href="https://www.artsy.net/partner/gallery-example"'
-          )
-          expect(htmlData.artist.biographyBlurb.credit).toBe(
-            "Submitted by Gallery Example"
           )
           expect(htmlData.artist.biographyBlurb.partnerID).toBe(
             "gallery-example"
@@ -562,7 +562,11 @@ describe("Artist type", () => {
 
           // Test Markdown format
           expect(markdownData.artist.biographyBlurb.text).toBe(
-            "This is a great artist biography.\n\n_Submitted by [Gallery Example](https://www.artsy.net/partner/gallery-example)_"
+            "This is a great artist biography."
+          )
+
+          expect(markdownData.artist.biographyBlurb.credit).toBe(
+            "Submitted by [Gallery Example](https://www.artsy.net/partner/gallery-example)"
           )
         })
       })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -494,12 +494,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
 
             // Return the featured partner bio if one exists
             if (biography && biography.length) {
-              // Append the credit to the text so it can be formatted
-              const creditedBiography = `${biography}\n\n_Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.id})_`
+              const credit = `Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.id})`
 
               return {
-                text: formatMarkdownValue(creditedBiography, format),
-                credit: `Submitted by ${partner.name}`,
+                text: formatMarkdownValue(biography, format),
+                credit: formatMarkdownValue(credit, format),
                 partner_id: partner.id,
                 partner: partner,
               }


### PR DESCRIPTION
This PR separates the credit text "Submitted by ..." that I previously appended to `biographyBlurb.text` so that Eigen and Force could both benefit from the same formatting without needing to make changes in 2 places.

It turns out that Volt also displays this text to partners when they are editing artist bios, so I need to separate those out again.

This work will be followed-up with PRs to Force and Eigen to display the `biographyBlurb.credit`.

cc: @artsy/diamond-devs 