### PR TITLE
chore: AMBER-1882 - location is nullable

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3214,7 +3214,7 @@ type ArtworkImport implements Node {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
-  locationID: String!
+  locationID: String
   rawDataMapping: JSON!
   rowsConnection(
     after: String

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -332,7 +332,7 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
       resolve: ({ file_name }) => file_name,
     },
     locationID: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       resolve: ({ location_id }) => location_id,
     },
     state: {


### PR DESCRIPTION
Follow up PR from https://github.com/artsy/metaphysics/pull/6993

The `locationID` on an Artwork Import is nullable. It is not required for Artworks to be created and they will also default to a `nil` location

cc: @artsy/amber-devs 