### PR TITLE
chore(imports): Update delete artwork endpoint

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -122,7 +122,7 @@ export default (accessToken, userID, opts) => {
       { artworkImportID: string; imageID: string }
     >(
       ({ artworkImportID, imageID }) =>
-        `artwork_import/${artworkImportID}/remove_image/${imageID}`,
+        `artwork_import/${artworkImportID}/image/${imageID}`,
       {},
       { method: "DELETE" }
     ),


### PR DESCRIPTION
Related: https://github.com/artsy/gravity/pull/19205

This updates the endpoint for the artwork_import remove artwork image. 

cc @artsy/amber-devs 