### PR TITLE
feat(AMBER-1739): Allow unsetting artwork import row fields on update

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -22678,7 +22678,7 @@ input UpdateArtworkImportRowInput {
   artworkImportRowID: String!
   clientMutationId: String
   fieldName: String!
-  fieldValue: String!
+  fieldValue: String
 }
 
 type UpdateArtworkImportRowPayload {

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowMutation.test.ts
@@ -48,4 +48,51 @@ describe("UpdateArtworkImportRowMutation", () => {
       },
     })
   })
+
+  it("updates a row with null fieldValue", async () => {
+    const artworkImportUpdateRowLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRow(
+          input: {
+            artworkImportID: "artwork-import-1"
+            artworkImportRowID: "row-1"
+            fieldName: "ArtistNames"
+            fieldValue: null
+          }
+        ) {
+          updateArtworkImportRowOrError {
+            ... on UpdateArtworkImportRowSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportUpdateRowLoader,
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportUpdateRowLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        row_id: "row-1",
+        field_name: "ArtistNames",
+        field_value: null,
+      }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRow: {
+        updateArtworkImportRowOrError: {
+          success: true,
+        },
+      },
+    })
+  })
 })

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowMutation.ts
@@ -1,16 +1,16 @@
 import {
-  GraphQLString,
-  GraphQLObjectType,
-  GraphQLUnionType,
-  GraphQLNonNull,
   GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
-import { ResolverContext } from "types/graphql"
 import {
   formatGravityError,
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
 import { ArtworkImportType } from "./artworkImport"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -64,7 +64,7 @@ export const UpdateArtworkImportRowMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
     },
     fieldValue: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
     },
   },
   outputFields: {


### PR DESCRIPTION
🔴 Do not merge before Gravity is ready

This PR resolves [AMBER-1739](https://artsyproduct.atlassian.net/browse/AMBER-1739?atlOrigin=eyJpIjoiMjRkYjg3NWNjY2UwNGYyNDk2MmNhNGJhMDQzZjNhNWIiLCJwIjoiaiJ9)

* [Slack discussion](https://artsy.slack.com/archives/C07UYRFAVPU/p1751891585059869)
* Related Gravity PR: https://github.com/artsy/gravity/pull/19091
* Related Volt PR: https://github.com/artsy/volt/pull/9445

## Description

This allows unsetting artwork import row fields with `updateArtworkImportRowMutation`.

@artsy/amber-devs 

[AMBER-1739]: https://artsyproduct.atlassian.net/browse/AMBER-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ