### PR TITLE
chore: add maximum eigen version for discovery sections

### DIFF
--- a/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
+++ b/src/schema/v2/homeView/sections/DiscoverSomethingNew.ts
@@ -27,6 +27,7 @@ export const DiscoverSomethingNew: HomeViewSection = {
     type: "Chips",
   },
   requiresAuthentication: false,
+  maximumEigenVersion: { major: 8, minor: 77, patch: 0 },
   resolver: async (_parent, args, context, _info) => {
     const { body } = await context.marketingCollectionsLoader({
       slugs: marketingCollectionSlugs,

--- a/src/schema/v2/homeView/sections/ExploreByCategory.ts
+++ b/src/schema/v2/homeView/sections/ExploreByCategory.ts
@@ -21,6 +21,7 @@ export const ExploreByCategory: HomeViewSection = {
     title: "Explore by Category",
   },
   requiresAuthentication: false,
+  maximumEigenVersion: { major: 8, minor: 77, patch: 0 },
   resolver: (_parent, args, _context, _info) => {
     const cards = orderedCategoryKeys.map((key) => {
       const category = marketingCollectionCategories[key]

--- a/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/DiscoverSomethingNew.test.ts
@@ -1,5 +1,7 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { isSectionDisplayable } from "schema/v2/homeView/helpers/isSectionDisplayable"
+import { DiscoverSomethingNew } from "../DiscoverSomethingNew"
 
 describe("DiscoverSomethingNew", () => {
   it("returns the section's metadata", async () => {
@@ -116,5 +118,46 @@ describe("DiscoverSomethingNew", () => {
           },
         }
       `)
+  })
+
+  describe("eigen version constraints", () => {
+    it("is displayable when user is on version 8.77.0 (at maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.77.0 Eigen/2024.12.10.06/8.77.0",
+      } as any
+      expect(isSectionDisplayable(DiscoverSomethingNew, context)).toBe(true)
+    })
+
+    it("is displayable when user is on version 8.76.0 (below maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.76.0 Eigen/2024.12.10.06/8.76.0",
+      } as any
+      expect(isSectionDisplayable(DiscoverSomethingNew, context)).toBe(true)
+    })
+
+    it("is not displayable when user is on version 8.78.0 (above maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.78.0 Eigen/2024.12.10.06/8.78.0",
+      } as any
+      expect(isSectionDisplayable(DiscoverSomethingNew, context)).toBe(false)
+    })
+
+    it("is not displayable when user is on version 9.0.0 (above maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/9.0.0 Eigen/2024.12.10.06/9.0.0",
+      } as any
+      expect(isSectionDisplayable(DiscoverSomethingNew, context)).toBe(false)
+    })
+
+    it("is displayable when user agent is unrecognized (graceful fallback)", () => {
+      const context = {
+        userAgent: "unknown browser",
+      } as any
+      expect(isSectionDisplayable(DiscoverSomethingNew, context)).toBe(true)
+    })
   })
 })

--- a/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/ExploreByCategory.test.ts
@@ -1,5 +1,7 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { isSectionDisplayable } from "schema/v2/homeView/helpers/isSectionDisplayable"
+import { ExploreByCategory } from "../ExploreByCategory"
 
 describe("ExploreByCategory", () => {
   it("returns the section's metadata", async () => {
@@ -105,5 +107,46 @@ describe("ExploreByCategory", () => {
           },
         }
       `)
+  })
+
+  describe("eigen version constraints", () => {
+    it("is displayable when user is on version 8.77.0 (at maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.77.0 Eigen/2024.12.10.06/8.77.0",
+      } as any
+      expect(isSectionDisplayable(ExploreByCategory, context)).toBe(true)
+    })
+
+    it("is displayable when user is on version 8.76.0 (below maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.76.0 Eigen/2024.12.10.06/8.76.0",
+      } as any
+      expect(isSectionDisplayable(ExploreByCategory, context)).toBe(true)
+    })
+
+    it("is not displayable when user is on version 8.78.0 (above maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/8.78.0 Eigen/2024.12.10.06/8.78.0",
+      } as any
+      expect(isSectionDisplayable(ExploreByCategory, context)).toBe(false)
+    })
+
+    it("is not displayable when user is on version 9.0.0 (above maximum)", () => {
+      const context = {
+        userAgent:
+          "unknown iOS/18.1.1 Artsy-Mobile/9.0.0 Eigen/2024.12.10.06/9.0.0",
+      } as any
+      expect(isSectionDisplayable(ExploreByCategory, context)).toBe(false)
+    })
+
+    it("is displayable when user agent is unrecognized (graceful fallback)", () => {
+      const context = {
+        userAgent: "unknown browser",
+      } as any
+      expect(isSectionDisplayable(ExploreByCategory, context)).toBe(true)
+    })
   })
 })


### PR DESCRIPTION
This PR adds 8.77.0 as the maximum eigen version for the _Discover Something New_ and _Explore by Category_ home view sections. For version 8.78.0 and beyond those sections will be displayed on the search tab instead of on the home view.

cc: @artsy/diamond-devs 