### PR TITLE
feat(partner): Add assignArtistToPartnerMutation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Imperative Instructions!
+
+- In almost all instances where a query returns data from the DB, we do not use an `id` field but rather an `internalID` field. `id` fields are specifically for Relay and bear no relationship to database IDs.
+- Field _arguments_ do frequently use `id` however (eg, `artist(id: "andy-warhol") { ... }`), and the values passed to them can typically be `slug` or `internalID`.
+
 ## Commands
-- Build: `yarn build`
+
+- Starting: `yarn start`
 - Dev server: `yarn dev` or `yarn verbose-dev` for more logs
 - Lint: `yarn lint` (fix with `yarn lint:fix`)
 - Type check: `yarn type-check`
@@ -13,6 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Format code: `yarn prettier-project`
 
 ## Code Style
+
 - TypeScript with strict typing
 - Prettier formatting: no semicolons, double quotes, trailing commas
 - Use camelCase for variables, PascalCase for types/interfaces

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3702,6 +3702,42 @@ enum AssetType {
   IMAGE
 }
 
+type AssignArtistToPartnerFailure {
+  mutationError: GravityMutationError
+}
+
+input AssignArtistToPartnerMutationInput {
+  # The ID of the artist to assign.
+  artistID: String!
+  clientMutationId: String
+
+  # Whether the artist should be featured.
+  featured: Boolean
+
+  # The ID of the partner to assign the artist to.
+  partnerID: String!
+
+  # The URL of the image to use for the partner artist.
+  remoteImageUrl: String
+}
+
+type AssignArtistToPartnerMutationPayload {
+  clientMutationId: String
+
+  # On success: the created partner artist. On error: the error that occurred.
+  partnerArtistOrError: AssignArtistToPartnerResponseOrError
+}
+
+union AssignArtistToPartnerResponseOrError =
+    AssignArtistToPartnerFailure
+  | AssignArtistToPartnerSuccess
+
+type AssignArtistToPartnerSuccess {
+  artist: Artist
+  partner: Partner
+  partnerArtist: PartnerArtist
+}
+
 type AssignArtworkImportArtistFailure {
   mutationError: GravityMutationError
 }
@@ -15444,6 +15480,11 @@ type Mutation {
   artworksCollectionsBatchUpdate(
     input: ArtworksCollectionsBatchUpdateInput!
   ): ArtworksCollectionsBatchUpdatePayload
+
+  # Assigns an artist to a partner, creating a PartnerArtist record.
+  assignArtistToPartner(
+    input: AssignArtistToPartnerMutationInput!
+  ): AssignArtistToPartnerMutationPayload
   assignArtworkImportArtist(
     input: AssignArtworkImportArtistInput!
   ): AssignArtworkImportArtistPayload

--- a/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/assignArtistToPartnerMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/__tests__/assignArtistToPartnerMutation.test.ts
@@ -1,0 +1,94 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("AssignArtistToPartnerMutation", () => {
+  const mutation = gql`
+    mutation {
+      assignArtistToPartner(
+        input: {
+          artistID: "artist-123"
+          partnerID: "partner-456"
+          featured: true
+          remoteImageUrl: "https://example.com/image.jpg"
+        }
+      ) {
+        partnerArtistOrError {
+          __typename
+          ... on AssignArtistToPartnerSuccess {
+            partnerArtist {
+              internalID
+            }
+            artist {
+              internalID
+            }
+            partner {
+              name
+            }
+          }
+          ... on AssignArtistToPartnerFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("assigns an artist to a partner successfully", async () => {
+    const partnerArtistResponse = {
+      id: "partner-artist-789",
+      artist: {
+        id: "artist-123",
+        _id: "artist-123",
+      },
+      partner: {
+        name: "Test Partner",
+      },
+    }
+
+    const context = {
+      createPartnerArtistLoader: () => Promise.resolve(partnerArtistResponse),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      assignArtistToPartner: {
+        partnerArtistOrError: {
+          __typename: "AssignArtistToPartnerSuccess",
+          partnerArtist: {
+            internalID: "partner-artist-789",
+          },
+          artist: {
+            internalID: "artist-123",
+          },
+          partner: {
+            name: "Test Partner",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws an error when the loader fails", async () => {
+    const context = {
+      createPartnerArtistLoader: () =>
+        Promise.reject(new Error("Artist not found")),
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Artist not found"
+    )
+  })
+
+  it("throws an error when user is not authenticated", async () => {
+    const context: any = {
+      createPartnerArtistLoader: null,
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "You need to be logged in to perform this action"
+    )
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerArtist/assignArtistToPartnerMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerArtist/assignArtistToPartnerMutation.ts
@@ -1,0 +1,125 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerArtistType } from "../../partner_artist"
+import { ArtistType } from "../../../artist"
+import { PartnerType } from "../../partner"
+
+interface AssignArtistToPartnerMutationInputProps {
+  artistID: string
+  partnerID: string
+  featured?: boolean
+  remoteImageUrl?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AssignArtistToPartnerSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerArtist: {
+      type: PartnerArtistType,
+      resolve: (result) => result,
+    },
+    artist: {
+      type: ArtistType,
+      resolve: ({ artist }) => artist,
+    },
+    partner: {
+      type: PartnerType,
+      resolve: ({ partner }) => partner,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AssignArtistToPartnerFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "AssignArtistToPartnerResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const assignArtistToPartnerMutation = mutationWithClientMutationId<
+  AssignArtistToPartnerMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "AssignArtistToPartnerMutation",
+  description:
+    "Assigns an artist to a partner, creating a PartnerArtist record.",
+  inputFields: {
+    artistID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artist to assign.",
+    },
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner to assign the artist to.",
+    },
+    featured: {
+      type: GraphQLBoolean,
+      description: "Whether the artist should be featured.",
+    },
+    remoteImageUrl: {
+      type: GraphQLString,
+      description: "The URL of the image to use for the partner artist.",
+    },
+  },
+  outputFields: {
+    partnerArtistOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the created partner artist. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artistID, partnerID, featured, remoteImageUrl },
+    { createPartnerArtistLoader }
+  ) => {
+    if (!createPartnerArtistLoader) {
+      throw new Error("You need to be logged in to perform this action")
+    }
+
+    const gravityArgs: {
+      featured?: boolean
+      remote_image_url?: string
+    } = {
+      featured,
+      remote_image_url: remoteImageUrl,
+    }
+
+    try {
+      const partnerArtist = await createPartnerArtistLoader(
+        { artistID, partnerID },
+        gravityArgs
+      )
+      return partnerArtist
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -267,6 +267,7 @@ import { deletePartnerArtistDocumentMutation } from "./partner/Mutations/Partner
 import { deletePartnerArtistMutation } from "./partner/Mutations/PartnerArtist/deletePartnerArtistMutation"
 import { repositionPartnerArtistArtworksMutation } from "./partner/Mutations/PartnerArtist/repositionPartnerArtistArtworksMutation"
 import { updatePartnerArtistDocumentMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistDocumentMutation"
+import { assignArtistToPartnerMutation } from "./partner/Mutations/PartnerArtist/assignArtistToPartnerMutation"
 import { updatePartnerArtistMutation } from "./partner/Mutations/PartnerArtist/updatePartnerArtistMutation"
 import { VerifyUser } from "./verifyUser"
 import { ArtistSeries, ArtistSeriesConnection } from "./artistSeries"
@@ -680,6 +681,7 @@ export default new GraphQLSchema({
       updateSaleAgreement: UpdateSaleAgreementMutation,
       updateSmsSecondFactor: updateSmsSecondFactorMutation,
       updateInstallShotForPartnerShow: updateInstallShotForPartnerShowMutation,
+      assignArtistToPartner: assignArtistToPartnerMutation,
       updatePartnerArtist: updatePartnerArtistMutation,
       updatePartnerArtistDocument: updatePartnerArtistDocumentMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,


### PR DESCRIPTION
This adds a new mutation for assigning an artist to a partner for flows like:
- Add Artist
- Search > Andy Warhol (already exists)
- Submit > assign andy warhol to gagosian 

```graphql
mutation {
  assignArtistToPartner(input: {artistID: "andrea-barzaghi", partnerID: "gagosian", featured: true, remoteImageUrl: "https://example.com/artist-image.jpg"}) {
    partnerArtistOrError {
      __typename
      ... on AssignArtistToPartnerSuccess {
        partnerArtist {
          internalID
          representedBy
          isDisplayOnPartnerProfile
        }
        artist {
          internalID
          name
        }
        partner {
          internalID
          name
        }
      }
      ... on AssignArtistToPartnerFailure {
        mutationError {
          message
          type
        }
      }
    }
  }
}
```

cc @artsy/amber-devs 