### PR TITLE
fix(serialization): Fix array serialization for complex nested objects in mutations

### DIFF
--- a/src/lib/__tests__/apis/fetch.test.ts
+++ b/src/lib/__tests__/apis/fetch.test.ts
@@ -4,6 +4,8 @@ const mockRequest = (request as any) as jest.Mock
 
 import fetch from "../../apis/fetch"
 import { constructUrlAndParams } from "../../apis/fetch"
+import { toQueryString } from "../../helpers"
+import { parse } from "qs"
 
 declare const expectPromiseRejectionToMatch: any
 
@@ -129,5 +131,124 @@ describe("constructUrlAndParams", () => {
     )
 
     expect(body).toEqual(["foo", "bar"])
+  })
+
+  it("correctly handles simple arrays with bracket notation", () => {
+    const { body } = constructUrlAndParams(
+      "POST",
+      "https://staging.artsy.net/api/v1/artworks/collections/batch?artwork_ids[]=id1&artwork_ids[]=id2&add_to[]=coll1"
+    )
+
+    expect(body).toEqual({
+      artwork_ids: ["id1", "id2"],
+      add_to: ["coll1"],
+    })
+  })
+
+  it("correctly handles mixed data types", () => {
+    const { body } = constructUrlAndParams(
+      "PUT",
+      "https://staging.artsy.net/api/v1/artist/banksy?name=Banksy&tags[]=street&tags[]=graffiti&public=true"
+    )
+
+    expect(body).toEqual({
+      name: "Banksy",
+      tags: ["street", "graffiti"],
+      public: "true",
+    })
+  })
+
+  it("correctly handles nested arrays with objects using indexed notation", () => {
+    const { body } = constructUrlAndParams(
+      "PUT",
+      "https://staging.artsy.net/api/v1/artwork_import/123/image_matches?images[0][id]=img1&images[0][position]=0&images[1][id]=img2&images[1][position]=1"
+    )
+
+    expect(body).toEqual({
+      images: [
+        { id: "img1", position: "0" },
+        { id: "img2", position: "1" },
+      ],
+    })
+  })
+
+  it("handles double bracket notation", () => {
+    const { body } = constructUrlAndParams(
+      "PUT",
+      "artwork_import/123/image_matches?images[][id]=img1&images[][position]=0&images[][id]=img2&images[][position]=1"
+    )
+
+    // Current behavior - creates arrays within single object
+    expect(body).toEqual({
+      images: [
+        {
+          id: ["img1", "img2"],
+          position: ["0", "1"],
+        },
+      ],
+    })
+  })
+
+  it("should handle indexed notation correctly", () => {
+    const { body } = constructUrlAndParams(
+      "PUT",
+      "artwork_import/123/image_matches?images[0][id]=img1&images[0][position]=0&images[1][id]=img2&images[1][position]=1"
+    )
+
+    expect(body).toEqual({
+      images: [
+        { id: "img1", position: "0" },
+        { id: "img2", position: "1" },
+      ],
+    })
+  })
+
+  it("test backwards compatibility with toQueryString helper", () => {
+    // Test simple arrays
+    const simpleArray = { tags: ["tag1", "tag2"] }
+    const simpleQuery = toQueryString(simpleArray)
+    const simpleParsed = parse(simpleQuery, { arrayLimit: 1000 })
+
+    expect(simpleParsed).toEqual({ tags: ["tag1", "tag2"] })
+
+    // Test complex nested objects
+    const complexArray = {
+      images: [
+        { id: "img1", position: 0 },
+        { id: "img2", position: 1 },
+      ],
+    }
+    const complexQuery = toQueryString(complexArray)
+    const complexParsed = parse(complexQuery, { arrayLimit: 1000 })
+
+    expect(complexParsed).toEqual({
+      images: [
+        { id: "img1", position: "0" },
+        { id: "img2", position: "1" },
+      ],
+    })
+
+    // Test that the generated query uses indices format
+    expect(complexQuery).toContain("images%5B0%5D")
+    expect(complexQuery).toContain("images%5B1%5D")
+  })
+
+  it("handles deeply nested complex structures", () => {
+    const deeplyNested = {
+      images: [
+        { id: "img1", position: { foo: [1, 2, 3] } },
+        { id: "img2", position: { bar: [1, { a: "hi" }] } },
+      ],
+    }
+
+    const query = toQueryString(deeplyNested)
+    const parsed = parse(query, { arrayLimit: 1000 })
+
+    expect(parsed).toEqual({
+      images: [
+        { id: "img1", position: { foo: ["1", "2", "3"] } },
+        { id: "img2", position: { bar: ["1", { a: "hi" }] } },
+      ],
+    })
   })
 })

--- a/src/lib/__tests__/helpers.test.ts
+++ b/src/lib/__tests__/helpers.test.ts
@@ -37,7 +37,7 @@ describe("toQueryString", () => {
   it("stringifies regular arraies", () => {
     expect(
       toQueryString({ ids: [13, 27], visible: true, availability: "for sale" })
-    ).toBe("ids%5B%5D=13&ids%5B%5D=27&visible=true&availability=for%20sale")
+    ).toBe("ids%5B0%5D=13&ids%5B1%5D=27&visible=true&availability=for%20sale")
   })
 
   it("ignores empty arraies", () => {
@@ -49,7 +49,7 @@ describe("toQueryString", () => {
   it("stringifies [null] as an empty array", () => {
     expect(
       toQueryString({ ids: [null], visible: true, availability: "for sale" })
-    ).toBe("ids%5B%5D=&visible=true&availability=for%20sale")
+    ).toBe("ids%5B0%5D=&visible=true&availability=for%20sale")
   })
 
   it("keeps order when request is batched", () => {
@@ -80,7 +80,20 @@ describe("toQueryString", () => {
         ],
       })
     ).toBe(
-      "ids%5B%5D=63f115629648b4000c707e37&ids%5B%5D=63c08f8408c833000db6ef58&ids%5B%5D=63ffbe494cc6f7000c920e0f&ids%5B%5D=63fcbacb68aa09000bd2609e&ids%5B%5D=63e67f5a70b792000b9e57c3&ids%5B%5D=63f89ccae5957d000c2ed8a3&ids%5B%5D=63e67f5a9e7407000bec0ec3&ids%5B%5D=63f89d924cc87a000e474c6e&ids%5B%5D=63f38b52380b9e000d788778&ids%5B%5D=63f38510f56dbb000d16e196&ids%5B%5D=63f5421caff176000c3c9c82"
+      "ids%5B0%5D=63f115629648b4000c707e37&ids%5B1%5D=63c08f8408c833000db6ef58&ids%5B2%5D=63ffbe494cc6f7000c920e0f&ids%5B3%5D=63fcbacb68aa09000bd2609e&ids%5B4%5D=63e67f5a70b792000b9e57c3&ids%5B5%5D=63f89ccae5957d000c2ed8a3&ids%5B6%5D=63e67f5a9e7407000bec0ec3&ids%5B7%5D=63f89d924cc87a000e474c6e&ids%5B8%5D=63f38b52380b9e000d788778&ids%5B9%5D=63f38510f56dbb000d16e196&ids%5B10%5D=63f5421caff176000c3c9c82"
+    )
+  })
+
+  it("handles complex nested arrays with objects", () => {
+    const result = toQueryString({
+      images: [
+        { id: "img1", position: 0 },
+        { id: "img2", position: 1 },
+      ],
+    })
+
+    expect(result).toBe(
+      "images%5B0%5D%5Bid%5D=img1&images%5B0%5D%5Bposition%5D=0&images%5B1%5D%5Bid%5D=img2&images%5B1%5D%5Bposition%5D=1"
     )
   })
 })

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -82,10 +82,10 @@ export const toQueryString = (options = {}) => {
   // @ts-ignore
   return options.batched || optionsIncludeArray
     ? stringify(options, {
-        arrayFormat: "brackets",
+        arrayFormat: "indices",
       })
     : stringify(options, {
-        arrayFormat: "brackets",
+        arrayFormat: "indices",
         sort: (a, b) => a.localeCompare(b),
       })
 }


### PR DESCRIPTION
### Description

While working on https://github.com/artsy/metaphysics/pull/7001, noticed a fundamental limitation in sending data to gravity, in that we could only handle simple serialization, so anything more complex like 
```
foo: [
  { position: 0 },
  { position: 1 }
]
```

would fail with a 400. 

The fix was simple: use the `indices` format instead of `brackets` [format](https://github.com/ljharb/qs?tab=readme-ov-file#stringifying) which ultimately end up deserializing back into the same JSON structure. Example:

- ids[]=13&ids[]=27 → {ids: ["13", "27"]}
- ids[0]=13&ids[1]=27 → {ids: ["13", "27"]}

Once this fix was in, I could successfully send this mutation:

```graphql
mutation {
  updateArtworkImportRowImages(
    input: {
      artworkImportID: "648e4d88-2ddf-4500-a295-b67760a4e5f6"
      images: [
        { id: "1bd4407a-90d6-4972-8cc0-c805a2dc9c31", position: 3 }
        { id: "a5458866-d25b-4cab-9745-44607abad42d", position: 2 }
        { id: "bb874e9c-b33e-47d7-8613-668dcb180359", position: 1 }
      ]
    }
  ) {
    updateArtworkImportRowImagesOrError {
      ... on UpdateArtworkImportRowImagesSuccess {
        artworkImportID
      }
      
      ... on UpdateArtworkImportRowImagesFailure {
        mutationError {
          error
          detail
          message
          statusCode
        }
      }
    }
  }
}
```

Tagging a few folks because this is a fairly sensitive change that is low in our stack. 

Issues of this kind (arrays of various shapes being sent over the wire) has come up a few times over the years and its always confusing; this should fix it so that we can now send any shape of JSON and solve the issue for good. 