### PR TITLE
feat(NWFY): create at-risk gallery boost experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -15,7 +15,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-quick-links-v2",
   "onyx_enable-home-view-auction-segmentation",
   "onyx_enable-quick-links-price-budget",
-  "onyx_nwfy-artist-diversity-experiment",
+  "onyx_nwfy-at-risk-gallery-boost-experiment",
   "onyx_based_on_your_saves_home_view_section",
 ] as const
 

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,4 +6,5 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
+  "onyx_nwfy-at-risk-gallery-boost-experiment",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -1,4 +1,5 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { getExperimentVariant } from "lib/featureFlags"
 import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
@@ -20,7 +21,18 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   requiresAuthentication: true,
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const recommendationsVersion = "C"
+    const variant = getExperimentVariant(
+      "onyx_nwfy-at-risk-gallery-boost-experiment",
+      {
+        userId: context.userID,
+      }
+    )
+
+    let recommendationsVersion = "C"
+
+    if (variant && variant.enabled && variant.name === "variant-a") {
+      recommendationsVersion = "A"
+    }
 
     const finalArgs = {
       // formerly specified client-side

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -1,10 +1,13 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { getExperimentVariant } from "lib/featureFlags"
 import "schema/v2/homeView/experiments/experiments"
 
 jest.mock("lib/featureFlags", () => ({
   getExperimentVariant: jest.fn(),
 }))
+
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("NewWorksForYou", () => {
   it("returns the section's metadata", async () => {
@@ -66,5 +69,111 @@ describe("NewWorksForYou", () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("returns the section's connection data", async () => {
     // see artworksForUser.test.ts
+  })
+
+  describe("when the onyx_nwfy-at-risk-gallery-boost-experiment experiment is enabled", () => {
+    it("serves Version C to the control group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "control",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "C"')
+    })
+
+    it("serves Version A to the experiment group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "variant-a",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "A"')
+    })
   })
 })


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ONYX-1854

Following established patterns (e.g. the just-concluded [artist diversity experiment](https://github.com/artsy/metaphysics/pull/6892)) we open a new experiment here for the [at-risk gallery boost](https://www.notion.so/artsy/At-Risk-Galleries-Boost-AB-Test-234cab0764a080a9b554dc3e960742b9?v=7bb661aa9b914cfdb5ff867c027ce6f9).

This is based on the Unleash flag [onyx_nwfy-at-risk-gallery-boost-experiment](https://unleash.artsy.net/projects/default/features/onyx_nwfy-at-risk-gallery-boost-experiment), which is already enabled in staging.