### PR TITLE
chore(EMI-2767): use Impulse unread by partner

### DIFF
--- a/src/schema/v2/conversation/__tests__/conversation.test.js
+++ b/src/schema/v2/conversation/__tests__/conversation.test.js
@@ -28,6 +28,7 @@ describe("Me", () => {
           },
           from_last_viewed_message_id: "20",
           to_last_viewed_message_id: "25",
+          is_unread_by_partner: false,
           items: [
             {
               item_type: "Artwork",

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -652,8 +652,7 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLBoolean,
       description: "True if there is an unread message by the Partner(to).",
       resolve: (conversation) => {
-        const { to_last_viewed_message_id } = conversation
-        return unreadConversation(conversation, to_last_viewed_message_id)
+        return conversation.is_unread_by_partner
       },
     },
   },


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-2767

Rely on Impulse to say if the conversation has been read by the Partner or not, instead of doing the logic again in MP.

Should be merged **_AFTER_** the Impulse migration is successfully run https://github.com/artsy/impulse/pull/951/