### PR TITLE
chore: add mutations to allow updating currency/dimension metric for an import, plus summary

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3206,6 +3206,7 @@ type ArtworkImport implements Node {
     last: Int
   ): ArtworkImportRowConnection
   state: ArtworkImportState
+  summary: ArtworkImportSummary
   unmatchedArtistNames: [String!]!
 }
 
@@ -3334,6 +3335,11 @@ enum ArtworkImportState {
   ARTWORKS_CREATION_COMPLETE
   CANCELED
   PENDING
+}
+
+type ArtworkImportSummary {
+  currencies: [String!]!
+  dimensionMetrics: [String!]!
 }
 
 type ArtworkImportTransformedData {
@@ -16132,6 +16138,12 @@ type Mutation {
   updateArtwork(
     input: UpdateArtworkMutationInput!
   ): UpdateArtworkMutationPayload
+  updateArtworkImportCurrency(
+    input: UpdateArtworkImportCurrencyInput!
+  ): UpdateArtworkImportCurrencyPayload
+  updateArtworkImportDimensionMetric(
+    input: UpdateArtworkImportDimensionMetricInput!
+  ): UpdateArtworkImportDimensionMetricPayload
   updateArtworkImportRow(
     input: UpdateArtworkImportRowInput!
   ): UpdateArtworkImportRowPayload
@@ -22742,6 +22754,54 @@ input UpdateArtworkEditionSetInput {
   published: Boolean
   shippingWeight: Float
   shippingWeightMetric: String
+}
+
+type UpdateArtworkImportCurrencyFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtworkImportCurrencyInput {
+  artworkImportID: String!
+  clientMutationId: String
+  fromCurrency: String!
+  toCurrency: String!
+}
+
+type UpdateArtworkImportCurrencyPayload {
+  clientMutationId: String
+  updateArtworkImportCurrencyOrError: UpdateArtworkImportCurrencyResponseOrError
+}
+
+union UpdateArtworkImportCurrencyResponseOrError =
+    UpdateArtworkImportCurrencyFailure
+  | UpdateArtworkImportCurrencySuccess
+
+type UpdateArtworkImportCurrencySuccess {
+  artworkImport: ArtworkImport
+}
+
+type UpdateArtworkImportDimensionMetricFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtworkImportDimensionMetricInput {
+  artworkImportID: String!
+  clientMutationId: String
+  fromDimensionMetric: String!
+  toDimensionMetric: String!
+}
+
+type UpdateArtworkImportDimensionMetricPayload {
+  clientMutationId: String
+  updateArtworkImportDimensionMetricOrError: UpdateArtworkImportDimensionMetricResponseOrError
+}
+
+union UpdateArtworkImportDimensionMetricResponseOrError =
+    UpdateArtworkImportDimensionMetricFailure
+  | UpdateArtworkImportDimensionMetricSuccess
+
+type UpdateArtworkImportDimensionMetricSuccess {
+  artworkImport: ArtworkImport
 }
 
 type UpdateArtworkImportRowFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -127,8 +127,21 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    artworkImportSummaryLoader: gravityLoader(
+      (id) => `artwork_import/${id}/summary`
+    ),
     artworkImportUnmatchedArtistNamesLoader: gravityLoader(
       (id) => `artwork_import/${id}/unmatched_artist_names`
+    ),
+    artworkImportUpdateCurrencyLoader: gravityLoader(
+      (id) => `artwork_import/${id}/update_currency`,
+      {},
+      { method: "PUT" }
+    ),
+    artworkImportUpdateDimensionMetricLoader: gravityLoader(
+      (id) => `artwork_import/${id}/update_dimension_metric`,
+      {},
+      { method: "PUT" }
     ),
     artworkImportUpdateRowLoader: gravityLoader(
       (id) => `artwork_import/${id}/update_row`,

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportCurrencyMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportCurrencyMutation.test.ts
@@ -1,0 +1,77 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateArtworkImportCurrencyMutation", () => {
+  const artworkImportID = "artwork-import-id"
+  const fromCurrency = "USD"
+  const toCurrency = "EUR"
+
+  const mutation = gql`
+    mutation {
+      updateArtworkImportCurrency(
+        input: {
+          artworkImportID: "artwork-import-id"
+          fromCurrency: "USD"
+          toCurrency: "EUR"
+        }
+      ) {
+        updateArtworkImportCurrencyOrError {
+          ... on UpdateArtworkImportCurrencySuccess {
+            artworkImport {
+              internalID
+            }
+          }
+          ... on UpdateArtworkImportCurrencyFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates artwork import currency", async () => {
+    const mockArtworkImport = {
+      id: artworkImportID,
+    }
+
+    const mockLoader = jest.fn().mockResolvedValue(mockArtworkImport)
+
+    const context = {
+      artworkImportUpdateCurrencyLoader: mockLoader,
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockLoader).toHaveBeenCalledWith(artworkImportID, {
+      from_currency: fromCurrency,
+      to_currency: toCurrency,
+    })
+
+    expect(result).toEqual({
+      updateArtworkImportCurrency: {
+        updateArtworkImportCurrencyOrError: {
+          artworkImport: {
+            internalID: artworkImportID,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns an error when loader throws", async () => {
+    const mockLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Currency update failed"))
+
+    const context = {
+      artworkImportUpdateCurrencyLoader: mockLoader,
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Currency update failed"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportDimensionMetricMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportDimensionMetricMutation.test.ts
@@ -1,0 +1,77 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateArtworkImportDimensionMetricMutation", () => {
+  const artworkImportID = "artwork-import-id"
+  const fromDimensionMetric = "in"
+  const toDimensionMetric = "cm"
+
+  const mutation = gql`
+    mutation {
+      updateArtworkImportDimensionMetric(
+        input: {
+          artworkImportID: "artwork-import-id"
+          fromDimensionMetric: "in"
+          toDimensionMetric: "cm"
+        }
+      ) {
+        updateArtworkImportDimensionMetricOrError {
+          ... on UpdateArtworkImportDimensionMetricSuccess {
+            artworkImport {
+              internalID
+            }
+          }
+          ... on UpdateArtworkImportDimensionMetricFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates artwork import dimension metric", async () => {
+    const mockArtworkImport = {
+      id: artworkImportID,
+    }
+
+    const mockLoader = jest.fn().mockResolvedValue(mockArtworkImport)
+
+    const context = {
+      artworkImportUpdateDimensionMetricLoader: mockLoader,
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockLoader).toHaveBeenCalledWith(artworkImportID, {
+      from_dimension_metric: fromDimensionMetric,
+      to_dimension_metric: toDimensionMetric,
+    })
+
+    expect(result).toEqual({
+      updateArtworkImportDimensionMetric: {
+        updateArtworkImportDimensionMetricOrError: {
+          artworkImport: {
+            internalID: artworkImportID,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns an error when loader throws", async () => {
+    const mockLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Dimension metric update failed"))
+
+    const context = {
+      artworkImportUpdateDimensionMetricLoader: mockLoader,
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Dimension metric update failed"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -71,6 +71,20 @@ const ArtworkImportCreatedBy = new GraphQLObjectType({
   },
 })
 
+const ArtworkImportSummaryType = new GraphQLObjectType({
+  name: "ArtworkImportSummary",
+  fields: {
+    currencies: {
+      type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
+      resolve: ({ currencies_found }) => currencies_found,
+    },
+    dimensionMetrics: {
+      type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),
+      resolve: ({ dimension_metrics_found }) => dimension_metrics_found,
+    },
+  },
+})
+
 const ArtworkImportRowErrorType = new GraphQLObjectType({
   name: "ArtworkImportRowError",
   fields: {
@@ -293,6 +307,14 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
     },
     state: {
       type: ArtworkImportStateType,
+    },
+    summary: {
+      type: ArtworkImportSummaryType,
+      resolve: async ({ id }, _args, { artworkImportSummaryLoader }) => {
+        if (!artworkImportSummaryLoader) return null
+
+        return await artworkImportSummaryLoader(id)
+      },
     },
     unmatchedArtistNames: {
       type: new GraphQLNonNull(GraphQLList(new GraphQLNonNull(GraphQLString))),

--- a/src/schema/v2/ArtworkImport/updateArtworkImportCurrencyMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportCurrencyMutation.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportCurrencySuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportCurrencyFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtworkImportCurrencyResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateArtworkImportCurrencyMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "UpdateArtworkImportCurrency",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    fromCurrency: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    toCurrency: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    updateArtworkImportCurrencyOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, fromCurrency, toCurrency },
+    { artworkImportUpdateCurrencyLoader }
+  ) => {
+    if (!artworkImportUpdateCurrencyLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      return await artworkImportUpdateCurrencyLoader(artworkImportID, {
+        from_currency: fromCurrency,
+        to_currency: toCurrency,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/ArtworkImport/updateArtworkImportDimensionMetricMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportDimensionMetricMutation.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportDimensionMetricSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportDimensionMetricFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtworkImportDimensionMetricResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateArtworkImportDimensionMetricMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "UpdateArtworkImportDimensionMetric",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    fromDimensionMetric: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    toDimensionMetric: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  outputFields: {
+    updateArtworkImportDimensionMetricOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, fromDimensionMetric, toDimensionMetric },
+    { artworkImportUpdateDimensionMetricLoader }
+  ) => {
+    if (!artworkImportUpdateDimensionMetricLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      return await artworkImportUpdateDimensionMetricLoader(artworkImportID, {
+        from_dimension_metric: fromDimensionMetric,
+        to_dimension_metric: toDimensionMetric,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -303,6 +303,8 @@ import { MatchArtworkImportArtistsMutation } from "./ArtworkImport/matchArtworkI
 import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtworkImportArtworksMutation"
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
+import { UpdateArtworkImportCurrencyMutation } from "./ArtworkImport/updateArtworkImportCurrencyMutation"
+import { UpdateArtworkImportDimensionMetricMutation } from "./ArtworkImport/updateArtworkImportDimensionMetricMutation"
 import { FlagArtworkImportCellMutation } from "./ArtworkImport/flagArtworkImportCellMutation"
 import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
@@ -623,6 +625,8 @@ export default new GraphQLSchema({
       updateArtist: updateArtistMutation,
       updateArtwork: updateArtworkMutation,
       updateArtworkImportRow: UpdateArtworkImportRowMutation,
+      updateArtworkImportCurrency: UpdateArtworkImportCurrencyMutation,
+      updateArtworkImportDimensionMetric: UpdateArtworkImportDimensionMetricMutation,
       updateCareerHighlight: updateCareerHighlightMutation,
       flagArtworkImportCell: FlagArtworkImportCellMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,


### PR DESCRIPTION
Based on https://github.com/artsy/gravity/pull/19154 - adds the required schema.

We now have a `summary` field, as well as the vanilla mutations.

Updating the currency/dimension metric of a row (inline editing) will already work by using the existing `updateArtworkImportRow` mutation with the right `fieldName`.