### PR TITLE
feat: Expose new string fields on batch edits experience

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4684,7 +4684,7 @@ input BulkUpdateArtworksMetadataInput {
   category: String
 
   # The artwork condition to be assigned
-  condition: String
+  conditionDescription: String
 
   # Flat fee for domestic shipping. It must be entered in cents.
   domesticShippingFeeCents: Int

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -12,7 +12,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           metadata: {
             artistIds: ["artist1", "artist2"]
             availability: SOLD
-            condition: "Excellent"
+            conditionDescription: "Excellent"
             domesticShippingFeeCents: 20000
             locationId: "location456"
             category: "Painting"
@@ -75,7 +75,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
       {
         metadata: {
           artist_ids: ["artist1", "artist2"],
-          condition: "Excellent",
+          condition_description: "Excellent",
           availability: "sold",
           domestic_shipping_fee_cents: 20000,
           location_id: "location456",

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -26,7 +26,7 @@ interface Input {
     artistIds?: string[]
     availability?: string
     category?: string
-    condition?: string
+    conditionDescription?: string
     domesticShippingFeeCents?: number
     ecommerce: boolean
     exhibitionHistory?: string
@@ -66,7 +66,7 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "The category (medium type) to be assigned",
     },
-    condition: {
+    conditionDescription: {
       type: GraphQLString,
       description: "The artwork condition to be assigned",
     },
@@ -240,7 +240,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         artist_ids: metadata.artistIds,
         availability: metadata.availability,
         category: metadata.category,
-        condition: metadata.condition,
+        condition_description: metadata.conditionDescription,
         domestic_shipping_fee_cents: metadata.domesticShippingFeeCents,
         ecommerce: metadata.ecommerce,
         exhibition_history: metadata.exhibitionHistory,


### PR DESCRIPTION
feat: Expose new string fields on batch edits experience
Associated Gravity changes here: https://github.com/artsy/gravity/pull/19226

We want to support more fields in batch edits experience, adding support to the following:
- artwork condition
- exhibition history
- literature / bibliography
- image rights


<img width="459" height="517" alt="Screenshot 2025-08-11 at 4 22 52 PM" src="https://github.com/user-attachments/assets/55eaff77-2300-4bf9-b145-c479ac4b9c0c" />


## Heads up
⚠️ I'll come back around to add in certificate of aunthenticity related fields in a separate PR⚠️ 
As that one requires more structured data


cc @artsy/amber-devs 