### PR TITLE
feat(show): Add published / unpublished counts

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21981,6 +21981,8 @@ type ShowCounts {
     format: String
     label: String
   ): FormattedNumber
+  publishedArtworks: Int
+  unpublishedArtworks: Int
 }
 
 # An edge in a connection.

--- a/src/schema/v2/__tests__/show.test.js
+++ b/src/schema/v2/__tests__/show.test.js
@@ -771,6 +771,74 @@ describe("Show type", () => {
     })
   })
 
+  it("includes the total number of published artworks", async () => {
+    context.partnerShowArtworksLoader = sinon.stub().returns(
+      Promise.resolve({
+        headers: {
+          "x-total-count": 42,
+        },
+      })
+    )
+    context.partnerShowArtistsLoader = jest.fn(() =>
+      Promise.resolve({
+        headers: {
+          "x-total-count": 21,
+        },
+      })
+    )
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            publishedArtworks
+          }
+        }
+      }
+    `
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      show: {
+        counts: {
+          publishedArtworks: 42,
+        },
+      },
+    })
+  })
+
+  it("includes the total number of unpublished artworks", async () => {
+    context.partnerShowArtworksLoader = sinon.stub().returns(
+      Promise.resolve({
+        headers: {
+          "x-total-count": 42,
+        },
+      })
+    )
+    context.partnerShowArtistsLoader = jest.fn(() =>
+      Promise.resolve({
+        headers: {
+          "x-total-count": 21,
+        },
+      })
+    )
+    const query = gql`
+      {
+        show(id: "new-museum-1-2015-triennial-surround-audience") {
+          counts {
+            unpublishedArtworks
+          }
+        }
+      }
+    `
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      show: {
+        counts: {
+          unpublishedArtworks: 42,
+        },
+      },
+    })
+  })
+
   it("includes the total number of artists", async () => {
     context.partnerShowArtistsLoader = jest.fn(() =>
       Promise.resolve({

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -327,6 +327,38 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
                 )
               },
             },
+            publishedArtworks: {
+              type: GraphQLInt,
+              resolve: ({ id, partner }, {}, { partnerShowArtworksLoader }) => {
+                const options: any = {
+                  published: true,
+                }
+                return totalViaLoader(
+                  partnerShowArtworksLoader,
+                  {
+                    partner_id: partner.id,
+                    show_id: id,
+                  },
+                  options
+                )
+              },
+            },
+            unpublishedArtworks: {
+              type: GraphQLInt,
+              resolve: ({ id, partner }, {}, { partnerShowArtworksLoader }) => {
+                const options: any = {
+                  published: false,
+                }
+                return totalViaLoader(
+                  partnerShowArtworksLoader,
+                  {
+                    partner_id: partner.id,
+                    show_id: id,
+                  },
+                  options
+                )
+              },
+            },
             eligibleArtworks: numeral(
               ({ eligible_artworks_count }) => eligible_artworks_count
             ),


### PR DESCRIPTION
Updates the show counts field with new `publishedArtworks` and `unpublishedArtworks` counts:

```graphql
{
  show(id:"gazelli-art-house-art-dubai-digital") {
    counts {
      publishedArtworks
      unpublishedArtworks
      artworks
    }
  }
}
```

cc @artsy/amber-devs 