### PR TITLE
feat: Adding mutation level support for bulk add to show

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4542,26 +4542,6 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
-input BulkAddArtworksToShowFilterInput {
-  # Filter artworks by artist id
-  artistId: String
-
-  # Filter artworks with matching ids
-  artworkIds: [String]
-
-  # Filter artworks by availability
-  availability: Availability
-
-  # Filter artworks by location
-  locationId: String
-
-  # Filter artworks by partner artist id
-  partnerArtistId: String
-
-  # Filter artworks by published status
-  published: Boolean
-}
-
 type BulkAddArtworksToShowMutationFailure {
   mutationError: GravityMutationError
 }
@@ -4570,7 +4550,7 @@ input BulkAddArtworksToShowMutationInput {
   clientMutationId: String
 
   # Filter options to apply
-  filters: BulkAddArtworksToShowFilterInput
+  filters: BulkArtworkFilterInput
 
   # ID of the partner
   id: String!
@@ -4598,7 +4578,7 @@ type BulkAddArtworksToShowResponse {
   ids: [String]
 }
 
-input BulkUpdateArtworksFilterInput {
+input BulkArtworkFilterInput {
   # Filter artworks by artist id
   artistId: String
 
@@ -4655,7 +4635,7 @@ input BulkUpdateArtworksMetadataMutationInput {
   clientMutationId: String
 
   # Filter options to apply
-  filters: BulkUpdateArtworksFilterInput
+  filters: BulkArtworkFilterInput
 
   # ID of the partner
   id: String!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4542,6 +4542,62 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
+type BulkAddArtworksToShowFailure {
+  mutationError: GravityMutationError
+}
+
+input BulkAddArtworksToShowFilterInput {
+  # Filter artworks by artist id
+  artistId: String
+
+  # Filter artworks with matching ids
+  artworkIds: [String]
+
+  # Filter artworks by availability
+  availability: Availability
+
+  # Filter artworks by location
+  locationId: String
+
+  # Filter artworks by partner artist id
+  partnerArtistId: String
+
+  # Filter artworks by published status
+  published: Boolean
+}
+
+input BulkAddArtworksToShowMutationInput {
+  clientMutationId: String
+
+  # Filter options to apply
+  filters: BulkAddArtworksToShowFilterInput
+
+  # ID of the partner
+  id: String!
+
+  # ID of the show to which artworks will be added
+  showId: String!
+}
+
+type BulkAddArtworksToShowMutationPayload {
+  bulkAddArtworksToShowOrError: BulkAddArtworksToShowMutationType
+  clientMutationId: String
+}
+
+type BulkAddArtworksToShowMutationSuccess {
+  skippedPartnerArtworks: BulkAddArtworksToShowResponse
+  updatedPartnerArtworks: BulkAddArtworksToShowResponse
+}
+
+union BulkAddArtworksToShowMutationType =
+    BulkAddArtworksToShowFailure
+  | BulkAddArtworksToShowMutationSuccess
+
+type BulkAddArtworksToShowResponse {
+  count: Int
+  ids: [String]
+}
+
 input BulkUpdateArtworksFilterInput {
   # Filter artworks by artist id
   artistId: String
@@ -15292,6 +15348,11 @@ type Mutation {
   assignArtworkImportArtist(
     input: AssignArtworkImportArtistInput!
   ): AssignArtworkImportArtistPayload
+
+  # Bulk add artworks to a show
+  bulkAddArtworksToShow(
+    input: BulkAddArtworksToShowMutationInput!
+  ): BulkAddArtworksToShowMutationPayload
 
   # Update all artworks that belong to the partner
   bulkUpdateArtworksMetadata(

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4542,10 +4542,6 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
-type BulkAddArtworksToShowFailure {
-  mutationError: GravityMutationError
-}
-
 input BulkAddArtworksToShowFilterInput {
   # Filter artworks by artist id
   artistId: String
@@ -4564,6 +4560,10 @@ input BulkAddArtworksToShowFilterInput {
 
   # Filter artworks by published status
   published: Boolean
+}
+
+type BulkAddArtworksToShowMutationFailure {
+  mutationError: GravityMutationError
 }
 
 input BulkAddArtworksToShowMutationInput {
@@ -4590,7 +4590,7 @@ type BulkAddArtworksToShowMutationSuccess {
 }
 
 union BulkAddArtworksToShowMutationType =
-    BulkAddArtworksToShowFailure
+    BulkAddArtworksToShowMutationFailure
   | BulkAddArtworksToShowMutationSuccess
 
 type BulkAddArtworksToShowResponse {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1242,6 +1242,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    addArtworksToShowLoader: gravityLoader(
+      (id) => `partner/${id}/bulk_operations/add_artworks_to_show`,
+      {},
+      { method: "PUT" }
+    ),
     updatePartnerContactLoader: gravityLoader<
       any,
       { partnerId: string; contactId: string }

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkAddArtworksToShowMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkAddArtworksToShowMutation.test.ts
@@ -1,0 +1,142 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("BulkAddArtworksToShowMutation", () => {
+  const mutation = gql`
+    mutation {
+      bulkAddArtworksToShow(
+        input: {
+          id: "partner123"
+          showId: "show456"
+          filters: {
+            artworkIds: ["artwork1", "artwork2"]
+            availability: FOR_SALE
+            locationId: "oldLocation"
+            partnerArtistId: "artist789"
+            published: true
+          }
+        }
+      ) {
+        bulkAddArtworksToShowOrError {
+          __typename
+          ... on BulkAddArtworksToShowMutationSuccess {
+            updatedPartnerArtworks {
+              count
+              ids
+            }
+            skippedPartnerArtworks {
+              count
+              ids
+            }
+          }
+          ... on BulkAddArtworksToShowMutationFailure {
+            mutationError {
+              error
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("adds multiple artworks to a given show", async () => {
+    const context = {
+      addArtworksToShowLoader: jest.fn().mockResolvedValue({
+        success: 2,
+        errors: {
+          count: 1,
+          ids: ["artwork3"],
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.addArtworksToShowLoader).toHaveBeenCalledWith("partner123", {
+      show_id: "show456",
+      filters: {
+        artwork_ids: ["artwork1", "artwork2"],
+        availability: "for sale",
+        location_id: "oldLocation",
+        partner_artist_id: "artist789",
+        published: true,
+      },
+    })
+
+    expect(result).toEqual({
+      bulkAddArtworksToShow: {
+        bulkAddArtworksToShowOrError: {
+          __typename: "BulkAddArtworksToShowMutationSuccess",
+          updatedPartnerArtworks: {
+            count: 2,
+            ids: [],
+          },
+          skippedPartnerArtworks: {
+            count: 1,
+            ids: ["artwork3"],
+          },
+        },
+      },
+    })
+  })
+
+  it("respects the filter parameters", async () => {
+    const mutationWithFilterOnly = gql`
+      mutation {
+        bulkAddArtworksToShow(
+          input: {
+            id: "partner123"
+            showId: "show456"
+            filters: { partnerArtistId: "artist789" }
+          }
+        ) {
+          bulkAddArtworksToShowOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      addArtworksToShowLoader: jest.fn().mockResolvedValue({
+        success: 5,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(mutationWithFilterOnly, context)
+
+    expect(context.addArtworksToShowLoader).toHaveBeenCalledWith("partner123", {
+      show_id: "show456",
+      filters: {
+        partner_artist_id: "artist789",
+      },
+    })
+  })
+
+  it("handles gravity API errors gracefully", async () => {
+    const context = {
+      addArtworksToShowLoader: () =>
+        Promise.reject(new HTTPError(`Forbidden`, 403, "Gravity Error")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      bulkAddArtworksToShow: {
+        bulkAddArtworksToShowOrError: {
+          __typename: "BulkAddArtworksToShowMutationFailure",
+          mutationError: {
+            error: null,
+            message: "Gravity Error",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
@@ -71,7 +71,7 @@ const BulkAddArtworksToShowResponseType = new GraphQLObjectType<
   }),
 })
 
-const BulkAddArtworksToShowSuccessType = new GraphQLObjectType<
+const BulkAddArtworksToShowMutationSuccessType = new GraphQLObjectType<
   any,
   ResolverContext
 >({
@@ -86,11 +86,11 @@ const BulkAddArtworksToShowSuccessType = new GraphQLObjectType<
   }),
 })
 
-const BulkAddArtworksToShowFailureType = new GraphQLObjectType<
+const BulkAddArtworksToShowMutationFailureType = new GraphQLObjectType<
   any,
   ResolverContext
 >({
-  name: "BulkAddArtworksToShowFailure",
+  name: "BulkAddArtworksToShowMutationFailure",
   isTypeOf: (data) => {
     return data._type === "GravityMutationError"
   },
@@ -104,12 +104,15 @@ const BulkAddArtworksToShowFailureType = new GraphQLObjectType<
 
 const BulkAddArtworksToShowMutationType = new GraphQLUnionType({
   name: "BulkAddArtworksToShowMutationType",
-  types: [BulkAddArtworksToShowSuccessType, BulkAddArtworksToShowFailureType],
+  types: [
+    BulkAddArtworksToShowMutationSuccessType,
+    BulkAddArtworksToShowMutationFailureType,
+  ],
   resolveType: (object) => {
     if (object.mutationError || object._type === "GravityMutationError") {
-      return BulkAddArtworksToShowFailureType
+      return BulkAddArtworksToShowMutationFailureType
     }
-    return BulkAddArtworksToShowSuccessType
+    return BulkAddArtworksToShowMutationSuccessType
   },
 })
 
@@ -156,8 +159,6 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
     { addArtworksToShowLoader }
   ) => {
     const gravityOptions: any = {}
-
-    console.log("filters", filters)
 
     if (filters) {
       gravityOptions.filters = {

--- a/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
@@ -151,8 +151,13 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
       },
     },
   },
-  mutateAndGetPayload: async ({ id, filters }, { addArtworksToShowLoader }) => {
+  mutateAndGetPayload: async (
+    { id, showId, filters },
+    { addArtworksToShowLoader }
+  ) => {
     const gravityOptions: any = {}
+
+    console.log("filters", filters)
 
     if (filters) {
       gravityOptions.filters = {
@@ -170,7 +175,10 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
     }
 
     try {
-      return await addArtworksToShowLoader(id, gravityOptions)
+      return await addArtworksToShowLoader(id, {
+        show_id: showId,
+        filters: gravityOptions.filters,
+      })
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
@@ -1,0 +1,183 @@
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { Availability } from "schema/v2/types/availability"
+import { ResolverContext } from "types/graphql"
+
+interface Input {
+  id: string
+  showId: string
+  filters?: {
+    artistId?: string
+    availability?: string
+    artworkIds?: string[]
+    locationId?: string
+    partnerArtistId?: string
+    published?: boolean
+  }
+}
+
+// Pull this out into something sharable?
+const BulkAddArtworksToShowFilterInput = new GraphQLInputObjectType({
+  name: "BulkAddArtworksToShowFilterInput",
+  fields: {
+    artistId: {
+      type: GraphQLString,
+      description: "Filter artworks by artist id",
+    },
+    availability: {
+      type: Availability,
+      description: "Filter artworks by availability",
+    },
+    artworkIds: {
+      type: new GraphQLList(GraphQLString),
+      description: "Filter artworks with matching ids",
+    },
+    locationId: {
+      type: GraphQLString,
+      description: "Filter artworks by location",
+    },
+    partnerArtistId: {
+      type: GraphQLString,
+      description: "Filter artworks by partner artist id",
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "Filter artworks by published status",
+    },
+  },
+})
+
+const BulkAddArtworksToShowResponseType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "BulkAddArtworksToShowResponse",
+  fields: () => ({
+    count: { type: GraphQLInt },
+    ids: { type: GraphQLList(GraphQLString) },
+  }),
+})
+
+const BulkAddArtworksToShowSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "BulkAddArtworksToShowMutationSuccess",
+  fields: () => ({
+    updatedPartnerArtworks: {
+      type: BulkAddArtworksToShowResponseType,
+    },
+    skippedPartnerArtworks: {
+      type: BulkAddArtworksToShowResponseType,
+    },
+  }),
+})
+
+const BulkAddArtworksToShowFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "BulkAddArtworksToShowFailure",
+  isTypeOf: (data) => {
+    return data._type === "GravityMutationError"
+  },
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const BulkAddArtworksToShowMutationType = new GraphQLUnionType({
+  name: "BulkAddArtworksToShowMutationType",
+  types: [BulkAddArtworksToShowSuccessType, BulkAddArtworksToShowFailureType],
+  resolveType: (object) => {
+    if (object.mutationError || object._type === "GravityMutationError") {
+      return BulkAddArtworksToShowFailureType
+    }
+    return BulkAddArtworksToShowSuccessType
+  },
+})
+
+export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "BulkAddArtworksToShowMutation",
+  description: "Bulk add artworks to a show",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner",
+    },
+    showId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the show to which artworks will be added",
+    },
+    filters: {
+      type: BulkAddArtworksToShowFilterInput,
+      description: "Filter options to apply",
+    },
+  },
+  outputFields: {
+    bulkAddArtworksToShowOrError: {
+      type: BulkAddArtworksToShowMutationType,
+      resolve: (result) => {
+        if (result._type === "GravityMutationError") {
+          return result
+        }
+        return {
+          updatedPartnerArtworks: { count: result.success, ids: [] },
+          skippedPartnerArtworks: {
+            count: result.errors.count,
+            ids: result.errors.ids,
+          },
+        }
+      },
+    },
+  },
+  mutateAndGetPayload: async ({ id, filters }, { addArtworksToShowLoader }) => {
+    const gravityOptions: any = {}
+
+    if (filters) {
+      gravityOptions.filters = {
+        artist_id: filters.artistId,
+        availability: filters.availability,
+        artwork_ids: filters.artworkIds,
+        location_id: filters.locationId,
+        partner_artist_id: filters.partnerArtistId,
+        published: filters.published,
+      }
+    }
+
+    if (!addArtworksToShowLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await addArtworksToShowLoader(id, gravityOptions)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error.message || error.toString())
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
@@ -1,6 +1,4 @@
 import {
-  GraphQLBoolean,
-  GraphQLInputObjectType,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
@@ -13,8 +11,8 @@ import {
   GravityMutationErrorType,
   formatGravityError,
 } from "lib/gravityErrorHandler"
-import { Availability } from "schema/v2/types/availability"
 import { ResolverContext } from "types/graphql"
+import { BulkArtworkFilterInput } from "./shared"
 
 interface Input {
   id: string
@@ -28,37 +26,6 @@ interface Input {
     published?: boolean
   }
 }
-
-// Pull this out into something sharable?
-const BulkAddArtworksToShowFilterInput = new GraphQLInputObjectType({
-  name: "BulkAddArtworksToShowFilterInput",
-  fields: {
-    artistId: {
-      type: GraphQLString,
-      description: "Filter artworks by artist id",
-    },
-    availability: {
-      type: Availability,
-      description: "Filter artworks by availability",
-    },
-    artworkIds: {
-      type: new GraphQLList(GraphQLString),
-      description: "Filter artworks with matching ids",
-    },
-    locationId: {
-      type: GraphQLString,
-      description: "Filter artworks by location",
-    },
-    partnerArtistId: {
-      type: GraphQLString,
-      description: "Filter artworks by partner artist id",
-    },
-    published: {
-      type: GraphQLBoolean,
-      description: "Filter artworks by published status",
-    },
-  },
-})
 
 const BulkAddArtworksToShowResponseType = new GraphQLObjectType<
   any,
@@ -133,7 +100,7 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
       description: "ID of the show to which artworks will be added",
     },
     filters: {
-      type: BulkAddArtworksToShowFilterInput,
+      type: BulkArtworkFilterInput,
       description: "Filter options to apply",
     },
   },

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -16,6 +16,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { Availability } from "schema/v2/types/availability"
 import { ResolverContext } from "types/graphql"
+import { BulkArtworkFilterInput } from "./shared"
 
 interface Input {
   id: string
@@ -80,36 +81,6 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     published: {
       type: GraphQLBoolean,
       description: "Publish or unpublish artworks",
-    },
-  },
-})
-
-const BulkUpdateArtworksFilterInput = new GraphQLInputObjectType({
-  name: "BulkUpdateArtworksFilterInput",
-  fields: {
-    artistId: {
-      type: GraphQLString,
-      description: "Filter artworks by artist id",
-    },
-    availability: {
-      type: Availability,
-      description: "Filter artworks by availability",
-    },
-    artworkIds: {
-      type: new GraphQLList(GraphQLString),
-      description: "Filter artworks with matching ids",
-    },
-    locationId: {
-      type: GraphQLString,
-      description: "Filter artworks by location",
-    },
-    partnerArtistId: {
-      type: GraphQLString,
-      description: "Filter artworks by partner artist id",
-    },
-    published: {
-      type: GraphQLBoolean,
-      description: "Filter artworks by published status",
     },
   },
 })
@@ -187,7 +158,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
       description: "Metadata to be updated",
     },
     filters: {
-      type: BulkUpdateArtworksFilterInput,
+      type: BulkArtworkFilterInput,
       description: "Filter options to apply",
     },
   },

--- a/src/schema/v2/partner/BulkOperation/shared.ts
+++ b/src/schema/v2/partner/BulkOperation/shared.ts
@@ -1,0 +1,37 @@
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLList,
+  GraphQLString,
+} from "graphql"
+import { Availability } from "schema/v2/types/availability"
+
+export const BulkArtworkFilterInput = new GraphQLInputObjectType({
+  name: "BulkArtworkFilterInput",
+  fields: {
+    artistId: {
+      type: GraphQLString,
+      description: "Filter artworks by artist id",
+    },
+    availability: {
+      type: Availability,
+      description: "Filter artworks by availability",
+    },
+    artworkIds: {
+      type: new GraphQLList(GraphQLString),
+      description: "Filter artworks with matching ids",
+    },
+    locationId: {
+      type: GraphQLString,
+      description: "Filter artworks by location",
+    },
+    partnerArtistId: {
+      type: GraphQLString,
+      description: "Filter artworks by partner artist id",
+    },
+    published: {
+      type: GraphQLBoolean,
+      description: "Filter artworks by published status",
+    },
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -330,6 +330,7 @@ import { updateOrderShippingAddressMutation } from "./order/updateOrderShippingA
 import { updatePurchaseMutation } from "./Purchases/updatePurchaseMutation"
 import { deletePurchaseMutation } from "./Purchases/deletePurchaseMutation"
 import { createPurchaseMutation } from "./Purchases/createPurchaseMutation"
+import { bulkAddArtworksToShowMutation } from "./partner/BulkOperation/bulkAddArtworksToShowMutation"
 
 const rootFields = {
   // artworkVersion: ArtworkVersionResolver,
@@ -492,6 +493,7 @@ export default new GraphQLSchema({
       artsyShippingOptIn: artsyShippingOptInMutation,
       artworksCollectionsBatchUpdate: artworksCollectionsBatchUpdateMutation,
       assignArtworkImportArtist: AssignArtworkImportArtistMutation,
+      bulkAddArtworksToShow: bulkAddArtworksToShowMutation,
       bulkUpdateArtworksMetadata: bulkUpdateArtworksMetadataMutation,
       cancelArtworkImport: CancelArtworkImportMutation,
       commerceOptIn: commerceOptInMutation,


### PR DESCRIPTION
Adding mutation level support for bulk add to show

This will power the experience in our bulk edits flow to allow users to batch add artworks to a show

Ex of the spiked behavior end to end can be seen in #bulk_publishing channel

cc @artsy/amber-devs 
