### PR TITLE
feat: Support bulk updating signature information

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4799,6 +4799,9 @@ input BulkUpdateArtworksMetadataInput {
   # Details about the signature
   signature: String
 
+  # Types of signatures on the artwork
+  signatureTypes: [ArtworkSignatureTypeEnum]
+
   # The title of the artwork
   title: String
 }

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -232,4 +232,132 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
       },
     })
   })
+
+  it("updates artworks with single signature type", async () => {
+    const signatureTypeMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            metadata: { signatureTypes: [HAND_SIGNED_BY_ARTIST] }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(signatureTypeMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          not_signed: false,
+          signed_by_artist: true,
+          signed_in_plate: false,
+          stamped_by_artist_estate: false,
+          sticker_label: false,
+          signed_other: false,
+        },
+      }
+    )
+  })
+
+  it("updates artworks with multiple signature types", async () => {
+    const signatureTypeMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            metadata: {
+              signatureTypes: [HAND_SIGNED_BY_ARTIST, SIGNED_IN_PLATE]
+            }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(signatureTypeMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          not_signed: false,
+          signed_by_artist: true,
+          signed_in_plate: true,
+          stamped_by_artist_estate: false,
+          sticker_label: false,
+          signed_other: false,
+        },
+      }
+    )
+  })
+
+  it("updates artworks with empty signature types array", async () => {
+    const signatureTypeMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: { id: "partner123", metadata: { signatureTypes: [] } }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(signatureTypeMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          not_signed: false,
+          signed_by_artist: false,
+          signed_in_plate: false,
+          stamped_by_artist_estate: false,
+          sticker_label: false,
+          signed_other: false,
+        },
+      }
+    )
+  })
 })

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -14,6 +14,10 @@ import {
   GravityMutationErrorType,
   formatGravityError,
 } from "lib/gravityErrorHandler"
+import {
+  ArtworkSignatureTypeEnum,
+  transformSignatureFieldsToGravityFields,
+} from "schema/v2/artwork/artworkSignatureTypes"
 import { Availability } from "schema/v2/types/availability"
 import { ResolverContext } from "types/graphql"
 import { BulkUpdateSourceEnum } from "../BulkUpdateSourceEnum"
@@ -157,6 +161,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "Details about the signature",
     },
+    signatureTypes: {
+      type: new GraphQLList(ArtworkSignatureTypeEnum),
+      description: "Types of signatures on the artwork",
+    },
     title: {
       type: GraphQLString,
       description: "The title of the artwork",
@@ -298,6 +306,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         provenance: metadata.provenance,
         published: metadata.published,
         signature: metadata.signature,
+        ...transformSignatureFieldsToGravityFields(metadata.signatureTypes),
         title: metadata.title,
       }
     }


### PR DESCRIPTION
Resolves [AMBER-1892](https://artsyproduct.atlassian.net/browse/AMBER-1892)
* Related Volt PR: https://github.com/artsy/volt/pull/9818

## Description

This adds support for bulk updating signature information. Types and transformation helpers have already been implemented for updating My Collection artworks in https://github.com/artsy/metaphysics/pull/5751 and are reused in this PR.

@artsy/amber-devs 

[AMBER-1892]: https://artsyproduct.atlassian.net/browse/AMBER-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ