### PR TITLE
feat: add github workflow to compare force schema

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -9,6 +9,6 @@ jobs:
     secrets:
       danger-token: ${{ secrets.DANGER_TOKEN }}
     with:
-      dangerfile: "peril/compareForceSchema.ts"
+      dangerfile: "danger/compareForceSchema.ts"
       install-from-caller: true
       fail-on-errors: false

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,0 +1,14 @@
+name: ☢️ Run Danger
+
+on:
+  pull_request:
+
+jobs:
+  run-danger:
+    uses: artsy/duchamp/.github/workflows/run-danger.yml@main
+    secrets:
+      danger-token: ${{ secrets.DANGER_TOKEN }}
+    with:
+      dangerfile: "peril/compareForceSchema.ts"
+      install-from-caller: true
+      fail-on-errors: false

--- a/danger/compareForceSchema.ts
+++ b/danger/compareForceSchema.ts
@@ -1,0 +1,34 @@
+import { buildSchema } from "graphql"
+const { diff: schemaDiff } = require("@graphql-inspector/core")
+import fetch from "node-fetch"
+import { warn, danger } from "danger"
+
+// If there is a breaking change between the local schema,
+// and the current Force one, warn.
+export default async () => {
+  const forceSchemaUrl =
+    "https://github.com/artsy/force/raw/main/data/schema.graphql"
+
+  const forceSchema = await (await fetch(forceSchemaUrl)).text()
+  const repo = danger.github.pr.head.repo.full_name
+  const sha = danger.github.pr.head.sha
+  const localSchema = await (
+    await fetch(
+      `https://raw.githubusercontent.com/${repo}/${sha}/_schemaV2.graphql`
+    )
+  ).text()
+
+  const allChanges = schemaDiff(
+    buildSchema(forceSchema),
+    buildSchema(localSchema)
+  )
+  const breakings = allChanges.filter((c) => c.criticality.level === "BREAKING")
+  const messages = breakings.map((c) => c.message)
+  if (messages.length) {
+    warn(
+      `The V2 schema in this PR has breaking changes with Force. Remember to update the Force schema if necessary.
+
+${messages.join("\n")}`
+    )
+  }
+}


### PR DESCRIPTION
Adds reusable workflow to run `compareForceSchema` checks via danger. The intent is to replace the current Peril checks.

Looking at [peril-settings](https://github.com/artsy/peril-settings/blob/main/peril.settings.json#L21-L22) it seems we are only running the `compareForceSchema` checks and not `dangerfile.ts`. Please let me know if I'm mistaken.

I set `fail-on-errors` to false, based off behaviours I could see in other PRs. For example, [this PR](https://github.com/artsy/metaphysics/pull/7065) failed the comparison but the check was marked as successful (apologies if this changes by the time you read this!).

**Testing**
[Here](https://github.com/artsy/metaphysics/pull/7071) is an example of a message being left when there's a breaking change.