### PR TITLE
feat(EMI-2674): update confimationToken query to support multiple types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18411,10 +18411,7 @@ enum PartnersSortType {
   SORTABLE_ID_DESC
 }
 
-type PaymentMethodPreview {
-  # Details of the card used in the payment method.
-  card: Card
-}
+union PaymentMethodPreview = Card | SEPADebit | USBankAccount
 
 union PaymentMethodUnion = BankAccount | CreditCard | WireTransfer
 
@@ -20763,6 +20760,11 @@ type S3PolicyDocumentType {
   expiration: String!
 }
 
+type SEPADebit {
+  # The last 4 digits of the bank account.
+  last4: String!
+}
+
 type Sale implements Node {
   # Returns a connection of artworks for a sale.
   artworksConnection(
@@ -22687,6 +22689,14 @@ union TriggerCampaignMutationSuccessOrError =
 type TriggerCampaignPayload {
   clientMutationId: String
   successOrError: TriggerCampaignMutationSuccessOrError
+}
+
+type USBankAccount {
+  # The name of the bank.
+  bankName: String!
+
+  # The last 4 digits of the bank account.
+  last4: String!
 }
 
 union UnderlyingCurrentEvent = Sale | Show


### PR DESCRIPTION
Followup on https://github.com/artsy/metaphysics/pull/6619 to support more payment method preview types so we can also display ACH and SEPA info in Force.

<img width="3248" height="2112" alt="Screenshot 2025-07-31 at 15 13 53" src="https://github.com/user-attachments/assets/a262c964-56ec-4944-b257-99c247f13537" />



<img width="3248" height="2112" alt="Screenshot 2025-07-31 at 15 09 56" src="https://github.com/user-attachments/assets/9b0c561c-c0aa-45fe-bcd1-474decca5ac5" />


@artsy/emerald-devs 