### PR TITLE
feat(onyx-1874): NWFY - create view frequency penalty experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -15,8 +15,8 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-quick-links-v2",
   "onyx_enable-home-view-auction-segmentation",
   "onyx_enable-quick-links-price-budget",
-  "onyx_nwfy-at-risk-gallery-boost-experiment",
   "onyx_based_on_your_saves_home_view_section",
+  "onyx_nwfy-view-frequency-penalty-experiment",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,5 +6,5 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
-  "onyx_nwfy-at-risk-gallery-boost-experiment",
+  "onyx_nwfy-view-frequency-penalty-experiment",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -22,7 +22,7 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
     const variant = getExperimentVariant(
-      "onyx_nwfy-at-risk-gallery-boost-experiment",
+      "onyx_nwfy-view-frequency-penalty-experiment",
       {
         userId: context.userID,
       }

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -71,7 +71,7 @@ describe("NewWorksForYou", () => {
     // see artworksForUser.test.ts
   })
 
-  describe("when the onyx_nwfy-at-risk-gallery-boost-experiment experiment is enabled", () => {
+  describe("when the onyx_nwfy-view-frequency-penalty-experiment experiment is enabled", () => {
     it("serves Version C to the control group", async () => {
       mockGetExperimentVariant.mockImplementation(() => ({
         name: "control",


### PR DESCRIPTION
We open a new experiment for the [view frequency penalty](https://github.com/artsy/zenith/pull/546). You can find an Unleash feature flag [here](https://unleash.artsy.net/projects/default/features/onyx_nwfy-view-frequency-penalty-experiment).