### PR TITLE
feat(EMI-2506): add Order.availablePaymentMethods field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16757,6 +16757,9 @@ union OpeningHoursUnion = OpeningHoursArray | OpeningHoursText
 
 # Buyer's representation of an order
 type Order {
+  # List of available payment methods for the order
+  availablePaymentMethods: [OrderPaymentMethodEnum!]!
+
   # List of alpha-2 country codes to which the order can be shipped
   availableShippingCountries: [String!]!
 

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -12,6 +12,7 @@ describe("Me", () => {
   beforeEach(() => {
     orderJson = {
       ...baseOrderJson,
+      available_payment_methods: ["credit card", "wire_transfer"],
       id: "order-id",
       source: "artwork_page",
       code: "order-code",
@@ -63,6 +64,7 @@ describe("Me", () => {
         query {
           me {
             order(id: "order-id") {
+              availablePaymentMethods
               availableShippingCountries
               buyerTotal {
                 display
@@ -158,6 +160,7 @@ describe("Me", () => {
       const result = await runAuthenticatedQuery(query, context)
 
       expect(result.me.order).toEqual({
+        availablePaymentMethods: ["CREDIT_CARD", "WIRE_TRANSFER"],
         availableShippingCountries: ["US", "JP"],
         buyerTotal: {
           display: "US$5,000",

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -15,7 +15,15 @@ export interface FulfillmentOptionJson {
   selected?: boolean
   shipping_quote_id?: string
 }
+
+type OrderPaymentMethodEnum =
+  | "credit card"
+  | "wire_transfer"
+  | "us_bank_account"
+  | "sepa_debit"
+
 export interface OrderJSON {
+  available_payment_methods: OrderPaymentMethodEnum[]
   available_shipping_countries: string[]
   awaiting_response_from: "buyer" | "seller" | null
   bank_account_id?: string
@@ -56,11 +64,7 @@ export interface OrderJSON {
     tax_cents?: number
   }>
   mode: "buy" | "offer"
-  payment_method?:
-    | "credit card"
-    | "wire_transfer"
-    | "us_bank_account"
-    | "sepa_debit"
+  payment_method?: OrderPaymentMethodEnum
   selected_fulfillment_option?: FulfillmentOptionJson
   seller_id: string
   seller_type: string

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -315,6 +315,13 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
   description: "Buyer's representation of an order",
   fields: {
     ...InternalIDFields,
+    availablePaymentMethods: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(OrderPaymentMethodEnum))
+      ),
+      description: "List of available payment methods for the order",
+      resolve: ({ available_payment_methods }) => available_payment_methods,
+    },
     availableShippingCountries: {
       description:
         "List of alpha-2 country codes to which the order can be shipped",


### PR DESCRIPTION
Depends on https://github.com/artsy/exchange/pull/2661
Completes [EMI-2506]

This order uses the existing OrderPaymentMethod enum and the new field returned from exchange's order json in artsy/exchange#2661 to add an `Order.availablePaymentMethods` field.

[EMI-2506]: https://artsyproduct.atlassian.net/browse/EMI-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ