### PR TITLE
fix: tolerate null signature, literature, and provenance values

### DIFF
--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2079,6 +2079,13 @@ describe("Artwork type", () => {
           expect(signature).toBe("<p>Foo <em>bar</em></p>\n")
         })
       })
+
+      it("tolerates null signatures", () => {
+        artwork.signature = null
+        return runQuery(query, context).then(({ artwork: { signature } }) => {
+          expect(signature).toBe(null)
+        })
+      })
     })
   })
 

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1166,7 +1166,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         resolve: () => false,
       },
       literature: markdown(({ literature }) =>
-        literature.replace(/^literature:\s+/i, "")
+        literature?.replace(/^literature:\s+/i, "")
       ),
       listingOptions,
       location: {
@@ -1592,7 +1592,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       provenance: markdown(({ provenance }) =>
-        provenance.replace(/^provenance:\s+/i, "")
+        provenance?.replace(/^provenance:\s+/i, "")
       ),
       publisher: markdown(),
       realizedPrice: {
@@ -1744,7 +1744,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             : [],
       },
       signature: markdown(({ signature }) =>
-        signature.replace(/^signature:\s+/i, "")
+        signature?.replace(/^signature:\s+/i, "")
       ),
       signatureDetails: {
         type: GraphQLString,


### PR DESCRIPTION
We began seeing ~1000 errors/hour early Aug. 26 tracing to `AuctionArtworkFilterQuery` ([here in Force](https://github.com/artsy/force/blob/2ff6801f713d8e8521eff6811aab599caed22242/src/Apps/Auction/Components/AuctionArtworkFilter.tsx#L141)). The traffic is suspicious in how regular it is, and how it references fields not found in our code's version of the query, but this does reveal a bug: these markdown fields can be `null` but often default to `""`. When null, the formatting logic would error.