### PR TITLE
chore: enable trackItemImpressions on WTYL section

### DIFF
--- a/src/schema/v2/homeView/sections/RecommendedArtworks.ts
+++ b/src/schema/v2/homeView/sections/RecommendedArtworks.ts
@@ -1,10 +1,10 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { HomeViewSection } from "."
-import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
-import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { ArtworkRecommendations } from "schema/v2/me/artworkRecommendations"
+import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
+import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
+import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 
-export const RecommendedArtworks: HomeViewSection = {
+export const RecommendedArtworks: HomeViewArtworksSection = {
   id: "home-view-section-recommended-artworks",
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.artworkRecommendationsRail,
@@ -18,6 +18,6 @@ export const RecommendedArtworks: HomeViewSection = {
   },
   ownerType: OwnerType.artworkRecommendations,
   requiresAuthentication: true,
-
+  trackItemImpressions: true,
   resolver: withHomeViewTimeout(ArtworkRecommendations.resolve!),
 }

--- a/src/schema/v2/homeView/sections/__tests__/RecommendedArtworks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/RecommendedArtworks.test.ts
@@ -22,6 +22,9 @@ describe("RecommendedArtworks", () => {
                 }
               }
             }
+            ... on HomeViewSectionArtworks {
+              trackItemImpressions
+            }
           }
         }
       }
@@ -51,6 +54,7 @@ describe("RecommendedArtworks", () => {
           "contextModule": "artworkRecommendationsRail",
           "internalID": "home-view-section-recommended-artworks",
           "ownerType": "artworkRecommendations",
+          "trackItemImpressions": true,
         },
       }
     `)
@@ -70,6 +74,9 @@ describe("RecommendedArtworks", () => {
                   }
                 }
               }
+            }
+            ... on HomeViewSectionArtworks {
+              trackItemImpressions
             }
           }
         }
@@ -166,6 +173,7 @@ describe("RecommendedArtworks", () => {
               },
             ],
           },
+          "trackItemImpressions": true,
         },
       }
     `)


### PR DESCRIPTION
Resolves: https://artsyproduct.atlassian.net/browse/ONYX-1896

This PR adds items impression tracking to **We Think You'll Love** section.


<img width="1152" height="403" alt="Screenshot 2025-09-02 at 14 31 14" src="https://github.com/user-attachments/assets/26675f9a-8a2d-491c-a581-3994aa09fba4" />
