### PR TITLE
feat(imports): Add rowID parameter to matchArtworkImportRowImage mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14520,6 +14520,7 @@ input MatchArtworkImportRowImageInput {
   artworkImportID: String!
   clientMutationId: String
   fileName: String!
+  rowID: String
   s3Bucket: String!
   s3Key: String!
 }

--- a/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportRowImageMutation.test.ts
@@ -48,4 +48,53 @@ describe("MatchArtworkImportRowImageMutation", () => {
       },
     })
   })
+
+  it("updates a row's image with rowID when provided", async () => {
+    const artworkImportRowMatchImageLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        matchArtworkImportRowImage(
+          input: {
+            artworkImportID: "artwork-import-1"
+            fileName: "cat.jpg"
+            s3Key: "/some/path/cat.jpg"
+            s3Bucket: "someBucket"
+            rowID: "row-123"
+          }
+        ) {
+          matchArtworkImportRowImageOrError {
+            ... on MatchArtworkImportRowImageSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportRowMatchImageLoader,
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportRowMatchImageLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        file_name: "cat.jpg",
+        s3_key: "/some/path/cat.jpg",
+        s3_bucket: "someBucket",
+        row_id: "row-123",
+      }
+    )
+
+    expect(result).toEqual({
+      matchArtworkImportRowImage: {
+        matchArtworkImportRowImageOrError: {
+          success: true,
+        },
+      },
+    })
+  })
 })

--- a/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportRowImageMutation.ts
@@ -66,6 +66,9 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
     s3Bucket: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    rowID: {
+      type: GraphQLString,
+    },
   },
   outputFields: {
     matchArtworkImportRowImageOrError: {
@@ -74,7 +77,7 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkImportID, fileName, s3Key, s3Bucket },
+    { artworkImportID, fileName, s3Key, s3Bucket, rowID },
     { artworkImportRowMatchImageLoader }
   ) => {
     if (!artworkImportRowMatchImageLoader) {
@@ -85,6 +88,7 @@ export const MatchArtworkImportRowImageMutation = mutationWithClientMutationId<
       file_name: fileName,
       s3_key: s3Key,
       s3_bucket: s3Bucket,
+      ...(rowID && { row_id: rowID }),
     }
 
     try {


### PR DESCRIPTION
### Description 

Added optional `rowID` parameter to the `matchArtworkImportRowImage` mutation to support associating images with artwork import rows that didn't originally have image columns.

This enhancement enables post-import image association for CSV imports that were uploaded with only basic columns (e.g., `artist,title,price,year`).

## Changes
- Added optional `rowID` input field to `MatchArtworkImportRowImageMutation`
- Updated mutation to conditionally pass `row_id` to Gravity endpoint
- Added test coverage for new functionality
- Maintains full backward compatibility

## Example Query
```graphql
mutation {
  matchArtworkImportRowImage(
    input: {
      artworkImportID: "artwork-import-1"
      fileName: "artwork.jpg"
      s3Key: "/uploads/artwork.jpg"
      s3Bucket: "artsy-images"
      rowID: "row-123"
    }
  ) {
    matchArtworkImportRowImageOrError {
      ... on MatchArtworkImportRowImageSuccess {
        success
        artworkImport {
          id
        }
      }
    }
  }
}
```

## Example Response
```json
{
  "data": {
    "matchArtworkImportRowImage": {
      "matchArtworkImportRowImageOrError": {
        "success": true,
        "artworkImport": {
          "id": "artwork-import-1"
        }
      }
    }
  }
}
```

Related: https://github.com/artsy/gravity/pull/19203

🤖 Generated with [Claude Code](https://claude.ai/code)

cc @artsy/amber-devs 