### PR TITLE
fix: Simplify batch image position mutation for Gravity API compatibility

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13673,14 +13673,6 @@ type ImageEdge {
   node: Image
 }
 
-input ImagePositionInput {
-  # The ID of the image to update
-  id: String!
-
-  # The new position for the image (0-based)
-  position: Int!
-}
-
 type ImageURLs {
   normalized: String
 }
@@ -23050,8 +23042,8 @@ input UpdateArtworkImportRowImagesInput {
   artworkImportID: String!
   clientMutationId: String
 
-  # Array of image position updates
-  images: [ImagePositionInput!]!
+  # Array of image IDs in desired position order
+  positions: [String!]!
 }
 
 type UpdateArtworkImportRowImagesPayload {

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
@@ -18,11 +18,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
         updateArtworkImportRowImages(
           input: {
             artworkImportID: "artwork-import-1"
-            images: [
-              { id: "image-1", position: 2 }
-              { id: "image-2", position: 1 }
-              { id: "image-3", position: 0 }
-            ]
+            positions: ["image-3", "image-2", "image-1"]
           }
         ) {
           updateArtworkImportRowImagesOrError {
@@ -45,11 +41,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
       "artwork-import-1",
       {
-        images: [
-          { id: "image-1", position: 2 },
-          { id: "image-2", position: 1 },
-          { id: "image-3", position: 0 },
-        ],
+        positions: ["image-3", "image-2", "image-1"],
       }
     )
 
@@ -72,10 +64,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     const mutation = gql`
       mutation {
         updateArtworkImportRowImages(
-          input: {
-            artworkImportID: "artwork-import-1"
-            images: [{ id: "image-1", position: 3 }]
-          }
+          input: { artworkImportID: "artwork-import-1", positions: ["image-1"] }
         ) {
           updateArtworkImportRowImagesOrError {
             ... on UpdateArtworkImportRowImagesSuccess {
@@ -97,7 +86,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
       "artwork-import-1",
       {
-        images: [{ id: "image-1", position: 3 }],
+        positions: ["image-1"],
       }
     )
 
@@ -118,10 +107,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     const mutation = gql`
       mutation {
         updateArtworkImportRowImages(
-          input: {
-            artworkImportID: "artwork-import-1"
-            images: [{ id: "image-1", position: 5 }]
-          }
+          input: { artworkImportID: "artwork-import-1", positions: ["image-1"] }
         ) {
           updateArtworkImportRowImagesOrError {
             ... on UpdateArtworkImportRowImagesSuccess {

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
@@ -3,9 +3,7 @@ import {
   GraphQLObjectType,
   GraphQLUnionType,
   GraphQLNonNull,
-  GraphQLInt,
   GraphQLList,
-  GraphQLInputObjectType,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
@@ -14,20 +12,6 @@ import {
   GravityMutationErrorType,
 } from "lib/gravityErrorHandler"
 import { ArtworkImportType } from "./artworkImport"
-
-const ImagePositionInputType = new GraphQLInputObjectType({
-  name: "ImagePositionInput",
-  fields: {
-    id: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The ID of the image to update",
-    },
-    position: {
-      type: new GraphQLNonNull(GraphQLInt),
-      description: "The new position for the image (0-based)",
-    },
-  },
-})
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "UpdateArtworkImportRowImagesSuccess",
@@ -72,11 +56,11 @@ export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId
     artworkImportID: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    images: {
+    positions: {
       type: new GraphQLNonNull(
-        new GraphQLList(new GraphQLNonNull(ImagePositionInputType))
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
       ),
-      description: "Array of image position updates",
+      description: "Array of image IDs in desired position order",
     },
   },
   outputFields: {
@@ -86,7 +70,7 @@ export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId
     },
   },
   mutateAndGetPayload: async (
-    { artworkImportID, images },
+    { artworkImportID, positions },
     { artworkImportBatchUpdateImageMatchesLoader }
   ) => {
     if (!artworkImportBatchUpdateImageMatchesLoader) {
@@ -95,7 +79,7 @@ export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId
 
     try {
       await artworkImportBatchUpdateImageMatchesLoader(artworkImportID, {
-        images,
+        positions,
       })
 
       return {


### PR DESCRIPTION
Related:
- https://github.com/artsy/gravity/pull/19229

### Description

Updates the batch image position mutation to align with simplified Gravity API, addressing GraphQL serialization issues with nested objects in array parameters.

#### Changes
- Simplified `updateArtworkImportRowImages` input to accept flat array of image IDs
- Position determined by array order (0-based indexing) instead of explicit position values
- Updated tests to reflect new API format

#### API Usage

```graphql
mutation {
  updateArtworkImportRowImages(
    input: {
      artworkImportID: "artwork-import-1"
      positions: ["imageID-3", "imageID-2", "imageID-1"]
    }
  )
}
```

cc @artsy/amber-devs