### PR TITLE
fix: correcting signature property name for bulk-update

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4639,6 +4639,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # Publish or unpublish artworks
   published: Boolean
+
+  # Details about the signature
+  signature: String
 }
 
 type BulkUpdateArtworksMetadataMutationFailure {

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -21,7 +21,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
             priceListed: 1000
             provenance: "Owned by a famous collector"
             published: true
-            signatureDetails: "Signed by the artist in the bottom right corner"
+            signature: "Signed by the artist in the bottom right corner"
           }
           filters: {
             artworkIds: ["artwork1", "artwork2"]

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -95,7 +95,7 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLBoolean,
       description: "Publish or unpublish artworks",
     },
-    signatureDetails: {
+    signature: {
       type: GraphQLString,
       description: "Details about the signature",
     },
@@ -222,7 +222,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         price_listed: metadata.priceListed,
         published: metadata.published,
         offer: metadata.offer,
-        signature: metadata.signatureDetails,
+        signature: metadata.signature,
         ecommerce: metadata.ecommerce,
       }
     }


### PR DESCRIPTION
This fix addresses a signature property misspelling in the previous change [AMBER-1813](https://artsyproduct.atlassian.net/browse/AMBER-1801)

[AMBER-1813]: https://artsyproduct.atlassian.net/browse/AMBER-1813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ