### PR TITLE
feat(onyx-1883): INTERNAL_AUTOSUGGEST mode for matchConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21676,6 +21676,7 @@ enum SearchEntity {
 
 enum SearchMode {
   AUTOSUGGEST
+  INTERNAL_AUTOSUGGEST
   SITE
 }
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1,6 +1,7 @@
 import { gravityGraphQL } from "lib/apis/gravityGraphQL"
 import trackedEntityLoaderFactory from "lib/loaders/loaders_with_authentication/tracked_entity"
 import factories from "../api"
+import { searchLoader } from "../searchLoader"
 
 export default (accessToken, userID, opts) => {
   const gravityAccessTokenLoader = () => Promise.resolve(accessToken)
@@ -769,6 +770,7 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    internalSearchLoader: searchLoader(gravityLoader),
     inquiryIntroductionLoader: gravityLoader(
       "me/inquiry_introduction",
       {},

--- a/src/lib/loaders/searchLoader.ts
+++ b/src/lib/loaders/searchLoader.ts
@@ -9,6 +9,10 @@ const modeMap = {
     fallbackEntities: SUGGEST_ENTITIES,
     pathname: "/match/suggest",
   },
+  INTERNAL_AUTOSUGGEST: {
+    fallbackEntities: SUGGEST_ENTITIES,
+    pathname: "/match/suggest/internal",
+  },
   DEFAULT: { fallbackEntities: DEFAULT_ENTITIES, pathname: "/match" },
 }
 

--- a/src/schema/v2/Match.ts
+++ b/src/schema/v2/Match.ts
@@ -26,6 +26,7 @@ import { SearchMode } from "./search"
 import { SearchEntity } from "./search/SearchEntity"
 import { ShowType } from "./show"
 import { TagType } from "./tag"
+import { compact } from "lodash"
 
 const MODELS = {
   Article: { loader: "articleLoader", type: ArticleType },
@@ -72,11 +73,19 @@ export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
   resolve: async (
     _root,
     { term, entities, mode, ...args },
-    { searchLoader, ...loaders }
+    { searchLoader, internalSearchLoader, ...loaders }
   ) => {
-    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    if (mode === "INTERNAL_AUTOSUGGEST" && !internalSearchLoader) {
+      throw new Error(
+        "You need to pass a X-Access-Token header to perform this action"
+      )
+    }
 
-    const { body, headers } = await searchLoader({
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+    const loader =
+      mode === "INTERNAL_AUTOSUGGEST" ? internalSearchLoader : searchLoader
+
+    const { body, headers } = await loader({
       term,
       entities,
       mode,
@@ -89,7 +98,10 @@ export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
 
     const results = await Promise.all(
       body.map(async ({ id, label }) => {
-        const loader = loaders[MODELS[label].loader]
+        const loader = loaders[MODELS[label]?.loader]
+
+        if (!loader) return
+
         const body = await loader(id)
 
         return { ...body, __typename: label }
@@ -101,7 +113,7 @@ export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
       offset,
       page,
       size,
-      body: results,
+      body: compact(results),
       args,
     })
   },

--- a/src/schema/v2/search/index.ts
+++ b/src/schema/v2/search/index.ts
@@ -26,6 +26,9 @@ export const SearchMode = new GraphQLEnumType({
     AUTOSUGGEST: {
       value: "AUTOSUGGEST",
     },
+    INTERNAL_AUTOSUGGEST: {
+      value: "INTERNAL_AUTOSUGGEST",
+    },
     SITE: {
       value: "SITE",
     },


### PR DESCRIPTION
Adds `INTERNAL_AUTOSUGGEST` search mode. When specified, it calls the `/match/suggest/internal` endpoint, created to support admin panel needs (e.g., search by slug, ID, etc.).

Related PRs:
- https://github.com/artsy/gravity/pull/19267
- https://github.com/artsy/gravity/pull/19274