### PR TITLE
feat: add isLiveOpenHappened attribute to sale to know that live sale is past it's live bidding open time

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20897,6 +20897,9 @@ type Sale implements Node {
   isClosed: Boolean
   isGalleryAuction: Boolean
   isLiveOpen: Boolean
+
+  # True for live auctions once live part is happening or in the past
+  isLiveOpenHappened: Boolean
   isLotConditionsReportEnabled: Boolean
 
   # True for a cascading-end-time enabled sale where lots have started closing

--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -64,6 +64,7 @@ describe("Sale type", () => {
           isPreview
           isOpen
           isLiveOpen
+          isLiveOpenHappened
           isClosed
           isPreliminary
           isRegistrationClosed
@@ -76,6 +77,7 @@ describe("Sale type", () => {
 
     it("returns the correct values when the sale is closed", async () => {
       sale.auction_state = "closed"
+      sale.live_start_at = null
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
@@ -84,6 +86,7 @@ describe("Sale type", () => {
           isPreview: false,
           isOpen: false,
           isLiveOpen: false,
+          isLiveOpenHappened: false,
           isClosed: true,
           isPreliminary: false,
           isRegistrationClosed: false,
@@ -96,6 +99,7 @@ describe("Sale type", () => {
 
     it("returns the correct values when the sale is in preview mode", async () => {
       sale.auction_state = "preview"
+      sale.live_start_at = null
       expect(await execute(query)).toEqual({
         sale: {
           internalID: "123",
@@ -104,6 +108,7 @@ describe("Sale type", () => {
           isPreview: true,
           isOpen: false,
           isLiveOpen: false,
+          isLiveOpenHappened: false,
           isClosed: false,
           isPreliminary: false,
           isRegistrationClosed: false,
@@ -125,6 +130,7 @@ describe("Sale type", () => {
           isPreview: false,
           isOpen: true,
           isLiveOpen: false,
+          isLiveOpenHappened: false,
           isClosed: false,
           isPreliminary: false,
           isRegistrationClosed: false,
@@ -146,6 +152,7 @@ describe("Sale type", () => {
           isPreview: false,
           isOpen: true,
           isLiveOpen: true,
+          isLiveOpenHappened: true,
           isClosed: false,
           isPreliminary: false,
           isRegistrationClosed: false,
@@ -167,12 +174,35 @@ describe("Sale type", () => {
           isPreview: false,
           isOpen: true,
           isLiveOpen: true,
+          isLiveOpenHappened: true,
           isClosed: false,
           isPreliminary: false,
           isRegistrationClosed: true,
           isLotConditionsReportEnabled: true,
           requireIdentityVerification: true,
           status: "open",
+        },
+      })
+    })
+
+    it("returns the correct values when live bidding sale is closed", async () => {
+      sale.auction_state = "closed"
+      sale.registration_ends_at = moment().subtract(2, "days")
+      expect(await execute(query)).toEqual({
+        sale: {
+          internalID: "123",
+          collectPayments: true,
+          isArtsyLicensed: false,
+          isPreview: false,
+          isOpen: false,
+          isLiveOpen: false,
+          isLiveOpenHappened: true,
+          isClosed: true,
+          isPreliminary: false,
+          isRegistrationClosed: true,
+          isLotConditionsReportEnabled: true,
+          requireIdentityVerification: true,
+          status: "closed",
         },
       })
     })

--- a/src/schema/v2/sale/display.ts
+++ b/src/schema/v2/sale/display.ts
@@ -22,10 +22,13 @@ defineCustomLocale(LocaleEnAuctionRelative, {
 })
 
 export const isLiveOpen = (sale) => {
+  return sale.auction_state === "open" && isLiveOpenHappened(sale)
+}
+
+export const isLiveOpenHappened = (sale) => {
   const liveStart = moment(sale.live_start_at)
   return (
-    sale.auction_state === "open" &&
-    (moment().isAfter(liveStart) || moment().isSame(liveStart))
+    !!liveStart && (moment().isAfter(liveStart) || moment().isSame(liveStart))
   )
 }
 

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -30,7 +30,7 @@ import { amount } from "schema/v2/fields/money"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { map } from "lodash"
 import { NodeInterface } from "schema/v2/object_identification"
-import { isLiveOpen, displayTimelyAt } from "./display"
+import { displayTimelyAt, isLiveOpen, isLiveOpenHappened } from "./display"
 import { flatten, first, isEmpty } from "lodash"
 
 import {
@@ -405,6 +405,12 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
         resolve: ({ auction_state }) => auction_state === "open",
       },
       isLiveOpen: { type: GraphQLBoolean, resolve: isLiveOpen },
+      isLiveOpenHappened: {
+        type: GraphQLBoolean,
+        description:
+          "True for live auctions once live part is happening or in the past",
+        resolve: isLiveOpenHappened,
+      },
       isPreview: {
         type: GraphQLBoolean,
         resolve: ({ auction_state }) => auction_state === "preview",


### PR DESCRIPTION
Step for https://artsyproduct.atlassian.net/browse/EMI-2582

The current available `isLiveOpen` on sale is only true during the lime live bidding is open. But we want to hide bidding info for collectors in history and other pages after life open happened as we can not guarantee that our 'bid status' is correct as the auction enters Live bidding part.

Instead of manually testing for live_start_at being after now in multiple clients adding the attribute here to be reused in Force and Eigen.