### PR TITLE
revert: "feat(EMI-2674): add a type field to the confirmationToken query"

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4791,9 +4791,6 @@ type Card {
 
   # The last 4 digits of the card.
   last4: String!
-
-  # The type of payment method.
-  type: String!
 }
 
 type CareerHighlight implements Node {
@@ -20784,9 +20781,6 @@ type S3PolicyDocumentType {
 type SEPADebit {
   # The last 4 digits of the bank account.
   last4: String!
-
-  # The type of payment method.
-  type: String!
 }
 
 type Sale implements Node {
@@ -22721,9 +22715,6 @@ type USBankAccount {
 
   # The last 4 digits of the bank account.
   last4: String!
-
-  # The type of payment method.
-  type: String!
 }
 
 union UnderlyingCurrentEvent = Sale | Show

--- a/src/schema/v2/order/__tests__/confirmationToken.test.ts
+++ b/src/schema/v2/order/__tests__/confirmationToken.test.ts
@@ -18,7 +18,6 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
-                type
                 displayBrand
                 last4
               }
@@ -46,7 +45,6 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
-            type: "card",
             displayBrand: "Visa",
             last4: "4242",
           },
@@ -62,7 +60,6 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
-                type
                 displayBrand
                 last4
               }
@@ -86,7 +83,6 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on Card {
-                type
                 displayBrand
                 last4
               }
@@ -112,7 +108,6 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on USBankAccount {
-                type
                 bankName
                 last4
               }
@@ -140,7 +135,6 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
-            type: "us_bank_account",
             bankName: "Chase Bank",
             last4: "6789",
           },
@@ -156,7 +150,6 @@ describe("ConfirmationToken", () => {
           confirmationToken(id: "tok_123456789") {
             paymentMethodPreview {
               ... on SEPADebit {
-                type
                 last4
               }
             }
@@ -182,7 +175,6 @@ describe("ConfirmationToken", () => {
       me: {
         confirmationToken: {
           paymentMethodPreview: {
-            type: "sepa_debit",
             last4: "1234",
           },
         },

--- a/src/schema/v2/order/confirmationToken.ts
+++ b/src/schema/v2/order/confirmationToken.ts
@@ -10,11 +10,6 @@ import { ResolverContext } from "types/graphql"
 const CardType = new GraphQLObjectType<any, ResolverContext>({
   name: "Card",
   fields: {
-    type: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The type of payment method.",
-      resolve: () => "card",
-    },
     displayBrand: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The display brand of the card (e.g., Visa, Mastercard).",
@@ -31,11 +26,6 @@ const CardType = new GraphQLObjectType<any, ResolverContext>({
 const UsBankAccountType = new GraphQLObjectType<any, ResolverContext>({
   name: "USBankAccount",
   fields: {
-    type: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The type of payment method.",
-      resolve: () => "us_bank_account",
-    },
     bankName: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The name of the bank.",
@@ -52,11 +42,6 @@ const UsBankAccountType = new GraphQLObjectType<any, ResolverContext>({
 const SepaType = new GraphQLObjectType<any, ResolverContext>({
   name: "SEPADebit",
   fields: {
-    type: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The type of payment method.",
-      resolve: () => "sepa_debit",
-    },
     last4: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The last 4 digits of the bank account.",


### PR DESCRIPTION
I realized we don't need this, we can just use `__typename`.

Reverts artsy/metaphysics#6962