### PR TITLE
fix: missing italics in artist bio credit line

### DIFF
--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -566,7 +566,7 @@ describe("Artist type", () => {
           )
 
           expect(markdownData.artist.biographyBlurb.credit).toBe(
-            "Submitted by [Gallery Example](https://www.artsy.net/partner/gallery-example)"
+            "_Submitted by [Gallery Example](https://www.artsy.net/partner/gallery-example)_"
           )
         })
       })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -494,7 +494,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
 
             // Return the featured partner bio if one exists
             if (biography && biography.length) {
-              const credit = `Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.id})`
+              const credit = `_Submitted by [${partner.name}](${config.FORCE_URL}/partner/${partner.id})_`
 
               return {
                 text: formatMarkdownValue(biography, format),


### PR DESCRIPTION
This PR adds italics to the credit line that is included in a `biographyBlurb` when the bio was written by a partner.