### PR TITLE
feat(imports): Add batch matchArtworkImportImages mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14586,6 +14586,46 @@ type MatchArtworkImportArtistsSuccess {
   unmatched: Int!
 }
 
+type MatchArtworkImportImagesFailure {
+  mutationError: GravityMutationError
+}
+
+input MatchArtworkImportImagesImageInput {
+  # The image filename
+  fileName: String!
+
+  # S3 bucket of the uploaded image asset
+  s3Bucket: String!
+
+  # S3 key of the uploaded image asset
+  s3Key: String!
+}
+
+input MatchArtworkImportImagesInput {
+  artworkImportID: String!
+  clientMutationId: String
+
+  # Array of image objects to match
+  images: [MatchArtworkImportImagesImageInput!]!
+
+  # ID of the row to associate the images with (required if images don't already exist)
+  rowID: String
+}
+
+type MatchArtworkImportImagesPayload {
+  clientMutationId: String
+  matchArtworkImportImagesOrError: MatchArtworkImportImagesResponseOrError
+}
+
+union MatchArtworkImportImagesResponseOrError =
+    MatchArtworkImportImagesFailure
+  | MatchArtworkImportImagesSuccess
+
+type MatchArtworkImportImagesSuccess {
+  artworkImport: ArtworkImport
+  success: Boolean!
+}
+
 type MatchArtworkImportRowImageFailure {
   mutationError: GravityMutationError
 }
@@ -16115,6 +16155,9 @@ type Mutation {
   matchArtworkImportArtists(
     input: MatchArtworkImportArtistsInput!
   ): MatchArtworkImportArtistsPayload
+  matchArtworkImportImages(
+    input: MatchArtworkImportImagesInput!
+  ): MatchArtworkImportImagesPayload
   matchArtworkImportRowImage(
     input: MatchArtworkImportRowImageInput!
   ): MatchArtworkImportRowImagePayload

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -112,6 +112,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    artworkImportMatchImagesLoader: gravityLoader(
+      (id) => `artwork_import/${id}/match_images`,
+      {},
+      { method: "PUT" }
+    ),
     artworkImportRowMatchImageLoader: gravityLoader(
       (id) => `artwork_import/${id}/match_image`,
       {},

--- a/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportImagesMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportImagesMutation.test.ts
@@ -1,0 +1,174 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("MatchArtworkImportImagesMutation", () => {
+  it("matches multiple images for a row", async () => {
+    const artworkImportMatchImagesLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        matchArtworkImportImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [
+              {
+                fileName: "cat.jpg"
+                s3Key: "/some/path/cat.jpg"
+                s3Bucket: "someBucket"
+              }
+              {
+                fileName: "dog.jpg"
+                s3Key: "/some/path/dog.jpg"
+                s3Bucket: "someBucket"
+              }
+            ]
+            rowID: "row-1"
+          }
+        ) {
+          matchArtworkImportImagesOrError {
+            ... on MatchArtworkImportImagesSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportMatchImagesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportMatchImagesLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        images: [
+          {
+            file_name: "cat.jpg",
+            s3_key: "/some/path/cat.jpg",
+            s3_bucket: "someBucket",
+          },
+          {
+            file_name: "dog.jpg",
+            s3_key: "/some/path/dog.jpg",
+            s3_bucket: "someBucket",
+          },
+        ],
+        row_id: "row-1",
+      }
+    )
+
+    expect(result).toEqual({
+      matchArtworkImportImages: {
+        matchArtworkImportImagesOrError: {
+          success: true,
+        },
+      },
+    })
+  })
+
+  it("matches multiple images without rowID", async () => {
+    const artworkImportMatchImagesLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-id",
+    })
+
+    const mutation = gql`
+      mutation {
+        matchArtworkImportImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [
+              {
+                fileName: "existing.jpg"
+                s3Key: "/new/path/existing.jpg"
+                s3Bucket: "newBucket"
+              }
+            ]
+          }
+        ) {
+          matchArtworkImportImagesOrError {
+            ... on MatchArtworkImportImagesSuccess {
+              success
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportMatchImagesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(artworkImportMatchImagesLoader).toHaveBeenCalledWith(
+      "artwork-import-1",
+      {
+        images: [
+          {
+            file_name: "existing.jpg",
+            s3_key: "/new/path/existing.jpg",
+            s3_bucket: "newBucket",
+          },
+        ],
+      }
+    )
+
+    expect(result).toEqual({
+      matchArtworkImportImages: {
+        matchArtworkImportImagesOrError: {
+          success: true,
+        },
+      },
+    })
+  })
+
+  it("handles errors gracefully", async () => {
+    const artworkImportMatchImagesLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Service error"))
+
+    const mutation = gql`
+      mutation {
+        matchArtworkImportImages(
+          input: {
+            artworkImportID: "artwork-import-1"
+            images: [
+              {
+                fileName: "test.jpg"
+                s3Key: "/path/test.jpg"
+                s3Bucket: "bucket"
+              }
+            ]
+          }
+        ) {
+          matchArtworkImportImagesOrError {
+            ... on MatchArtworkImportImagesFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      artworkImportMatchImagesLoader,
+      artworkImportLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "artwork-import-1" }),
+    }
+
+    await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+      "Service error"
+    )
+  })
+})

--- a/src/schema/v2/ArtworkImport/matchArtworkImportImagesMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportImagesMutation.ts
@@ -1,0 +1,129 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLInputObjectType,
+  GraphQLBoolean,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtworkImportType } from "./artworkImport"
+
+const ImageInputType = new GraphQLInputObjectType({
+  name: "MatchArtworkImportImagesImageInput",
+  fields: {
+    fileName: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The image filename",
+    },
+    s3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 key of the uploaded image asset",
+    },
+    s3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 bucket of the uploaded image asset",
+    },
+  },
+})
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MatchArtworkImportImagesSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    success: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: () => true,
+    },
+    artworkImport: {
+      type: ArtworkImportType,
+      resolve: ({ artworkImportID }, _args, { artworkImportLoader }) => {
+        if (!artworkImportLoader) return null
+        return artworkImportLoader(artworkImportID)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "MatchArtworkImportImagesFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "MatchArtworkImportImagesResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const MatchArtworkImportImagesMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "MatchArtworkImportImages",
+  inputFields: {
+    artworkImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    images: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ImageInputType))
+      ),
+      description: "Array of image objects to match",
+    },
+    rowID: {
+      type: GraphQLString,
+      description:
+        "ID of the row to associate the images with (required if images don't already exist)",
+    },
+  },
+  outputFields: {
+    matchArtworkImportImagesOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkImportID, images, rowID },
+    { artworkImportMatchImagesLoader }
+  ) => {
+    if (!artworkImportMatchImagesLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    const gravityArgs = {
+      images: images.map(({ fileName, s3Key, s3Bucket }) => ({
+        file_name: fileName,
+        s3_key: s3Key,
+        s3_bucket: s3Bucket,
+      })),
+      ...(rowID && { row_id: rowID }),
+    }
+
+    try {
+      return {
+        ...(await artworkImportMatchImagesLoader(artworkImportID, gravityArgs)),
+        artworkImportID,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -325,6 +325,7 @@ import { UpdateArtworkImportWeightMetricMutation } from "./ArtworkImport/updateA
 import { ToggleArtworkImportRowExclusionMutation } from "./ArtworkImport/toggleArtworkImportRowExclusionMutation"
 import { FlagArtworkImportCellMutation } from "./ArtworkImport/flagArtworkImportCellMutation"
 import { MatchArtworkImportRowImageMutation } from "./ArtworkImport/matchArtworkImportRowImageMutation"
+import { MatchArtworkImportImagesMutation } from "./ArtworkImport/matchArtworkImportImagesMutation"
 import { RemoveArtworkImportImageMutation } from "./ArtworkImport/removeArtworkImportImageMutation"
 import { FeaturedFairs } from "./FeaturedFairs/featuredFairs"
 import { CancelArtworkImportMutation } from "./ArtworkImport/cancelArtworkImportMutation"
@@ -613,6 +614,7 @@ export default new GraphQLSchema({
       markNotificationsAsSeen: markNotificationsAsSeenMutation,
       matchArtworkImportArtists: MatchArtworkImportArtistsMutation,
       matchArtworkImportRowImage: MatchArtworkImportRowImageMutation,
+      matchArtworkImportImages: MatchArtworkImportImagesMutation,
       removeArtworkImportImage: RemoveArtworkImportImageMutation,
       mergeArtists: mergeArtistsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,


### PR DESCRIPTION
⚠️ This wont actually work until https://github.com/artsy/metaphysics/pull/7002 is merged, so lets hold on merging this til then!

### Description

Adds a new `matchArtworkImportImages` mutation that allows matching multiple images in a single request, corresponding to the new `match_images` endpoint added in https://github.com/artsy/gravity/pull/19251.

This provides a more efficient way to match multiple images at once rather than sending individual mutations for each image.

### Example

```graphql
mutation {
  matchArtworkImportImages(
    input: {
      artworkImportID: "artwork-import-1"
      images: [
        {
          fileName: "cat.jpg"
          s3Key: "/some/path/cat.jpg"
          s3Bucket: "someBucket"
        }
        {
          fileName: "dog.jpg"
          s3Key: "/some/path/dog.jpg"
          s3Bucket: "someBucket"
        }
      ]
      rowID: "row-1"
    }
  ) {
    matchArtworkImportImagesOrError {
      ... on MatchArtworkImportImagesSuccess {
        success
      }
    }
  }
}
```

cc @artsy/amber-devs 