### PR TITLE
feat: Support filtering by show status on showsSearchConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17573,6 +17573,7 @@ type Partner implements Node {
     page: Int = 1
     query: String!
     size: Int = 10
+    status: [String]
   ): ShowConnection
 
   # A slug ID.

--- a/src/schema/v2/partner/PartnerMatch.ts
+++ b/src/schema/v2/partner/PartnerMatch.ts
@@ -1,4 +1,4 @@
-import { GraphQLInt, GraphQLNonNull, GraphQLString } from "graphql"
+import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString } from "graphql"
 import { GraphQLFieldConfig } from "graphql"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { pageable } from "relay-cursor-paging"
@@ -19,6 +19,7 @@ export const partnerShowsMatchConnection: GraphQLFieldConfig<
     },
     size: { type: GraphQLInt, defaultValue: 10 },
     page: { type: GraphQLInt, defaultValue: 1 },
+    status: { type: new GraphQLList(GraphQLString) },
   }),
   resolve: async ({ id }, { query, ...args }, { partnerSearchShowsLoader }) => {
     if (!partnerSearchShowsLoader) return null
@@ -27,6 +28,7 @@ export const partnerShowsMatchConnection: GraphQLFieldConfig<
 
     const { body, headers } = await partnerSearchShowsLoader(id, {
       term: query,
+      status: args.status,
       size,
       offset,
       total_count: true,


### PR DESCRIPTION
Allow users of `showsSearchConnection` to filter down search results by `status`

This allows users to filter down from a list of shows in a given `status`
`status` supports singular or multiple options

```graphql
{
  partner(id: "gagosian") {
    showsSearchConnection(first: 15, query: "os", status: ["running", "upcoming"]) {
      edges {
        node {
          name
          status
          startAt
          endAt
        }
      }
    }
  }
}

```

Associated gravity changes here:
- https://github.com/artsy/gravity/pull/19217

## Example
Returns only shows where `term='os'` and is of status `running` or `upcoming`
<img width="1386" height="801" alt="Screenshot 2025-08-05 at 2 53 17 PM" src="https://github.com/user-attachments/assets/69161ad8-9678-477a-8100-c5c1ed0a96df" />


## Previous behavior
Returns all shows where `term='os'`
<img width="1334" height="834" alt="Screenshot 2025-08-05 at 2 53 28 PM" src="https://github.com/user-attachments/assets/0c223d66-3da7-40ed-9b54-cbaec0282c9c" />

cc @artsy/amber-devs 
