### PR TITLE
feat: add foundations and residencies field to UpdateArtistMutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -861,9 +861,11 @@ type AnalyticsPageviewStats {
 # Audience stats of a partner
 type AnalyticsPartnerAudienceStats {
   commercialVisitors: Int!
+  commercialVisitorsPercentageChanged: Int!
   partnerId: String!
   period: AnalyticsQueryPeriodEnum!
   uniqueVisitors: Int!
+  uniqueVisitorsPercentageChanged: Int!
 }
 
 # Inquiry count time series data of a partner
@@ -1925,6 +1927,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   # The most recent show for an artist
   recentShow: String
   related: ArtistRelatedData
+  residencies: String
 
   # publications that have reviewed the artist
   reviewSources: String
@@ -22848,6 +22851,7 @@ input UpdateArtistMutationInput {
   deathday: String
   displayName: String
   first: String
+  foundations: String
   gender: String
   groupIndicator: ArtistGroupIndicator
   hometown: String
@@ -22858,6 +22862,7 @@ input UpdateArtistMutationInput {
   nationality: String
   public: Boolean
   recentShow: String
+  residencies: String
   reviewSources: String
   targetSupplyPriority: ArtistTargetSupplyPriority
   targetSupplyType: ArtistTargetSupplyType

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -7,11 +7,9 @@ describe("Artist type", () => {
   let context
 
   beforeEach(() => {
-    config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = true
     config.FORCE_URL = "https://www.artsy.net"
   })
   afterEach(() => {
-    config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = false
     delete config.FORCE_URL
   })
 

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -949,6 +949,10 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      residencies: {
+        type: GraphQLString,
+        resolve: ({ residencies }) => residencies,
+      },
       duplicates: {
         type: new GraphQLList(Artist.type),
         resolve: ({ id }, _args, { artistDuplicatesLoader }, _info) => {

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -36,6 +36,7 @@ interface Input {
   deathday?: string
   displayName?: string
   first?: string
+  foundations?: string
   gender?: string
   groupIndicator?: ArtistGroupIndicator
   hometown?: string
@@ -46,6 +47,7 @@ interface Input {
   nationality?: string
   public?: boolean
   recentShow?: string
+  residencies?: string
   reviewSources?: string
   targetSupplyPriority?: ArtistTargetSupplyPriority
   targetSupplyType?: ArtistTargetSupplyType
@@ -63,6 +65,7 @@ const inputFields = {
   deathday: { type: GraphQLString },
   displayName: { type: GraphQLString },
   first: { type: GraphQLString },
+  foundations: { type: GraphQLString },
   gender: { type: GraphQLString },
   groupIndicator: { type: ArtistGroupIndicatorEnum },
   hometown: { type: GraphQLString },
@@ -73,6 +76,7 @@ const inputFields = {
   nationality: { type: GraphQLString },
   public: { type: GraphQLBoolean },
   recentShow: { type: GraphQLString },
+  residencies: { type: GraphQLString },
   reviewSources: { type: GraphQLString },
   targetSupplyPriority: { type: ArtistTargetSupplyPriorityEnum },
   targetSupplyType: { type: ArtistTargetSupplyTypeEnum },
@@ -90,6 +94,7 @@ interface GravityInput {
   deathday?: string
   display_name?: string
   first?: string
+  foundations?: string
   gender?: string
   group_indicator?: string
   hometown?: string
@@ -99,6 +104,7 @@ interface GravityInput {
   middle?: string
   nationality?: string
   public?: boolean
+  residencies?: string
   recent_show?: string
   review_sources?: string
   target_supply_priority?: string

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -6,19 +6,11 @@ import { getMicrofunnelDataByArtworkInternalID } from "schema/v2/artist/targetSu
 import { runQuery } from "schema/v2/test/utils"
 import { CHECKOUT_TAXES_DOC_URL } from "../taxInfo"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
-import config from "config"
 
 jest.mock("schema/v2/artist/targetSupply/utils/getMicrofunnelData")
 
 describe("Artwork type", () => {
   const sale = { id: "existy" }
-
-  beforeEach(() => {
-    config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = true
-  })
-  afterEach(() => {
-    config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = false
-  })
 
   let artwork = null
   let context = null
@@ -5504,12 +5496,6 @@ describe("Artwork type", () => {
   })
 
   describe("artistSeriesConnection", () => {
-    beforeEach(() => {
-      config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = true
-    })
-    afterEach(() => {
-      config.USE_UNSTITCHED_ARTIST_SERIES_SCHEMA = false
-    })
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {


### PR DESCRIPTION
This PR adds `foundations` and `residencies` fields to updateArtistMutation and cleans up unused `USE_UNSTITCHED_ARTIST_SERIES_SCHEMA` env vars from unrelated tests.

### Next Steps

- Add foundations and residencies inputs to the Forque UI for admin support 

<img width="753" height="515" alt="Screenshot 2025-08-05 at 12 54 06" src="https://github.com/user-attachments/assets/68eb1d6a-0ad7-4ddb-818d-bae7852159b6" />




/cc @artsy/diamond-devs 