### PR TITLE
feat: Add image position mutations for artwork imports

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3347,6 +3347,7 @@ type ArtworkImportRowImage {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  position: Int!
   publicUrl: String
   s3Bucket: String
   s3Key: String
@@ -13672,6 +13673,14 @@ type ImageEdge {
   node: Image
 }
 
+input ImagePositionInput {
+  # The ID of the image to update
+  id: String!
+
+  # The new position for the image (0-based)
+  position: Int!
+}
+
 type ImageURLs {
   normalized: String
 }
@@ -16224,6 +16233,12 @@ type Mutation {
   updateArtworkImportRow(
     input: UpdateArtworkImportRowInput!
   ): UpdateArtworkImportRowPayload
+  updateArtworkImportRowImage(
+    input: UpdateArtworkImportRowImageInput!
+  ): UpdateArtworkImportRowImagePayload
+  updateArtworkImportRowImages(
+    input: UpdateArtworkImportRowImagesInput!
+  ): UpdateArtworkImportRowImagesPayload
   updateArtworkImportWeightMetric(
     input: UpdateArtworkImportWeightMetricInput!
   ): UpdateArtworkImportWeightMetricPayload
@@ -22998,6 +23013,59 @@ union UpdateArtworkImportResponseOrError =
 
 type UpdateArtworkImportRowFailure {
   mutationError: GravityMutationError
+}
+
+type UpdateArtworkImportRowImageFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtworkImportRowImageInput {
+  artworkImportID: String!
+  clientMutationId: String
+  imageID: String!
+
+  # New position for the image (0-based)
+  position: Int!
+}
+
+type UpdateArtworkImportRowImagePayload {
+  clientMutationId: String
+  updateArtworkImportRowImageOrError: UpdateArtworkImportRowImageResponseOrError
+}
+
+union UpdateArtworkImportRowImageResponseOrError =
+    UpdateArtworkImportRowImageFailure
+  | UpdateArtworkImportRowImageSuccess
+
+type UpdateArtworkImportRowImageSuccess {
+  artworkImport: ArtworkImport
+  artworkImportID: String!
+}
+
+type UpdateArtworkImportRowImagesFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateArtworkImportRowImagesInput {
+  artworkImportID: String!
+  clientMutationId: String
+
+  # Array of image position updates
+  images: [ImagePositionInput!]!
+}
+
+type UpdateArtworkImportRowImagesPayload {
+  clientMutationId: String
+  updateArtworkImportRowImagesOrError: UpdateArtworkImportRowImagesResponseOrError
+}
+
+union UpdateArtworkImportRowImagesResponseOrError =
+    UpdateArtworkImportRowImagesFailure
+  | UpdateArtworkImportRowImagesSuccess
+
+type UpdateArtworkImportRowImagesSuccess {
+  artworkImport: ArtworkImport
+  artworkImportID: String!
 }
 
 input UpdateArtworkImportRowInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -172,6 +172,20 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    artworkImportUpdateImageMatchLoader: gravityLoader<
+      any,
+      { artworkImportID: string; imageID: string }
+    >(
+      ({ artworkImportID, imageID }) =>
+        `artwork_import/${artworkImportID}/image_matches/${imageID}`,
+      {},
+      { method: "PUT" }
+    ),
+    artworkImportBatchUpdateImageMatchesLoader: gravityLoader(
+      (id) => `artwork_import/${id}/image_matches`,
+      {},
+      { method: "PUT" }
+    ),
     artworksCollectionsBatchUpdateLoader: gravityLoader(
       "artworks/collections/batch",
       {},

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImageMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImageMutation.test.ts
@@ -1,0 +1,131 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateArtworkImportRowImageMutation", () => {
+  it("updates a single image position", async () => {
+    const artworkImportUpdateImageMatchLoader = jest.fn().mockResolvedValue({
+      id: "image-1",
+      position: 5,
+    })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImage(
+          input: {
+            artworkImportID: "artwork-import-1"
+            imageID: "image-1"
+            position: 5
+          }
+        ) {
+          updateArtworkImportRowImageOrError {
+            ... on UpdateArtworkImportRowImageSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportUpdateImageMatchLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportUpdateImageMatchLoader).toHaveBeenCalledWith(
+      { artworkImportID: "artwork-import-1", imageID: "image-1" },
+      { position: 5 }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRowImage: {
+        updateArtworkImportRowImageOrError: {
+          artworkImportID: "artwork-import-1",
+        },
+      },
+    })
+  })
+
+  it("updates position 0", async () => {
+    const artworkImportUpdateImageMatchLoader = jest.fn().mockResolvedValue({
+      id: "image-1",
+      position: 0,
+    })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImage(
+          input: {
+            artworkImportID: "artwork-import-1"
+            imageID: "image-1"
+            position: 0
+          }
+        ) {
+          updateArtworkImportRowImageOrError {
+            ... on UpdateArtworkImportRowImageSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportUpdateImageMatchLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportUpdateImageMatchLoader).toHaveBeenCalledWith(
+      { artworkImportID: "artwork-import-1", imageID: "image-1" },
+      { position: 0 }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRowImage: {
+        updateArtworkImportRowImageOrError: {
+          artworkImportID: "artwork-import-1",
+        },
+      },
+    })
+  })
+
+  it("returns an error when loader throws", async () => {
+    const artworkImportUpdateImageMatchLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Image not found"))
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImage(
+          input: {
+            artworkImportID: "artwork-import-1"
+            imageID: "image-1"
+            position: 5
+          }
+        ) {
+          updateArtworkImportRowImageOrError {
+            ... on UpdateArtworkImportRowImageSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportUpdateImageMatchLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Image not found"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
@@ -1,0 +1,146 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdateArtworkImportRowImagesMutation", () => {
+  it("updates multiple image positions", async () => {
+    const artworkImportBatchUpdateImageMatchesLoader = jest
+      .fn()
+      .mockResolvedValue({
+        images: [
+          { id: "image-1", position: 2 },
+          { id: "image-2", position: 1 },
+          { id: "image-3", position: 0 },
+        ],
+      })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [
+              { id: "image-1", position: 2 }
+              { id: "image-2", position: 1 }
+              { id: "image-3", position: 0 }
+            ]
+          }
+        ) {
+          updateArtworkImportRowImagesOrError {
+            ... on UpdateArtworkImportRowImagesSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        images: [
+          { id: "image-1", position: 2 },
+          { id: "image-2", position: 1 },
+          { id: "image-3", position: 0 },
+        ],
+      }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRowImages: {
+        updateArtworkImportRowImagesOrError: {
+          artworkImportID: "artwork-import-1",
+        },
+      },
+    })
+  })
+
+  it("handles single image in batch", async () => {
+    const artworkImportBatchUpdateImageMatchesLoader = jest
+      .fn()
+      .mockResolvedValue({
+        images: [{ id: "image-1", position: 3 }],
+      })
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [{ id: "image-1", position: 3 }]
+          }
+        ) {
+          updateArtworkImportRowImagesOrError {
+            ... on UpdateArtworkImportRowImagesSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        images: [{ id: "image-1", position: 3 }],
+      }
+    )
+
+    expect(result).toEqual({
+      updateArtworkImportRowImages: {
+        updateArtworkImportRowImagesOrError: {
+          artworkImportID: "artwork-import-1",
+        },
+      },
+    })
+  })
+
+  it("returns an error when loader throws", async () => {
+    const artworkImportBatchUpdateImageMatchesLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Batch update failed"))
+
+    const mutation = gql`
+      mutation {
+        updateArtworkImportRowImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [{ id: "image-1", position: 5 }]
+          }
+        ) {
+          updateArtworkImportRowImagesOrError {
+            ... on UpdateArtworkImportRowImagesSuccess {
+              artworkImportID
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Batch update failed"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -6,6 +6,7 @@ import {
   GraphQLBoolean,
   GraphQLList,
   GraphQLEnumType,
+  GraphQLInt,
 } from "graphql"
 import { InternalIDFields, NodeInterface } from "../object_identification"
 import { ResolverContext } from "types/graphql"
@@ -131,6 +132,10 @@ const ArtworkImportRowImageType = new GraphQLObjectType({
     s3Bucket: {
       type: GraphQLString,
       resolve: ({ s3_bucket }) => s3_bucket,
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ position }) => position,
     },
   },
 })

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowImageMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowImageMutation.ts
@@ -1,0 +1,99 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLInt,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowImageSuccess",
+  isTypeOf: (data) => !!data.artworkImportID,
+  fields: () => ({
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowImageFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtworkImportRowImageResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateArtworkImportRowImageMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "UpdateArtworkImportRowImage",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    imageID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "New position for the image (0-based)",
+    },
+  },
+  outputFields: {
+    updateArtworkImportRowImageOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, imageID, position },
+    { artworkImportUpdateImageMatchLoader }
+  ) => {
+    if (!artworkImportUpdateImageMatchLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      await artworkImportUpdateImageMatchLoader(
+        { artworkImportID, imageID },
+        { position }
+      )
+
+      return {
+        artworkImportID,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
@@ -1,0 +1,113 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLInputObjectType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const ImagePositionInputType = new GraphQLInputObjectType({
+  name: "ImagePositionInput",
+  fields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the image to update",
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "The new position for the image (0-based)",
+    },
+  },
+})
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowImagesSuccess",
+  isTypeOf: (data) => !!data.artworkImportID,
+  fields: () => ({
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateArtworkImportRowImagesFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateArtworkImportRowImagesResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "UpdateArtworkImportRowImages",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    images: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ImagePositionInputType))
+      ),
+      description: "Array of image position updates",
+    },
+  },
+  outputFields: {
+    updateArtworkImportRowImagesOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, images },
+    { artworkImportBatchUpdateImageMatchesLoader }
+  ) => {
+    if (!artworkImportBatchUpdateImageMatchesLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      await artworkImportBatchUpdateImageMatchesLoader(artworkImportID, {
+        images,
+      })
+
+      return {
+        artworkImportID,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -305,6 +305,8 @@ import { CreateArtworkImportArtworksMutation } from "./ArtworkImport/createArtwo
 import { AssignArtworkImportArtistMutation } from "./ArtworkImport/assignArtworkImportArtistMutation"
 import { UpdateArtworkImportMutation } from "./ArtworkImport/updateArtworkImportMutation"
 import { UpdateArtworkImportRowMutation } from "./ArtworkImport/updateArtworkImportRowMutation"
+import { UpdateArtworkImportRowImageMutation } from "./ArtworkImport/updateArtworkImportRowImageMutation"
+import { UpdateArtworkImportRowImagesMutation } from "./ArtworkImport/updateArtworkImportRowImagesMutation"
 import { UpdateArtworkImportCurrencyMutation } from "./ArtworkImport/updateArtworkImportCurrencyMutation"
 import { UpdateArtworkImportDimensionMetricMutation } from "./ArtworkImport/updateArtworkImportDimensionMetricMutation"
 import { UpdateArtworkImportWeightMetricMutation } from "./ArtworkImport/updateArtworkImportWeightMetricMutation"
@@ -633,6 +635,8 @@ export default new GraphQLSchema({
       updateArtwork: updateArtworkMutation,
       updateArtworkImport: UpdateArtworkImportMutation,
       updateArtworkImportRow: UpdateArtworkImportRowMutation,
+      updateArtworkImportRowImage: UpdateArtworkImportRowImageMutation,
+      updateArtworkImportRowImages: UpdateArtworkImportRowImagesMutation,
       updateArtworkImportCurrency: UpdateArtworkImportCurrencyMutation,
       updateArtworkImportDimensionMetric: UpdateArtworkImportDimensionMetricMutation,
       updateArtworkImportWeightMetric: UpdateArtworkImportWeightMetricMutation,


### PR DESCRIPTION
Related:
- https://github.com/artsy/gravity/pull/19228.


### Description

Adds some mutations to support image reordering in artwork imports.
#### Changes
- `updateArtworkImportRowImage` - Updates single image position
- `updateArtworkImportRowImages` - Batch updates multiple image positions  
- Added `position` field to `ArtworkImportRowImage` type
- Added loaders for both REST endpoints

### Example Usage

#### Single image update:
```graphql
mutation {
  updateArtworkImportRowImage(
    input: {
      artworkImportID: "artwork-import-1"
      imageID: "image-1" 
      position: 3
    }
  ) {
    updateArtworkImportRowImageOrError {
      ... on UpdateArtworkImportRowImageSuccess {
        artworkImportID
      }
    }
  }
}
```

#### Batch update:
```graphql
mutation {
  updateArtworkImportRowImages(
    input: {
      artworkImportID: "artwork-import-1"
      images: [
        { id: "image-1", position: 0 }
        { id: "image-2", position: 1 }
      ]
    }
  ) {
    updateArtworkImportRowImagesOrError {
      ... on UpdateArtworkImportRowImagesSuccess {
        artworkImportID
      }
    }
  }
}
```

cc @artsy/amber-devs 