### PR TITLE
fix: param/body construction on createNewGeminiAssetLoader

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gemini.ts
+++ b/src/lib/loaders/loaders_without_authentication/gemini.ts
@@ -11,7 +11,7 @@ export default () => ({
   // The outer function is so that we can pass params from the schema,
   // into the gemini api options.
   createNewGeminiAssetLoader: ({ name, acl }) =>
-    geminiUncachedLoader(`uploads/new.json?acl=${acl}`, {
+    geminiUncachedLoader("uploads/new.json", {
       acl,
       headers: {
         Authorization: "Basic " + toBase64(name + ":"),


### PR DESCRIPTION
We were passing acl as an query param on the URL path but also providing acl in the request body.

This commit is focused on fixing this one instance but it's possible that an [earlier PR][#7002] to fix array serialization in mutations and POST request bodies introduced incompatibility with combining both query params in the URL path and a request body at the same time.

[#7002]: https://github.com/artsy/metaphysics/pull/7002

cc/ @joeyAghion 