### PR TITLE
chore: set the default size for UserAddresses

### DIFF
--- a/src/schema/v2/me/userAddress/userAddressesConnection.ts
+++ b/src/schema/v2/me/userAddress/userAddressesConnection.ts
@@ -22,6 +22,9 @@ export const UserAddressesConnection: GraphQLFieldConfig<
     if (!meUserAddressesLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
+    if (!args.first) {
+      args.first = 20 // TODO: Remove this once clients are updated
+    }
 
     const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 


### PR DESCRIPTION
This PR sets the default size for UserAddresses to 20. Normally, the size comes from the client, but this is an exception due to how the stitched experience worked.

/cc @artsy/diamond-devs 