### PR TITLE
feat(EMI-2356): return collector signals for inquireable artworks as well as for purchasable

### DIFF
--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -102,7 +102,8 @@ const AVAILABLE_LABEL_COUNT = LabelSignalEnumType.getValues().length
 export const CollectorSignals: GraphQLFieldConfig<any, ResolverContext> = {
   description: "Collector signals on artwork",
   resolve: (artwork) => {
-    const canSendSignals = artwork.purchasable || isAuctionArtwork(artwork)
+    const canSendSignals =
+      artwork.purchasable || artwork.inquireable || isAuctionArtwork(artwork)
     return canSendSignals ? artwork : null
   },
   type: new GraphQLObjectType({


### PR DESCRIPTION
Theoretically we could have removed the check for sale_ids as `inquireable` include the check for `at_auction` however the work is considered `at_auction` seems to only be true if the auction is active and not in a live portion but `sale_id` stays persistent. So not sure what exactly we want to 'collector signals` so decided not to touch it.

