### PR TITLE
chore: ignore .claude/settings.local.json folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache
+.claude/settings.local.json
 .env
 .env.staging
 .env.shared


### PR DESCRIPTION
Little security cleanup. User local settings shouldn't be checked into git.