### PR TITLE
feat(NWFY): serve version C with artist diversity re-reranking to all users

### DIFF
--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,5 +6,4 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
-  "onyx_nwfy-artist-diversity-experiment",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -1,5 +1,4 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { getExperimentVariant } from "lib/featureFlags"
 import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
@@ -21,18 +20,7 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   requiresAuthentication: true,
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const variant = getExperimentVariant(
-      "onyx_nwfy-artist-diversity-experiment",
-      {
-        userId: context.userID,
-      }
-    )
-
-    let recommendationsVersion = "C"
-
-    if (variant && variant.enabled && variant.name === "variant-a") {
-      recommendationsVersion = "A"
-    }
+    const recommendationsVersion = "C"
 
     const finalArgs = {
       // formerly specified client-side

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -1,13 +1,10 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
-import { getExperimentVariant } from "lib/featureFlags"
 import "schema/v2/homeView/experiments/experiments"
 
 jest.mock("lib/featureFlags", () => ({
   getExperimentVariant: jest.fn(),
 }))
-
-const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("NewWorksForYou", () => {
   it("returns the section's metadata", async () => {
@@ -69,111 +66,5 @@ describe("NewWorksForYou", () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("returns the section's connection data", async () => {
     // see artworksForUser.test.ts
-  })
-
-  describe("when the onyx_nwfy-artist-diversity-experiment experiment is enabled", () => {
-    it("serves Version C to the control group", async () => {
-      mockGetExperimentVariant.mockImplementation(() => ({
-        name: "control",
-        enabled: true,
-      }))
-
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-new-works-for-you") {
-              ... on HomeViewSectionArtworks {
-                artworksConnection(first: 20) {
-                  edges {
-                    node {
-                      slug
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      type VortexGraphqlLoaderArgs = { query: string }
-      const mockVortexGraphqlLoader = jest.fn(
-        (_args: VortexGraphqlLoaderArgs) => () =>
-          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
-      )
-
-      const context = {
-        accessToken: "424242",
-        userID: "vortex-user-id",
-        artworksLoader: jest.fn(() => Promise.resolve([])),
-        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
-        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
-        authenticatedLoaders: {
-          vortexGraphqlLoader: mockVortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: jest.fn(),
-        },
-      } as any
-
-      await runQuery(query, context)
-
-      const vortexGraphqlQuery =
-        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
-
-      expect(vortexGraphqlQuery).toMatch('version: "C"')
-    })
-
-    it("serves Version A to the experiment group", async () => {
-      mockGetExperimentVariant.mockImplementation(() => ({
-        name: "variant-a",
-        enabled: true,
-      }))
-
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-new-works-for-you") {
-              ... on HomeViewSectionArtworks {
-                artworksConnection(first: 20) {
-                  edges {
-                    node {
-                      slug
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      type VortexGraphqlLoaderArgs = { query: string }
-      const mockVortexGraphqlLoader = jest.fn(
-        (_args: VortexGraphqlLoaderArgs) => () =>
-          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
-      )
-
-      const context = {
-        accessToken: "424242",
-        userID: "vortex-user-id",
-        artworksLoader: jest.fn(() => Promise.resolve([])),
-        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
-        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
-        authenticatedLoaders: {
-          vortexGraphqlLoader: mockVortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: jest.fn(),
-        },
-      } as any
-
-      await runQuery(query, context)
-
-      const vortexGraphqlQuery =
-        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
-
-      expect(vortexGraphqlQuery).toMatch('version: "A"')
-    })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1844

- The [Artist Diversity re-ranking experiment](https://www.notion.so/Artist-Diversity-Re-Ranking-in-NWFY-225cab0764a08056b47ed08d283cf4ab?pvs=21) that was added in https://github.com/artsy/metaphysics/pull/6892 has passed 🎉
- So this removes the experiment flag and serves Version C ([now updated](https://github.com/artsy/zenith/pull/535) to incorporate the winning variant's logic)
<!-- (The Unleash experiment flag was [already updated](https://artsy.slack.com/archives/C05EQL4R5N0/p1752827064387289?thread_ts=1752775033.524029&cid=C05EQL4R5N0) to serve Version A to 100% of users) -->

TODO

- [x] Merge only after Version C has been rebuilt with updated logic from [zenith/535](https://github.com/artsy/zenith/pull/535)
- [ ] Remove the Unleash flag ( ⚠️ only after this PR is merged)

