### PR TITLE
chore: add mutation to deselect an artwork import row from import

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3269,6 +3269,7 @@ type ArtworkImportRow {
   currency: String!
   dimensionMetric: String!
   errors: [ArtworkImportRowError!]!
+  excludedFromImport: Boolean!
 
   # A globally unique ID.
   id: ID!
@@ -16103,6 +16104,9 @@ type Mutation {
 
   # Submit an order
   submitOrder(input: submitOrderInput!): submitOrderPayload
+  toggleArtworkImportRowExclusion(
+    input: ToggleArtworkImportRowExclusionInput!
+  ): ToggleArtworkImportRowExclusionPayload
   transferMyCollection(
     # Parameters for TransferMyCollection
     input: TransferMyCollectionInput!
@@ -22576,6 +22580,30 @@ type TaxLine {
 type TaxMoreInfo {
   displayText: String!
   url: String!
+}
+
+type ToggleArtworkImportRowExclusionFailure {
+  mutationError: GravityMutationError
+}
+
+input ToggleArtworkImportRowExclusionInput {
+  artworkImportID: String!
+  artworkImportRowID: String!
+  clientMutationId: String
+  excludedFromImport: Boolean!
+}
+
+type ToggleArtworkImportRowExclusionPayload {
+  clientMutationId: String
+  toggleArtworkImportRowExclusionOrError: ToggleArtworkImportRowExclusionResponseOrError
+}
+
+union ToggleArtworkImportRowExclusionResponseOrError =
+    ToggleArtworkImportRowExclusionFailure
+  | ToggleArtworkImportRowExclusionSuccess
+
+type ToggleArtworkImportRowExclusionSuccess {
+  artworkImport: ArtworkImport
 }
 
 # Total line

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -130,6 +130,11 @@ export default (accessToken, userID, opts) => {
     artworkImportSummaryLoader: gravityLoader(
       (id) => `artwork_import/${id}/summary`
     ),
+    artworkImportToggleRowExclusionLoader: gravityLoader(
+      (id) => `artwork_import/${id}/toggle_row_exclusion`,
+      {},
+      { method: "PUT" }
+    ),
     artworkImportUnmatchedArtistNamesLoader: gravityLoader(
       (id) => `artwork_import/${id}/unmatched_artist_names`
     ),

--- a/src/schema/v2/ArtworkImport/__tests__/toggleArtworkImportRowExclusionMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/toggleArtworkImportRowExclusionMutation.test.ts
@@ -1,0 +1,77 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("ToggleArtworkImportRowExclusionMutation", () => {
+  const artworkImportID = "artwork-import-id"
+  const artworkImportRowID = "artwork-import-row-id"
+  const excludedFromImport = true
+
+  const mutation = gql`
+    mutation {
+      toggleArtworkImportRowExclusion(
+        input: {
+          artworkImportID: "artwork-import-id"
+          artworkImportRowID: "artwork-import-row-id"
+          excludedFromImport: true
+        }
+      ) {
+        toggleArtworkImportRowExclusionOrError {
+          ... on ToggleArtworkImportRowExclusionSuccess {
+            artworkImport {
+              internalID
+            }
+          }
+          ... on ToggleArtworkImportRowExclusionFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("toggles artwork import row exclusion", async () => {
+    const mockArtworkImport = {
+      id: artworkImportID,
+    }
+
+    const mockLoader = jest.fn().mockResolvedValue(mockArtworkImport)
+
+    const context = {
+      artworkImportToggleRowExclusionLoader: mockLoader,
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(mockLoader).toHaveBeenCalledWith(artworkImportID, {
+      row_id: artworkImportRowID,
+      excluded_from_import: excludedFromImport,
+    })
+
+    expect(result).toEqual({
+      toggleArtworkImportRowExclusion: {
+        toggleArtworkImportRowExclusionOrError: {
+          artworkImport: {
+            internalID: artworkImportID,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns an error when loader throws", async () => {
+    const mockLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Toggle row exclusion failed"))
+
+    const context = {
+      artworkImportToggleRowExclusionLoader: mockLoader,
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Toggle row exclusion failed"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -272,6 +272,10 @@ const ArtworkImportRowType = new GraphQLObjectType({
       ),
       resolve: ({ artwork_import_row_images }) => artwork_import_row_images,
     },
+    excludedFromImport: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ excluded_from_import }) => excluded_from_import,
+    },
   },
 })
 

--- a/src/schema/v2/ArtworkImport/toggleArtworkImportRowExclusionMutation.ts
+++ b/src/schema/v2/ArtworkImport/toggleArtworkImportRowExclusionMutation.ts
@@ -1,0 +1,88 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ToggleArtworkImportRowExclusionSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ToggleArtworkImportRowExclusionFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "ToggleArtworkImportRowExclusionResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const ToggleArtworkImportRowExclusionMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "ToggleArtworkImportRowExclusion",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artworkImportRowID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    excludedFromImport: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+    },
+  },
+  outputFields: {
+    toggleArtworkImportRowExclusionOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, artworkImportRowID, excludedFromImport },
+    { artworkImportToggleRowExclusionLoader }
+  ) => {
+    if (!artworkImportToggleRowExclusionLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      return await artworkImportToggleRowExclusionLoader(artworkImportID, {
+        row_id: artworkImportRowID,
+        excluded_from_import: excludedFromImport,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -306,6 +306,7 @@ import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtwork
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
 import { UpdateArtworkImportCurrencyMutation } from "./ArtworkImport/updateArtworkImportCurrencyMutation"
 import { UpdateArtworkImportDimensionMetricMutation } from "./ArtworkImport/updateArtworkImportDimensionMetricMutation"
+import { ToggleArtworkImportRowExclusionMutation } from "./ArtworkImport/toggleArtworkImportRowExclusionMutation"
 import { FlagArtworkImportCellMutation } from "./ArtworkImport/flagArtworkImportCellMutation"
 import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
@@ -629,6 +630,7 @@ export default new GraphQLSchema({
       updateArtworkImportRow: UpdateArtworkImportRowMutation,
       updateArtworkImportCurrency: UpdateArtworkImportCurrencyMutation,
       updateArtworkImportDimensionMetric: UpdateArtworkImportDimensionMetricMutation,
+      toggleArtworkImportRowExclusion: ToggleArtworkImportRowExclusionMutation,
       updateCareerHighlight: updateCareerHighlightMutation,
       flagArtworkImportCell: FlagArtworkImportCellMutation,
       updateCMSLastAccessTimestamp: updateCMSLastAccessTimestampMutation,


### PR DESCRIPTION
Mutation to use https://github.com/artsy/gravity/pull/19171 to deselect an artwork import row from import.

I'll also need to raise another small Gravity PR to make sure those deselected rows are not returned to `rowsConnection`.