### PR TITLE
feat: create NWFY artist diversity experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -16,7 +16,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-quick-links-v2",
   "onyx_enable-home-view-auction-segmentation",
   "onyx_enable-quick-links-price-budget",
-  "onyx_nwfy-price-affinity-test",
+  "onyx_nwfy-artist-diversity-experiment",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,5 +6,5 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
-  "onyx_nwfy-price-affinity-test",
+  "onyx_nwfy-artist-diversity-experiment",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -21,13 +21,16 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   requiresAuthentication: true,
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const variant = getExperimentVariant("onyx_nwfy-price-affinity-test", {
-      userId: context.userID,
-    })
+    const variant = getExperimentVariant(
+      "onyx_nwfy-artist-diversity-experiment",
+      {
+        userId: context.userID,
+      }
+    )
 
     let recommendationsVersion = "C"
 
-    if (variant && variant.enabled && variant.name === "experiment") {
+    if (variant && variant.enabled && variant.name === "variant-a") {
       recommendationsVersion = "A"
     }
 

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -71,7 +71,7 @@ describe("NewWorksForYou", () => {
     // see artworksForUser.test.ts
   })
 
-  describe("when the onyx_nwfy-price-affinity-test experiment is enabled", () => {
+  describe("when the onyx_nwfy-artist-diversity-experiment experiment is enabled", () => {
     it("serves Version C to the control group", async () => {
       mockGetExperimentVariant.mockImplementation(() => ({
         name: "control",
@@ -126,7 +126,7 @@ describe("NewWorksForYou", () => {
 
     it("serves Version A to the experiment group", async () => {
       mockGetExperimentVariant.mockImplementation(() => ({
-        name: "experiment",
+        name: "variant-a",
         enabled: true,
       }))
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1798

> [!NOTE]
>  We [recently](https://artsy.slack.com/archives/C07SYJBE2BC/p1751017440653529?thread_ts=1745333102.588449&cid=C07SYJBE2BC) standardized some [advice on flag and variant naming](https://www.notion.so/artsy/Feature-Toggles-and-Experiments-43523493b48a4a92882037f0106bef5c?source=copy_link#21bcab0764a0807b9446f66a0db44a44), so this PR adheres to that — thus the slight naming inconsistency between the previous and current experiment.

Last week we [closed](https://artsy.slack.com/archives/C05EQL4R5N0/p1751563795173429) the price affinity experiment (and plan to re-open it at a later date once we have revised the price prediction model).

In the meantime we will run a different experiment in NWYF recs — this time a/b testing a version in which we [improved perceived artist diversity](https://github.com/artsy/zenith/pull/523).

Since our current NWFY experiment setup requires us to run these tests serially, in this PR we simply flip the flag and variant names to reflect the new experiment. (And can flip them back once we re-run the price experiment.)

This is enabled **only** in development/staging as of now and produces this kind of result:

| Version C (`control`) | Version A (`variant-a`) |
|--------|--------|
| _dominated by Warhol and Hockney_ | _better diversity_ |
| <img width="300" alt="c" src="https://github.com/user-attachments/assets/15cc9113-c27d-462d-961e-7da00d7d4a40" /> | <img width="300" alt="a" src="https://github.com/user-attachments/assets/3081e280-111a-441e-8143-1b3f847d2425" /> |


