### PR TITLE
fix: fixes matchConnection when it tried to return unsupported entity types

### DIFF
--- a/src/schema/v2/Match.ts
+++ b/src/schema/v2/Match.ts
@@ -26,6 +26,7 @@ import { SearchMode } from "./search"
 import { SearchEntity } from "./search/SearchEntity"
 import { ShowType } from "./show"
 import { TagType } from "./tag"
+import { compact } from "lodash"
 
 const MODELS = {
   Article: { loader: "articleLoader", type: ArticleType },
@@ -89,7 +90,9 @@ export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
 
     const results = await Promise.all(
       body.map(async ({ id, label }) => {
-        const loader = loaders[MODELS[label].loader]
+        const loader = loaders[MODELS[label]?.loader]
+        if (!loader) return
+
         const body = await loader(id)
 
         return { ...body, __typename: label }
@@ -101,7 +104,7 @@ export const MatchConnection: GraphQLFieldConfig<void, ResolverContext> = {
       offset,
       page,
       size,
-      body: results,
+      body: compact(results),
       args,
     })
   },


### PR DESCRIPTION
`matchConnection` fails when search returns an entity which type is not in the MODELS array. For example, such request fails:

```graphql
{
  matchConnection(term: "Trolleys", entities: [], mode: AUTOSUGGEST) {
    edges {
      node {
        ... on Artist {
          name
        }
      }
    }
  }
}
```

because Trolleys returns artist series, which are not supported by Match.