### PR TITLE
chore(batch-imports): Add new UNSUPPORTED_IMAGE_SEPERATOR Enum Type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3285,6 +3285,7 @@ enum ArtworkImportError {
   MISSING_TITLE
   UNMATCHED_ARTIST
   UNMATCHED_IMAGE
+  UNSUPPORTED_IMAGE_SEPERATOR
 }
 
 type ArtworkImportRow {

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -53,6 +53,7 @@ export const ArtworkImportErrorType = new GraphQLEnumType({
     // OTHER
     UNMATCHED_IMAGE: { value: "unmatched_image" },
     UNMATCHED_ARTIST: { value: "unmatched_artist" },
+    UNSUPPORTED_IMAGE_SEPERATOR: { value: "unsupported_image_separator" },
     ARTWORK_CREATION_FAILED: { value: "artwork_creation_failed" },
   },
 })


### PR DESCRIPTION
Threading through the changes introduced in [this gravity PR](https://github.com/artsy/gravity/pull/19279)

Adds a new error type which raises if the user attempts to upload a list of images with no delimiter present

We support whitespace within file names this is to just thwart the white space as a seperator between filenames

```
❌
Image1.jpg Image2.jpg Image3.jpg
```

```
✅
Image 1.jpg,Image 2.jpg,Image 3.jpg
```


### Next steps
- Display the error in Volt


cc @artsy/amber-devs 