### PR TITLE
feat(EMI-2540): Enable SCA for order submit endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16799,6 +16799,10 @@ type Order {
   totalListPrice: Money
 }
 
+type OrderActionData {
+  clientSecret: String!
+}
+
 enum OrderBuyerStateEnum {
   # Order has been approved
   APPROVED
@@ -16850,11 +16854,18 @@ enum OrderModeEnum {
   OFFER
 }
 
+type OrderMutationActionRequired {
+  actionData: OrderActionData!
+}
+
 type OrderMutationError {
   mutationError: ExchangeError!
 }
 
-union OrderMutationResponse = OrderMutationError | OrderMutationSuccess
+union OrderMutationResponse =
+    OrderMutationActionRequired
+  | OrderMutationError
+  | OrderMutationSuccess
 
 type OrderMutationSuccess {
   order: Order!

--- a/src/schema/v2/order/__tests__/submitOrderMutation.test.ts
+++ b/src/schema/v2/order/__tests__/submitOrderMutation.test.ts
@@ -20,6 +20,11 @@ const mockMutation = `
             internalID
           }     
         }
+        ...on OrderMutationActionRequired {
+          actionData {
+            clientSecret
+          }
+        }
       }
     }
   }
@@ -153,6 +158,30 @@ describe("submitOrderMutation", () => {
             // fallback message for a non-exchange formatted error
             message: "An error occurred",
             code: "create_credit_card_failed",
+          },
+        },
+      },
+    })
+  })
+
+  it("handles payment_requires_action error with action required response", async () => {
+    context.meOrderSubmitLoader = jest.fn().mockRejectedValue({
+      statusCode: 422,
+      body: {
+        code: "payment_requires_action",
+        action_data: {
+          client_secret: "pi_test_1234567890_secret_abc123",
+        },
+      },
+    })
+    const result = await runAuthenticatedQuery(mockMutation, context)
+
+    expect(result.errors).toBeUndefined()
+    expect(result).toEqual({
+      submitOrder: {
+        orderOrError: {
+          actionData: {
+            clientSecret: "pi_test_1234567890_secret_abc123",
           },
         },
       },

--- a/src/schema/v2/order/exchangeErrorHandling.ts
+++ b/src/schema/v2/order/exchangeErrorHandling.ts
@@ -5,11 +5,25 @@ type ExchangeError = Error & {
   body?: {
     message?: string
     code: string
+    action_data?: {
+      client_secret: string
+    }
   }
 }
 
 export const handleExchangeError = (error: ExchangeError) => {
   let errorProperties: { message: string; code: string }
+
+  if (
+    error.statusCode === 422 &&
+    error.body?.code === "payment_requires_action"
+  ) {
+    return {
+      clientSecret: error.body.action_data?.client_secret,
+      _type: ORDER_MUTATION_FLAGS.ACTION_REQUIRED,
+      __typename: "OrderMutationActionRequired",
+    }
+  }
 
   if (error.statusCode === 422 && typeof error.body === "object") {
     errorProperties = {

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -562,6 +562,13 @@ const ExchangeErrorType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
+const OrderActionDataType = new GraphQLObjectType<any, ResolverContext>({
+  name: "OrderActionData",
+  fields: {
+    clientSecret: { type: new GraphQLNonNull(GraphQLString) },
+  },
+})
+
 const ErrorType = new GraphQLObjectType<any, ResolverContext>({
   name: "OrderMutationError",
   fields: () => ({
@@ -584,18 +591,35 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   }),
 })
 
+const ActionRequiredType = new GraphQLObjectType<any, ResolverContext>({
+  name: "OrderMutationActionRequired",
+  fields: () => ({
+    actionData: {
+      type: new GraphQLNonNull(OrderActionDataType),
+      resolve: (response) => response,
+    },
+  }),
+})
+
 export const ORDER_MUTATION_FLAGS = {
   SUCCESS: "ExchangeSuccessType",
   ERROR: "ExchangeErrorType",
+  ACTION_REQUIRED: "ExchangeActionRequiredType",
 } as const
 
 export const OrderMutationResponseType = new GraphQLUnionType({
   name: "OrderMutationResponse",
-  types: [SuccessType, ErrorType],
+  types: [SuccessType, ErrorType, ActionRequiredType],
   resolveType: (data) => {
-    const result =
-      data._type === ORDER_MUTATION_FLAGS.ERROR ? ErrorType : SuccessType
-    return result
+    switch (data._type) {
+      case ORDER_MUTATION_FLAGS.ACTION_REQUIRED:
+        return ActionRequiredType
+      case ORDER_MUTATION_FLAGS.ERROR:
+        return ErrorType
+      case ORDER_MUTATION_FLAGS.SUCCESS:
+      default:
+        return SuccessType
+    }
   },
 })
 


### PR DESCRIPTION
This PR resolves [EMI-2540]

### Description

> [!warning]
> This PR requires artsy/exchange#2657 to be merged first

This PR exposes an error handling that is introduced in artsy/exchange#2657 to handle Stripe's SCA in the new order endpoints