### PR TITLE
feat: Thread through support for batch editing of international shipping fee

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4746,6 +4746,9 @@ input BulkUpdateArtworksMetadataInput {
   # The image rights to be assigned
   imageRights: String
 
+  # Flat fee for international shipping. It must be entered in cents.
+  internationalShippingFeeCents: Int
+
   # The literature to be assigned
   literature: String
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -18,6 +18,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
             conditionDescription: "Excellent"
             domesticShippingFeeCents: 20000
             locationId: "location456"
+            internationalShippingFeeCents: 30000
             category: "Painting"
             ecommerce: true
             medium: "Oil on Canvas"
@@ -88,6 +89,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           coa_by_authenticating_body: null,
           domestic_shipping_fee_cents: 20000,
           location_id: "location456",
+          international_shipping_fee_cents: 30000,
           category: "Painting",
           ecommerce: true,
           offer: false,

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -35,6 +35,7 @@ interface Input {
     ecommerce: boolean
     exhibitionHistory?: string
     imageRights?: string
+    internationalShippingFeeCents?: number
     literature?: string
     locationId?: string
     medium?: string
@@ -109,6 +110,11 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     imageRights: {
       type: GraphQLString,
       description: "The image rights to be assigned",
+    },
+    internationalShippingFeeCents: {
+      type: GraphQLInt,
+      description:
+        "Flat fee for international shipping. It must be entered in cents.",
     },
     literature: {
       type: GraphQLString,
@@ -280,6 +286,8 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         ecommerce: metadata.ecommerce,
         exhibition_history: metadata.exhibitionHistory,
         image_rights: metadata.imageRights,
+        international_shipping_fee_cents:
+          metadata.internationalShippingFeeCents,
         literature: metadata.literature,
         location_id: metadata.locationId,
         medium: metadata.medium,


### PR DESCRIPTION
Adds support for `internationalShippingFeeCents` in the batch update flows


Associated gravity changes here: https://github.com/artsy/gravity/pull/19285

cc @artsy/amber-devs 