### PR TITLE
feat(mcp): [POC] Add Apollo MCP Server example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tmp
 coverage*
 .hokusai-tmp
 Brewfile.lock.json
+
+# Apollo MCP binary
+apollo-mcp-server

--- a/mcp-config.yml
+++ b/mcp-config.yml
@@ -4,6 +4,7 @@ transport:
 operations:
   source: local
   paths:
+    - ./mcp/operations/llmSystemContext.graphql
     - ./mcp/operations/analytics
     - ./mcp/operations/artist
 schema:
@@ -19,5 +20,5 @@ introspection:
   search:
     enabled: true
 headers:
-  "x-access-token": "fill in"
-  "x-user-id": "fill in"
+  "x-access-token": "fill-in"
+  "x-user-id": "fill-in"

--- a/mcp-config.yml
+++ b/mcp-config.yml
@@ -1,0 +1,20 @@
+endpoint: http://localhost:5001/v2
+transport:
+  type: streamable_http
+operations:
+  source: local
+  paths:
+    - ./mcp/operations/analytics
+schema:
+  source: local
+  path: ./_schemaV2.graphql
+introspection:
+  execute:
+    enabled: true
+  introspect:
+    enabled: true
+  search:
+    enabled: true
+headers:
+  "x-access-token": "fill in"
+  "x-user-id": "fill in"

--- a/mcp/operations/analytics/activityStats.graphql
+++ b/mcp/operations/analytics/activityStats.graphql
@@ -1,0 +1,23 @@
+query activityStatsToolQuery(
+  $partnerId: String!
+  $period: AnalyticsQueryPeriodEnum!
+) {
+  partner(id: $partnerId) {
+    name
+    analytics {
+      pageviews(period: $period) {
+        totalCount
+        percentageChanged
+        artworkViews
+        galleryViews
+        showViews
+        uniqueVisitors
+        timeSeries {
+          count
+          startTime
+          endTime
+        }
+      }
+    }
+  }
+}

--- a/mcp/operations/llmSystemContext.graphql
+++ b/mcp/operations/llmSystemContext.graphql
@@ -1,0 +1,11 @@
+# This is the LLM system context tool defining common behaviors and rules for our GraphQL server.
+
+# - **IMPORTANT**: When querying for records or passing IDs between different operations, use a record's `internalID`, not `id` or `_id`. Frequently, `slug` can also be used.
+# - When asking for the ID of a record, return the value of `internalID`, but just call it "id". Devs and other users know what this means.
+
+query llmSystemContext {
+  # Intentionally no-op-ish
+  system {
+    time
+  }
+}


### PR DESCRIPTION
Follow-up experiment to https://github.com/artsy/mcp-analytics. 

This implements a bare bones config for https://github.com/apollographql/apollo-mcp-server. 

### Setup:
- Followed the [installation methods](https://www.apollographql.com/docs/apollo-mcp-server/command-reference#installation-methods) to install a local version. 
```bash
cd metaphysics
curl -sSL https://mcp.apollo.dev/download/nix/latest | sh
```

Can also use the docker container. 

- Add this `mcp-config.yml` config to the root of the project:
```yml
endpoint: http://localhost:5001/v2
transport:
  type: streamable_http
operations:
  source: local
  paths:
    - ./mcp/operations/analytics
schema:
  source: local
  path: ./_schemaV2.graphql
overrides:
  mutation_mode: "all" # enable mutations! 
introspection:
  execute:
    enabled: true
  introspect:
    enabled: true
  search:
    enabled: true
headers:
  "x-access-token": "fill in"
  "x-user-id": "fill in"
```
- Update `mcp-config.yml` with access tokens and user ID 
- Start the MCP server in one terminal pane: `./apollo-mcp-server mcp-config.yml`
- Open another terminal pane and boot local metaphysics: `yarn start` 
- Add this config to Claude Desktop or Claude code (via `~/.claude.json`):
```json
"artsy-mcp": {
  "command": "npx",
  "args": [
    "mcp-remote",
    "http://127.0.0.1:5000/mcp"
  ]
}
```
- Boot Claude Desktop or start `claude-code`

More information in this [slack thread](https://artsy.slack.com/archives/CA8SANW3W/p1754335676656499)