### PR TITLE
feat(batch-edit): Support Certificate of Authenticity related boolean fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4683,9 +4683,6 @@ input BulkUpdateArtworksMetadataInput {
   # The category (medium type) to be assigned
   category: String
 
-  # Whether a certificate of authenticity is provided for these artworks.
-  certificateOfAuthenticity: Boolean
-
   # If COA is provided by a third-party authenticating body.
   coaByAuthenticatingBody: Boolean
 
@@ -4703,6 +4700,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # The exhibition history to be assigned
   exhibitionHistory: String
+
+  # Whether a certificate of authenticity is provided for these artworks.
+  hasCertificateOfAuthenticity: Boolean
 
   # The image rights to be assigned
   imageRights: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4683,6 +4683,15 @@ input BulkUpdateArtworksMetadataInput {
   # The category (medium type) to be assigned
   category: String
 
+  # Whether a certificate of authenticity is provided for these artworks.
+  certificateOfAuthenticity: Boolean
+
+  # If COA is provided by a third-party authenticating body.
+  coaByAuthenticatingBody: Boolean
+
+  # If COA is provided by the gallery.
+  coaByGallery: Boolean
+
   # The artwork condition to be assigned
   conditionDescription: String
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -12,6 +12,9 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           metadata: {
             artistIds: ["artist1", "artist2"]
             availability: SOLD
+            certificateOfAuthenticity: true
+            coaByGallery: true
+            coaByAuthenticatingBody: null
             conditionDescription: "Excellent"
             domesticShippingFeeCents: 20000
             locationId: "location456"
@@ -78,6 +81,9 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           artist_ids: ["artist1", "artist2"],
           condition_description: "Excellent",
           availability: "sold",
+          certificate_of_authenticity: true,
+          coa_by_gallery: true,
+          coa_by_authenticating_body: null,
           domestic_shipping_fee_cents: 20000,
           location_id: "location456",
           category: "Painting",

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -12,7 +12,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           metadata: {
             artistIds: ["artist1", "artist2"]
             availability: SOLD
-            certificateOfAuthenticity: true
+            hasCertificateOfAuthenticity: true
             coaByGallery: true
             coaByAuthenticatingBody: null
             conditionDescription: "Excellent"

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -26,6 +26,9 @@ interface Input {
     artistIds?: string[]
     availability?: string
     category?: string
+    certificateOfAuthenticity?: boolean
+    coaByGallery?: boolean
+    coaByAuthenticatingBody?: boolean
     conditionDescription?: string
     domesticShippingFeeCents?: number
     ecommerce: boolean
@@ -65,6 +68,19 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     category: {
       type: GraphQLString,
       description: "The category (medium type) to be assigned",
+    },
+    certificateOfAuthenticity: {
+      type: GraphQLBoolean,
+      description:
+        "Whether a certificate of authenticity is provided for these artworks.",
+    },
+    coaByGallery: {
+      type: GraphQLBoolean,
+      description: "If COA is provided by the gallery.",
+    },
+    coaByAuthenticatingBody: {
+      type: GraphQLBoolean,
+      description: "If COA is provided by a third-party authenticating body.",
     },
     conditionDescription: {
       type: GraphQLString,
@@ -244,6 +260,9 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         artist_ids: metadata.artistIds,
         availability: metadata.availability,
         category: metadata.category,
+        certificate_of_authenticity: metadata.certificateOfAuthenticity,
+        coa_by_gallery: metadata.coaByGallery,
+        coa_by_authenticating_body: metadata.coaByAuthenticatingBody,
         condition_description: metadata.conditionDescription,
         domestic_shipping_fee_cents: metadata.domesticShippingFeeCents,
         ecommerce: metadata.ecommerce,

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -26,7 +26,7 @@ interface Input {
     artistIds?: string[]
     availability?: string
     category?: string
-    certificateOfAuthenticity?: boolean
+    hasCertificateOfAuthenticity?: boolean
     coaByGallery?: boolean
     coaByAuthenticatingBody?: boolean
     conditionDescription?: string
@@ -69,7 +69,7 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "The category (medium type) to be assigned",
     },
-    certificateOfAuthenticity: {
+    hasCertificateOfAuthenticity: {
       type: GraphQLBoolean,
       description:
         "Whether a certificate of authenticity is provided for these artworks.",
@@ -260,7 +260,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         artist_ids: metadata.artistIds,
         availability: metadata.availability,
         category: metadata.category,
-        certificate_of_authenticity: metadata.certificateOfAuthenticity,
+        certificate_of_authenticity: metadata.hasCertificateOfAuthenticity,
         coa_by_gallery: metadata.coaByGallery,
         coa_by_authenticating_body: metadata.coaByAuthenticatingBody,
         condition_description: metadata.conditionDescription,


### PR DESCRIPTION
feat: Support Certificate of Authenticity related boolean fields in Batch edits

Exposes the backend logic [here](https://github.com/artsy/gravity/blob/main/app/services/partner_artworks/batch_edit_builder_service.rb#L10-L30)

Allows client to send over values for
- certificate of authenticity
- coa by gallery
- coa by 3rd party

AKA: These boolean fields on the artwork form:
<img width="1511" height="768" alt="Screenshot 2025-08-12 at 2 34 00 PM" src="https://github.com/user-attachments/assets/3e86d346-36d2-4616-8387-382cd0843baf" />



cc @artsy/amber-devs 