### PR TITLE
feat(EMI-2674): add a type field to the confirmationToken query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4791,6 +4791,9 @@ type Card {
 
   # The last 4 digits of the card.
   last4: String!
+
+  # The type of payment method.
+  type: String!
 }
 
 type CareerHighlight implements Node {
@@ -20781,6 +20784,9 @@ type S3PolicyDocumentType {
 type SEPADebit {
   # The last 4 digits of the bank account.
   last4: String!
+
+  # The type of payment method.
+  type: String!
 }
 
 type Sale implements Node {
@@ -22715,6 +22721,9 @@ type USBankAccount {
 
   # The last 4 digits of the bank account.
   last4: String!
+
+  # The type of payment method.
+  type: String!
 }
 
 union UnderlyingCurrentEvent = Sale | Show

--- a/src/schema/v2/order/__tests__/confirmationToken.test.ts
+++ b/src/schema/v2/order/__tests__/confirmationToken.test.ts
@@ -18,6 +18,7 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
+                type
                 displayBrand
                 last4
               }
@@ -45,6 +46,7 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
+            type: "card",
             displayBrand: "Visa",
             last4: "4242",
           },
@@ -60,6 +62,7 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
+                type
                 displayBrand
                 last4
               }
@@ -83,6 +86,7 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
+                type
                 displayBrand
                 last4
               }
@@ -108,6 +112,7 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on USBankAccount {
+                type
                 bankName
                 last4
               }
@@ -135,6 +140,7 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
+            type: "us_bank_account",
             bankName: "Chase Bank",
             last4: "6789",
           },
@@ -150,6 +156,7 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on SEPADebit {
+                type
                 last4
               }
             }
@@ -175,6 +182,7 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
+            type: "sepa_debit",
             last4: "1234",
           },
         },

--- a/src/schema/v2/order/confirmationToken.ts
+++ b/src/schema/v2/order/confirmationToken.ts
@@ -10,6 +10,11 @@ import { ResolverContext } from "types/graphql"
 const CardType = new GraphQLObjectType<any, ResolverContext>({
   name: "Card",
   fields: {
+    type: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The type of payment method.",
+      resolve: () => "card",
+    },
     displayBrand: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The display brand of the card (e.g., Visa, Mastercard).",
@@ -26,6 +31,11 @@ const CardType = new GraphQLObjectType<any, ResolverContext>({
 const UsBankAccountType = new GraphQLObjectType<any, ResolverContext>({
   name: "USBankAccount",
   fields: {
+    type: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The type of payment method.",
+      resolve: () => "us_bank_account",
+    },
     bankName: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The name of the bank.",
@@ -42,6 +52,11 @@ const UsBankAccountType = new GraphQLObjectType<any, ResolverContext>({
 const SepaType = new GraphQLObjectType<any, ResolverContext>({
   name: "SEPADebit",
   fields: {
+    type: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The type of payment method.",
+      resolve: () => "sepa_debit",
+    },
     last4: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The last 4 digits of the bank account.",


### PR DESCRIPTION
Followup from https://github.com/artsy/metaphysics/pull/6961 to add a `type` field so we can infer the payment method in Force.

@artsy/emerald-devs 