### PR TITLE
fix(imports): Row id arg should be image level

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14594,6 +14594,9 @@ input MatchArtworkImportImagesImageInput {
   # The image filename
   fileName: String!
 
+  # ID of the row to associate the images with (required if images don't already exist)
+  rowID: String
+
   # S3 bucket of the uploaded image asset
   s3Bucket: String!
 
@@ -14607,9 +14610,6 @@ input MatchArtworkImportImagesInput {
 
   # Array of image objects to match
   images: [MatchArtworkImportImagesImageInput!]!
-
-  # ID of the row to associate the images with (required if images don't already exist)
-  rowID: String
 }
 
 type MatchArtworkImportImagesPayload {

--- a/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportImagesMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/__tests__/matchArtworkImportImagesMutation.test.ts
@@ -17,14 +17,15 @@ describe("MatchArtworkImportImagesMutation", () => {
                 fileName: "cat.jpg"
                 s3Key: "/some/path/cat.jpg"
                 s3Bucket: "someBucket"
+                rowID: "row-1"
               }
               {
                 fileName: "dog.jpg"
                 s3Key: "/some/path/dog.jpg"
                 s3Bucket: "someBucket"
+                rowID: "row-1"
               }
             ]
-            rowID: "row-1"
           }
         ) {
           matchArtworkImportImagesOrError {
@@ -52,14 +53,15 @@ describe("MatchArtworkImportImagesMutation", () => {
             file_name: "cat.jpg",
             s3_key: "/some/path/cat.jpg",
             s3_bucket: "someBucket",
+            row_id: "row-1",
           },
           {
             file_name: "dog.jpg",
             s3_key: "/some/path/dog.jpg",
             s3_bucket: "someBucket",
+            row_id: "row-1",
           },
         ],
-        row_id: "row-1",
       }
     )
 

--- a/src/schema/v2/ArtworkImport/matchArtworkImportImagesMutation.ts
+++ b/src/schema/v2/ArtworkImport/matchArtworkImportImagesMutation.ts
@@ -30,6 +30,11 @@ const ImageInputType = new GraphQLInputObjectType({
       type: new GraphQLNonNull(GraphQLString),
       description: "S3 bucket of the uploaded image asset",
     },
+    rowID: {
+      type: GraphQLString,
+      description:
+        "ID of the row to associate the images with (required if images don't already exist)",
+    },
   },
 })
 
@@ -83,11 +88,6 @@ export const MatchArtworkImportImagesMutation = mutationWithClientMutationId<
       ),
       description: "Array of image objects to match",
     },
-    rowID: {
-      type: GraphQLString,
-      description:
-        "ID of the row to associate the images with (required if images don't already exist)",
-    },
   },
   outputFields: {
     matchArtworkImportImagesOrError: {
@@ -96,7 +96,7 @@ export const MatchArtworkImportImagesMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkImportID, images, rowID },
+    { artworkImportID, images },
     { artworkImportMatchImagesLoader }
   ) => {
     if (!artworkImportMatchImagesLoader) {
@@ -104,12 +104,12 @@ export const MatchArtworkImportImagesMutation = mutationWithClientMutationId<
     }
 
     const gravityArgs = {
-      images: images.map(({ fileName, s3Key, s3Bucket }) => ({
+      images: images.map(({ fileName, s3Key, s3Bucket, rowID }) => ({
         file_name: fileName,
         s3_key: s3Key,
         s3_bucket: s3Bucket,
+        ...(rowID && { row_id: rowID }),
       })),
-      ...(rowID && { row_id: rowID }),
     }
 
     try {


### PR DESCRIPTION
Ah, didn't update the MP PR after addressing PR feedback in here: https://github.com/artsy/gravity/pull/19251. This moves the rowID arg into the image mutation, to keep things flexible (vs just on the parent arg of the mutation. 

cc @artsy/amber-devs 