### PR TITLE
Migrate from asdf to mise

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,11 +14,11 @@ if ! which memcached > /dev/null; then
   brew install memcached
 fi
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "Installing dependencies..."


### PR DESCRIPTION
## Summary
- Replace `asdf` with `mise` in setup script
- Update command checks and installation commands
- Maintain compatibility with existing `.tool-versions` files

## Changes
- Replace `if command -v asdf` with `if command -v mise`
- Replace `asdf install` with `mise install`
- Update echo messages to reference mise instead of asdf

This migration maintains full compatibility with existing `.tool-versions` files, which work with both asdf and mise.

Related to RFC: https://github.com/artsy/README/issues/550

🤖 Generated with [Claude Code](https://claude.ai/code)