### PR TITLE
chore: always use row-level properties for currency and dimension metric for imports

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3262,6 +3262,8 @@ enum ArtworkImportError {
 type ArtworkImportRow {
   artists: [Artist!]
   artwork: Artwork
+  currency: String!
+  dimensionMetric: String!
   errors: [ArtworkImportRowError!]!
 
   # A globally unique ID.

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -117,6 +117,13 @@ const ArtworkImportRowType = new GraphQLObjectType({
     artists: {
       type: new GraphQLList(new GraphQLNonNull(ArtistType)),
     },
+    currency: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    dimensionMetric: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ dimension_metric }) => dimension_metric,
+    },
     priceListed: {
       type: Money,
       resolve: (
@@ -326,7 +333,7 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
           type: GraphQLBoolean,
         },
       }),
-      resolve: async ({ id, currency }, args, { artworkImportRowsLoader }) => {
+      resolve: async ({ id }, args, { artworkImportRowsLoader }) => {
         if (!artworkImportRowsLoader) {
           throw new Error(
             "A X-Access-Token header is required to perform this action."
@@ -352,10 +359,7 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
           offset,
           page,
           size,
-          body: body.map((row) => ({
-            ...row,
-            currency,
-          })),
+          body,
           args,
         })
       },


### PR DESCRIPTION
Another easy one/no-op!

We now expose currency/dimension metric at the row level, _and_ we can use that currency to generate our nicely formatted prices (vs. needing to inject the import-level one).

With this PR (on top of https://github.com/artsy/gravity/pull/19120), I can go into Volt and update the import table to always use these row-level attributes when rendering the actual row.

That's going to be a no-op as well (backwards compatible).

But, this will unlock something neat - if I go in to a Gravity console and update the currency/dimension metric of a particular row on an import and reload the table in Volt - I'll see that row with the correct info! (and the artwork will be created with those attributes as well).

So that will fully unlock actually integrating setting the row-level attributes at parse time (probably just from the AI assisted version to start).

The main design/UI to work through after that's in place:
  - in the import table: should each row have a toggle to set the currency/dimension for that row?
  - what to do about the messaging at the top that says 'Prices shown in....' which assumes import-level setting?