### PR TITLE
chore(EMI-1996): stop pushing schema to Pulse

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -53,7 +53,7 @@ async function updateSchemaFile({
           prettierArgs = "--parser=graphql"
 
           // Running the compiler directly for Rails projects
-          const relayCompilerCommand = ["pulse", "volt"].includes(repo)
+          const relayCompilerCommand = ["volt"].includes(repo)
             ? "./node_modules/.bin/relay-compiler"
             : "yarn relay"
 
@@ -77,7 +77,6 @@ const supportedRepos = {
   prediction: {},
   force: {},
   forque: {},
-  pulse: { destinations: ["vendor/graphql/schema/metaphysics.json"] },
   volt: {
     destinations: [
       "vendor/graphql/schema/schema.graphql",


### PR DESCRIPTION
After the work to remove Artemis from Pulse, we don't need to sync the schema there anymore.

@artsy/emerald-devs 