### PR TITLE
feat: Allow source to be sent in bulk update mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2562,6 +2562,9 @@ input ArtsyShippingOptInMutationInput {
 
   # ID of the partner
   id: String!
+
+  # Source of the mutation being triggered, E.g. admin, artworks_list
+  source: BulkUpdateSourceEnum
 }
 
 type ArtsyShippingOptInMutationPayload {
@@ -4559,6 +4562,9 @@ input BulkAddArtworksToShowMutationInput {
 
   # ID of the show to which artworks will be added
   showId: String!
+
+  # Source of the mutation being triggered, E.g. admin, artworks_list
+  source: BulkUpdateSourceEnum
 }
 
 type BulkAddArtworksToShowMutationPayload {
@@ -4644,6 +4650,9 @@ input BulkUpdateArtworksMetadataMutationInput {
 
   # Metadata to be updated
   metadata: BulkUpdateArtworksMetadataInput
+
+  # Source of the mutation being triggered, E.g. admin, artworks_list
+  source: BulkUpdateSourceEnum
 }
 
 type BulkUpdateArtworksMetadataMutationPayload {
@@ -4663,6 +4672,14 @@ union BulkUpdateArtworksMetadataMutationType =
 type BulkUpdateArtworksMetadataResponse {
   count: Int
   ids: [String]
+}
+
+# Possible sources of the bulk operation
+enum BulkUpdateSourceEnum {
+  ADMIN
+  ARTWORKS_LIST
+  PARTNER_ARTIST_ARTWORKS_LIST
+  SHOW_ARTWORKS_LIST
 }
 
 type BuyersPremium {
@@ -6306,6 +6323,9 @@ input CommerceOptInMutationInput {
 
   # whether or not other is selected for signature
   signedOther: Boolean
+
+  # Source of the mutation being triggered, E.g. admin, artworks_list
+  source: BulkUpdateSourceEnum
 
   # whether or not it is stamped by the artist estate
   stampedByArtistEstate: Boolean

--- a/src/schema/v2/partner/ArtsyShippingOptIn/artsyShippingOptInMutation.ts
+++ b/src/schema/v2/partner/ArtsyShippingOptIn/artsyShippingOptInMutation.ts
@@ -13,9 +13,11 @@ import {
   formatGravityError,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { BulkUpdateSourceEnum } from "../BulkUpdateSourceEnum"
 
 interface Input {
   id: string
+  source: string
   artsyShippingDomestic: boolean | null
   artsyShippingInternational: boolean | null
 }
@@ -92,6 +94,11 @@ export const artsyShippingOptInMutation = mutationWithClientMutationId<
       type: GraphQLBoolean,
       description: "Whether Artsy international shipping should be enabled",
     },
+    source: {
+      type: BulkUpdateSourceEnum,
+      description:
+        "Source of the mutation being triggered, E.g. admin, artworks_list",
+    },
   },
   outputFields: {
     ArtsyShippingOptInOrError: {
@@ -112,12 +119,13 @@ export const artsyShippingOptInMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, artsyShippingDomestic, artsyShippingInternational },
+    { id, artsyShippingDomestic, artsyShippingInternational, source },
     { artsyShippingOptInLoader }
   ) => {
     const gravityOptions = {
       artsy_shipping_domestic: artsyShippingDomestic,
       artsy_shipping_international: artsyShippingInternational,
+      source,
     }
 
     if (!artsyShippingOptInLoader) {

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkAddArtworksToShowMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkAddArtworksToShowMutation.test.ts
@@ -9,6 +9,7 @@ describe("BulkAddArtworksToShowMutation", () => {
         input: {
           id: "partner123"
           showId: "show456"
+          source: ADMIN
           filters: {
             artworkIds: ["artwork1", "artwork2"]
             availability: FOR_SALE
@@ -56,6 +57,7 @@ describe("BulkAddArtworksToShowMutation", () => {
 
     expect(context.addArtworksToShowLoader).toHaveBeenCalledWith("partner123", {
       show_id: "show456",
+      source: "admin",
       filters: {
         artwork_ids: ["artwork1", "artwork2"],
         availability: "for sale",

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -8,6 +8,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
       bulkUpdateArtworksMetadata(
         input: {
           id: "partner123"
+          source: ARTWORKS_LIST
           metadata: {
             availability: SOLD
             domesticShippingFeeCents: 20000
@@ -85,6 +86,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           partner_artist_id: "artist789",
           published: true,
         },
+        source: "artworks_list",
       }
     )
 

--- a/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkAddArtworksToShowMutation.ts
@@ -13,10 +13,12 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { BulkArtworkFilterInput } from "./shared"
+import { BulkUpdateSourceEnum } from "../BulkUpdateSourceEnum"
 
 interface Input {
   id: string
   showId: string
+  source: string
   filters?: {
     artistId?: string
     availability?: string
@@ -99,6 +101,11 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the show to which artworks will be added",
     },
+    source: {
+      type: BulkUpdateSourceEnum,
+      description:
+        "Source of the mutation being triggered, E.g. admin, artworks_list",
+    },
     filters: {
       type: BulkArtworkFilterInput,
       description: "Filter options to apply",
@@ -122,7 +129,7 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, showId, filters },
+    { id, showId, source, filters },
     { addArtworksToShowLoader }
   ) => {
     const gravityOptions: any = {}
@@ -145,6 +152,7 @@ export const bulkAddArtworksToShowMutation = mutationWithClientMutationId<
     try {
       return await addArtworksToShowLoader(id, {
         show_id: showId,
+        source,
         filters: gravityOptions.filters,
       })
     } catch (error) {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -17,9 +17,11 @@ import {
 import { Availability } from "schema/v2/types/availability"
 import { ResolverContext } from "types/graphql"
 import { BulkArtworkFilterInput } from "./shared"
+import { BulkUpdateSourceEnum } from "../BulkUpdateSourceEnum"
 
 interface Input {
   id: string
+  source: string
   metadata?: {
     availability?: string
     domesticShippingFeeCents?: number
@@ -153,6 +155,11 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the partner",
     },
+    source: {
+      type: BulkUpdateSourceEnum,
+      description:
+        "Source of the mutation being triggered, E.g. admin, artworks_list",
+    },
     metadata: {
       type: BulkUpdateArtworksMetadataInput,
       description: "Metadata to be updated",
@@ -181,10 +188,12 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, metadata, filters },
+    { id, filters, metadata, source },
     { updatePartnerArtworksMetadataLoader }
   ) => {
-    const gravityOptions: any = {}
+    const gravityOptions: any = {
+      source,
+    }
 
     if (metadata) {
       gravityOptions.metadata = {

--- a/src/schema/v2/partner/BulkUpdateSourceEnum.ts
+++ b/src/schema/v2/partner/BulkUpdateSourceEnum.ts
@@ -1,0 +1,12 @@
+import { GraphQLEnumType } from "graphql"
+
+export const BulkUpdateSourceEnum = new GraphQLEnumType({
+  name: "BulkUpdateSourceEnum",
+  description: "Possible sources of the bulk operation",
+  values: {
+    ADMIN: { value: "admin" },
+    ARTWORKS_LIST: { value: "artworks_list" },
+    PARTNER_ARTIST_ARTWORKS_LIST: { value: "partner_artist_artworks_list" },
+    SHOW_ARTWORKS_LIST: { value: "show_artworks_list" },
+  },
+})

--- a/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
+++ b/src/schema/v2/partner/CommerceOptIn/commerceOptInMutation.ts
@@ -13,6 +13,7 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { BulkUpdateSourceEnum } from "../BulkUpdateSourceEnum"
 
 export const CommerceOptInResponseType = new GraphQLObjectType<
   any,
@@ -27,6 +28,7 @@ export const CommerceOptInResponseType = new GraphQLObjectType<
 
 interface Input {
   id: string
+  source: string
   exactPrice?: boolean
   pickupAvailable?: boolean
   framed?: boolean
@@ -89,6 +91,11 @@ export const commerceOptInMutation = mutationWithClientMutationId<
     id: {
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the partner",
+    },
+    source: {
+      type: BulkUpdateSourceEnum,
+      description:
+        "Source of the mutation being triggered, E.g. admin, artworks_list",
     },
     exactPrice: {
       type: GraphQLBoolean,
@@ -169,6 +176,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       stickerLabel,
       signedInPlate,
       signedOther,
+      source,
       notSigned,
     },
     { optInArtworksIntoCommerceLoader }
@@ -187,6 +195,7 @@ export const commerceOptInMutation = mutationWithClientMutationId<
       sticker_label: stickerLabel,
       signed_in_plate: signedInPlate,
       signed_other: signedOther,
+      source,
       not_signed: notSigned,
     }
 


### PR DESCRIPTION
Allow clients to pass in a `source` arg into our batch operation mutations

This allows us to diagnose and record where these batches are getting triggered from

Options include:
- admin
- artworks_list
- partner_artist_artworks_list
- show_artworks_list

See gravity API here
- https://github.com/artsy/gravity/pull/19124
- https://github.com/artsy/gravity/pull/19099

cc @artsy/amber-devs 