### PR TITLE
feat: remove onyx_nwfy-view-frequency-penalty-experiment experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -16,7 +16,6 @@ const FEATURE_FLAGS_LIST = [
   "onyx_enable-home-view-auction-segmentation",
   "onyx_enable-quick-links-price-budget",
   "onyx_based_on_your_saves_home_view_section",
-  "onyx_nwfy-view-frequency-penalty-experiment",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -6,5 +6,4 @@ import { FeatureFlag } from "lib/featureFlags"
  */
 export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
   "onyx_experiment_home_view_test",
-  "onyx_nwfy-view-frequency-penalty-experiment",
 ]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -1,5 +1,4 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { getExperimentVariant } from "lib/featureFlags"
 import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
@@ -21,18 +20,7 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   requiresAuthentication: true,
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const variant = getExperimentVariant(
-      "onyx_nwfy-view-frequency-penalty-experiment",
-      {
-        userId: context.userID,
-      }
-    )
-
-    let recommendationsVersion = "C"
-
-    if (variant && variant.enabled && variant.name === "variant-a") {
-      recommendationsVersion = "A"
-    }
+    const recommendationsVersion = "C"
 
     const finalArgs = {
       // formerly specified client-side

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -1,13 +1,10 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
-import { getExperimentVariant } from "lib/featureFlags"
 import "schema/v2/homeView/experiments/experiments"
 
 jest.mock("lib/featureFlags", () => ({
   getExperimentVariant: jest.fn(),
 }))
-
-const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("NewWorksForYou", () => {
   it("returns the section's metadata", async () => {
@@ -69,111 +66,5 @@ describe("NewWorksForYou", () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("returns the section's connection data", async () => {
     // see artworksForUser.test.ts
-  })
-
-  describe("when the onyx_nwfy-view-frequency-penalty-experiment experiment is enabled", () => {
-    it("serves Version C to the control group", async () => {
-      mockGetExperimentVariant.mockImplementation(() => ({
-        name: "control",
-        enabled: true,
-      }))
-
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-new-works-for-you") {
-              ... on HomeViewSectionArtworks {
-                artworksConnection(first: 20) {
-                  edges {
-                    node {
-                      slug
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      type VortexGraphqlLoaderArgs = { query: string }
-      const mockVortexGraphqlLoader = jest.fn(
-        (_args: VortexGraphqlLoaderArgs) => () =>
-          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
-      )
-
-      const context = {
-        accessToken: "424242",
-        userID: "vortex-user-id",
-        artworksLoader: jest.fn(() => Promise.resolve([])),
-        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
-        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
-        authenticatedLoaders: {
-          vortexGraphqlLoader: mockVortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: jest.fn(),
-        },
-      } as any
-
-      await runQuery(query, context)
-
-      const vortexGraphqlQuery =
-        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
-
-      expect(vortexGraphqlQuery).toMatch('version: "C"')
-    })
-
-    it("serves Version A to the experiment group", async () => {
-      mockGetExperimentVariant.mockImplementation(() => ({
-        name: "variant-a",
-        enabled: true,
-      }))
-
-      const query = gql`
-        {
-          homeView {
-            section(id: "home-view-section-new-works-for-you") {
-              ... on HomeViewSectionArtworks {
-                artworksConnection(first: 20) {
-                  edges {
-                    node {
-                      slug
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      `
-
-      type VortexGraphqlLoaderArgs = { query: string }
-      const mockVortexGraphqlLoader = jest.fn(
-        (_args: VortexGraphqlLoaderArgs) => () =>
-          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
-      )
-
-      const context = {
-        accessToken: "424242",
-        userID: "vortex-user-id",
-        artworksLoader: jest.fn(() => Promise.resolve([])),
-        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
-        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
-        authenticatedLoaders: {
-          vortexGraphqlLoader: mockVortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: jest.fn(),
-        },
-      } as any
-
-      await runQuery(query, context)
-
-      const vortexGraphqlQuery =
-        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
-
-      expect(vortexGraphqlQuery).toMatch('version: "A"')
-    })
   })
 })


### PR DESCRIPTION
We are closing the Freshness AB test. View to Tap ratio improved in the experiment version. [Here](https://github.com/artsy/zenith/pull/579) I aligned NWFY version C (control) with A (experiment)