### PR TITLE
fix(push-schema): Update parallelism count for push-schema-changes job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     executor:
       name: node/default
       tag: "22.5"
-    parallelism: 6
+    parallelism: 7
     steps:
       - checkout
       - setup_hokusai

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -71,6 +71,10 @@ async function updateSchemaFile({
   })
 }
 
+/**
+ * IMPORTANT: When updating or removing a repo from this list, be sure to *also*
+ * update .circleci/config.yml `push-schema-changes` job parallelism count to match
+ */
 const supportedRepos = {
   "artsy-mcp": {},
   eigen: { body: `${defaultBody} #nochangelog` },


### PR DESCRIPTION
Parallelism needs to match the number of repos we're pushing to, otherwise things error out on ci:

https://app.circleci.com/pipelines/github/artsy/metaphysics/28677/workflows/43d4c458-5636-4c58-9836-50f325b11954/jobs/58288. This was after adding `artsy-mcp` to the list of repos needing changes. 

cc @artsy/amber-devs 