### PR TITLE
chore(imports): remove unnecessary s3/key fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3227,8 +3227,6 @@ type ArtworkImport implements Node {
     hasErrors: Boolean
     last: Int
   ): ArtworkImportRowConnection
-  s3Bucket: String!
-  s3Key: String!
   state: ArtworkImportState
   summary: ArtworkImportSummary
   unmatchedArtistNames: [String!]!

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -364,14 +364,6 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLNonNull(GraphQLString),
       resolve: ({ file_name }) => file_name,
     },
-    s3Key: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ s3_key }) => s3_key,
-    },
-    s3Bucket: {
-      type: new GraphQLNonNull(GraphQLString),
-      resolve: ({ s3_bucket }) => s3_bucket,
-    },
     locationID: {
       type: GraphQLString,
       resolve: ({ location_id }) => location_id,


### PR DESCRIPTION
Turns out we didn't need these, so removing them from the schema. 