### PR TITLE
feat(push-changes): Add artsy-mcp to repo list

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3227,6 +3227,8 @@ type ArtworkImport implements Node {
     hasErrors: Boolean
     last: Int
   ): ArtworkImportRowConnection
+  s3Bucket: String!
+  s3Key: String!
   state: ArtworkImportState
   summary: ArtworkImportSummary
   unmatchedArtistNames: [String!]!

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -72,6 +72,7 @@ async function updateSchemaFile({
 }
 
 const supportedRepos = {
+  "artsy-mcp": {},
   eigen: { body: `${defaultBody} #nochangelog` },
   energy: {},
   prediction: {},

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -364,6 +364,14 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ file_name }) => file_name,
     },
+    s3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ s3_key }) => s3_key,
+    },
+    s3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ s3_bucket }) => s3_bucket,
+    },
     locationID: {
       type: GraphQLString,
       resolve: ({ location_id }) => location_id,


### PR DESCRIPTION
Also exposes s3Key and s3Bucket on artwork imports