### PR TITLE
feat: Update artwork import image mutations for row-scoped API

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20584,6 +20584,9 @@ input RemoveArtworkImportImageInput {
   artworkImportID: String!
   clientMutationId: String
   imageID: String!
+
+  # The ID of the row containing the image
+  rowID: String!
 }
 
 type RemoveArtworkImportImagePayload {
@@ -23054,8 +23057,11 @@ input UpdateArtworkImportRowImagesInput {
   artworkImportID: String!
   clientMutationId: String
 
+  # The ID of the row to update images for
+  rowID: String!
+
   # Array of image IDs in desired position order
-  positions: [String!]!
+  sortedImageIDs: [String!]!
 }
 
 type UpdateArtworkImportRowImagesPayload {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -119,10 +119,10 @@ export default (accessToken, userID, opts) => {
     ),
     artworkImportRemoveImageLoader: gravityLoader<
       any,
-      { artworkImportID: string; imageID: string }
+      { artworkImportID: string; rowID: string; imageID: string }
     >(
-      ({ artworkImportID, imageID }) =>
-        `artwork_import/${artworkImportID}/image/${imageID}`,
+      ({ artworkImportID, rowID, imageID }) =>
+        `artwork_import/${artworkImportID}/row/${rowID}/images/${imageID}`,
       {},
       { method: "DELETE" }
     ),
@@ -181,8 +181,12 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
-    artworkImportBatchUpdateImageMatchesLoader: gravityLoader(
-      (id) => `artwork_import/${id}/image_matches`,
+    artworkImportUpdateRowImagesLoader: gravityLoader<
+      any,
+      { artworkImportID: string; rowID: string }
+    >(
+      ({ artworkImportID, rowID }) =>
+        `artwork_import/${artworkImportID}/row/${rowID}/images`,
       {},
       { method: "PUT" }
     ),

--- a/src/schema/v2/ArtworkImport/__tests__/removeArtworkImportImageMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/removeArtworkImportImageMutation.test.ts
@@ -10,7 +10,11 @@ describe("RemoveArtworkImportImageMutation", () => {
     const mutation = gql`
       mutation {
         removeArtworkImportImage(
-          input: { artworkImportID: "artwork-import-1", imageID: "image-123" }
+          input: {
+            artworkImportID: "artwork-import-1"
+            rowID: "row-1"
+            imageID: "image-123"
+          }
         ) {
           removeArtworkImportImageOrError {
             ... on RemoveArtworkImportImageSuccess {
@@ -28,6 +32,7 @@ describe("RemoveArtworkImportImageMutation", () => {
 
     expect(artworkImportRemoveImageLoader).toHaveBeenCalledWith({
       artworkImportID: "artwork-import-1",
+      rowID: "row-1",
       imageID: "image-123",
     })
 
@@ -52,6 +57,7 @@ describe("RemoveArtworkImportImageMutation", () => {
         removeArtworkImportImage(
           input: {
             artworkImportID: "artwork-import-1"
+            rowID: "row-1"
             imageID: "nonexistent-image"
           }
         ) {
@@ -73,6 +79,7 @@ describe("RemoveArtworkImportImageMutation", () => {
 
     expect(artworkImportRemoveImageLoader).toHaveBeenCalledWith({
       artworkImportID: "artwork-import-1",
+      rowID: "row-1",
       imageID: "nonexistent-image",
     })
 

--- a/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/updateArtworkImportRowImagesMutation.test.ts
@@ -3,22 +3,21 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("UpdateArtworkImportRowImagesMutation", () => {
   it("updates multiple image positions", async () => {
-    const artworkImportBatchUpdateImageMatchesLoader = jest
-      .fn()
-      .mockResolvedValue({
-        images: [
-          { id: "image-1", position: 2 },
-          { id: "image-2", position: 1 },
-          { id: "image-3", position: 0 },
-        ],
-      })
+    const artworkImportUpdateRowImagesLoader = jest.fn().mockResolvedValue({
+      images: [
+        { id: "image-3", position: 0 },
+        { id: "image-2", position: 1 },
+        { id: "image-1", position: 2 },
+      ],
+    })
 
     const mutation = gql`
       mutation {
         updateArtworkImportRowImages(
           input: {
             artworkImportID: "artwork-import-1"
-            positions: ["image-3", "image-2", "image-1"]
+            rowID: "row-1"
+            sortedImageIDs: ["image-3", "image-2", "image-1"]
           }
         ) {
           updateArtworkImportRowImagesOrError {
@@ -31,17 +30,17 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     `
 
     const context = {
-      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportUpdateRowImagesLoader,
       artworkImportLoader: jest
         .fn()
         .mockResolvedValue({ id: "artwork-import-1" }),
     }
     const result = await runAuthenticatedQuery(mutation, context)
 
-    expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
-      "artwork-import-1",
+    expect(artworkImportUpdateRowImagesLoader).toHaveBeenCalledWith(
+      { artworkImportID: "artwork-import-1", rowID: "row-1" },
       {
-        positions: ["image-3", "image-2", "image-1"],
+        sorted_image_ids: ["image-3", "image-2", "image-1"],
       }
     )
 
@@ -55,16 +54,18 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
   })
 
   it("handles single image in batch", async () => {
-    const artworkImportBatchUpdateImageMatchesLoader = jest
-      .fn()
-      .mockResolvedValue({
-        images: [{ id: "image-1", position: 3 }],
-      })
+    const artworkImportUpdateRowImagesLoader = jest.fn().mockResolvedValue({
+      images: [{ id: "image-1", position: 0 }],
+    })
 
     const mutation = gql`
       mutation {
         updateArtworkImportRowImages(
-          input: { artworkImportID: "artwork-import-1", positions: ["image-1"] }
+          input: {
+            artworkImportID: "artwork-import-1"
+            rowID: "row-1"
+            sortedImageIDs: ["image-1"]
+          }
         ) {
           updateArtworkImportRowImagesOrError {
             ... on UpdateArtworkImportRowImagesSuccess {
@@ -76,17 +77,17 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     `
 
     const context = {
-      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportUpdateRowImagesLoader,
       artworkImportLoader: jest
         .fn()
         .mockResolvedValue({ id: "artwork-import-1" }),
     }
     const result = await runAuthenticatedQuery(mutation, context)
 
-    expect(artworkImportBatchUpdateImageMatchesLoader).toHaveBeenCalledWith(
-      "artwork-import-1",
+    expect(artworkImportUpdateRowImagesLoader).toHaveBeenCalledWith(
+      { artworkImportID: "artwork-import-1", rowID: "row-1" },
       {
-        positions: ["image-1"],
+        sorted_image_ids: ["image-1"],
       }
     )
 
@@ -100,14 +101,18 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
   })
 
   it("returns an error when loader throws", async () => {
-    const artworkImportBatchUpdateImageMatchesLoader = jest
+    const artworkImportUpdateRowImagesLoader = jest
       .fn()
       .mockRejectedValue(new Error("Batch update failed"))
 
     const mutation = gql`
       mutation {
         updateArtworkImportRowImages(
-          input: { artworkImportID: "artwork-import-1", positions: ["image-1"] }
+          input: {
+            artworkImportID: "artwork-import-1"
+            rowID: "row-1"
+            sortedImageIDs: ["image-1"]
+          }
         ) {
           updateArtworkImportRowImagesOrError {
             ... on UpdateArtworkImportRowImagesSuccess {
@@ -119,7 +124,7 @@ describe("UpdateArtworkImportRowImagesMutation", () => {
     `
 
     const context = {
-      artworkImportBatchUpdateImageMatchesLoader,
+      artworkImportUpdateRowImagesLoader,
       artworkImportLoader: jest
         .fn()
         .mockResolvedValue({ id: "artwork-import-1" }),

--- a/src/schema/v2/ArtworkImport/removeArtworkImportImageMutation.ts
+++ b/src/schema/v2/ArtworkImport/removeArtworkImportImageMutation.ts
@@ -57,6 +57,10 @@ export const RemoveArtworkImportImageMutation = mutationWithClientMutationId<
     artworkImportID: {
       type: new GraphQLNonNull(GraphQLString),
     },
+    rowID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the row containing the image",
+    },
     imageID: {
       type: new GraphQLNonNull(GraphQLString),
     },
@@ -68,7 +72,7 @@ export const RemoveArtworkImportImageMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkImportID, imageID },
+    { artworkImportID, rowID, imageID },
     { artworkImportRemoveImageLoader }
   ) => {
     if (!artworkImportRemoveImageLoader) {
@@ -79,6 +83,7 @@ export const RemoveArtworkImportImageMutation = mutationWithClientMutationId<
       return {
         ...(await artworkImportRemoveImageLoader({
           artworkImportID,
+          rowID,
           imageID,
         })),
         artworkImportID,

--- a/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
+++ b/src/schema/v2/ArtworkImport/updateArtworkImportRowImagesMutation.ts
@@ -56,7 +56,11 @@ export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId
     artworkImportID: {
       type: new GraphQLNonNull(GraphQLString),
     },
-    positions: {
+    rowID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the row to update images for",
+    },
+    sortedImageIDs: {
       type: new GraphQLNonNull(
         new GraphQLList(new GraphQLNonNull(GraphQLString))
       ),
@@ -70,17 +74,20 @@ export const UpdateArtworkImportRowImagesMutation = mutationWithClientMutationId
     },
   },
   mutateAndGetPayload: async (
-    { artworkImportID, positions },
-    { artworkImportBatchUpdateImageMatchesLoader }
+    { artworkImportID, rowID, sortedImageIDs },
+    { artworkImportUpdateRowImagesLoader }
   ) => {
-    if (!artworkImportBatchUpdateImageMatchesLoader) {
+    if (!artworkImportUpdateRowImagesLoader) {
       throw new Error("This operation requires an `X-Access-Token` header.")
     }
 
     try {
-      await artworkImportBatchUpdateImageMatchesLoader(artworkImportID, {
-        positions,
-      })
+      await artworkImportUpdateRowImagesLoader(
+        { artworkImportID, rowID },
+        {
+          sorted_image_ids: sortedImageIDs,
+        }
+      )
 
       return {
         artworkImportID,


### PR DESCRIPTION
Related:
- https://github.com/artsy/gravity/pull/19232

### Description

Updates artwork import image mutations to align with refactored Gravity API that migrates image operations from import-level to row-level scoping.

#### Changes
- Updated `updateArtworkImportRowImages` mutation to use row-scoped endpoint
- Updated `removeArtworkImportImage` mutation to use row-scoped endpoint  
- Added required `rowID` parameter to both mutations
- Changed `positions` to `sortedImageIDs` for batch updates
- Updated loaders and tests for new API structure

#### API Usage

```graphql
mutation {
  updateArtworkImportRowImages(
    input: {
      artworkImportID: "artwork-import-1"
      rowID: "row-1"
      sortedImageIDs: ["image-3", "image-2", "image-1"]
    }
  )
}
```

cc @artsy/amber-devs