### PR TITLE
feat(sync): Add config params for skipping common graphql operations during sync

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -24,6 +24,7 @@ async function updateSchemaFile({
   body = defaultBody,
 }) {
   console.log(`Updating schema for ${repo}`)
+
   await updateRepo({
     repo: {
       owner: "artsy",
@@ -37,8 +38,12 @@ async function updateSchemaFile({
     assignees: ["artsyit"],
     labels: ["Squash On Green"],
     update: (repoDir) => {
-      execSync("yarn config set ignore-engines true", { cwd: repoDir })
-      execSync("yarn install", { cwd: repoDir })
+      const repoConfig = supportedRepos[repo] || {}
+
+      if (!repoConfig.skipInstall) {
+        execSync("yarn config set ignore-engines true", { cwd: repoDir })
+        execSync("yarn install", { cwd: repoDir })
+      }
 
       destinations.forEach((dest) => {
         const repoDest = path.join(repoDir, dest)
@@ -52,20 +57,24 @@ async function updateSchemaFile({
           execSync(`cp _schemaV2.graphql '${repoDest}'`)
           prettierArgs = "--parser=graphql"
 
-          // Running the compiler directly for Rails projects
-          const relayCompilerCommand = ["volt"].includes(repo)
-            ? "./node_modules/.bin/relay-compiler"
-            : "yarn relay"
+          if (!repoConfig.skipRelay) {
+            // Running the compiler directly for Rails projects
+            const relayCompilerCommand = ["volt"].includes(repo)
+              ? "./node_modules/.bin/relay-compiler"
+              : "yarn relay"
 
-          execSync(relayCompilerCommand, { cwd: repoDir })
+            execSync(relayCompilerCommand, { cwd: repoDir })
+          }
         }
 
-        execSync(
-          `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier ${prettierArgs} --write ${dest}`,
-          {
-            cwd: repoDir,
-          }
-        )
+        if (!repoConfig.skipPrettier) {
+          execSync(
+            `[ ! -f ./node_modules/.bin/prettier ] || ./node_modules/.bin/prettier ${prettierArgs} --write ${dest}`,
+            {
+              cwd: repoDir,
+            }
+          )
+        }
       })
     },
   })
@@ -76,8 +85,14 @@ async function updateSchemaFile({
  * update .circleci/config.yml `push-schema-changes` job parallelism count to match
  */
 const supportedRepos = {
-  "artsy-mcp": {},
-  eigen: { body: `${defaultBody} #nochangelog` },
+  "artsy-mcp": {
+    skipInstall: true,
+    skipRelay: true,
+    skipPrettier: true,
+  },
+  eigen: {
+    body: `${defaultBody} #nochangelog`,
+  },
   energy: {},
   prediction: {},
   force: {},


### PR DESCRIPTION
All of our repos typically have relay, prettier, etc installed, but our mcp server just needs the schema. So add a few config options for skipping these common operations. 