### PR TITLE
feat: Adds support for batch edit artistIds array field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4613,6 +4613,9 @@ input BulkArtworkFilterInput {
 }
 
 input BulkUpdateArtworksMetadataInput {
+  # The artist IDs to be assigned
+  artistIds: [String]
+
   # The availaiblity to be assigned
   availability: Availability
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -10,6 +10,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           id: "partner123"
           source: ARTWORKS_LIST
           metadata: {
+            artistIds: ["artist1", "artist2"]
             availability: SOLD
             domesticShippingFeeCents: 20000
             locationId: "location456"
@@ -72,6 +73,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
       "partner123",
       {
         metadata: {
+          artist_ids: ["artist1", "artist2"],
           availability: "sold",
           domestic_shipping_fee_cents: 20000,
           location_id: "location456",

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -23,6 +23,7 @@ interface Input {
   id: string
   source: string
   metadata?: {
+    artistIds?: string[]
     availability?: string
     domesticShippingFeeCents?: number
     ecommerce: boolean
@@ -49,6 +50,10 @@ interface Input {
 const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
   name: "BulkUpdateArtworksMetadataInput",
   fields: {
+    artistIds: {
+      type: GraphQLList(GraphQLString),
+      description: "The artist IDs to be assigned",
+    },
     availability: {
       type: Availability,
       description: "The availaiblity to be assigned",
@@ -212,6 +217,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
 
     if (metadata) {
       gravityOptions.metadata = {
+        artist_ids: metadata.artistIds,
         availability: metadata.availability,
         domestic_shipping_fee_cents: metadata.domesticShippingFeeCents,
         location_id: metadata.locationId,


### PR DESCRIPTION
Adds support to batch edit project to assign artist ids to a batch of artworks

`BulkUpdateArtworksMetadataMutation` will accept a new `artistIds` optional argument



Associated backend changes: https://github.com/artsy/gravity/pull/19162


```
 bulkUpdateArtworksMetadata(
        input: {
          id: "partner123"
          source: ARTWORKS_LIST
          metadata: {
            artistIds: ["artist1", "artist2"]
            availability: SOLD
            domesticShippingFeeCents: 20000
            locationId: "location456"
            category: "Painting"
            ecommerce: true
            medium: "Oil on Canvas"
            offer: false
            priceAdjustment: -5
            priceListed: 1000
            provenance: "Owned by a famous collector"
            published: true
            signature: "Signed by the artist in the bottom right corner"
          }
          filters: {
            artworkIds: ["artwork1", "artwork2"]
            availability: FOR_SALE
            locationId: "oldLocation"
            partnerArtistId: "artist789"
            published: true
          }
        }
```

cc @artsy/amber-devs 