### PR TITLE
fix(yarn): yarn 2+ doesn't support ignore-engines

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -41,7 +41,6 @@ async function updateSchemaFile({
       const repoConfig = supportedRepos[repo] || {}
 
       if (!repoConfig.skipInstall) {
-        execSync("yarn config set ignore-engines true", { cwd: repoDir })
         execSync("yarn install", { cwd: repoDir })
       }
 


### PR DESCRIPTION
MP CI is failing due to upgrades from yarn 1 to 4, looks like this `ignore-engines` option [isn't supported anymore](https://github.com/yarnpkg/berry/blob/62fd8525b8e1e6fc73431c38e4101eab2496c3b6/packages/plugin-essentials/sources/commands/install.ts#L137).

Not sure if this is the right fix, but figured I'd open a PR for feedback and see.

<img width="719" height="138" alt="Screenshot 2025-09-09 at 7 50 00 AM" src="https://github.com/user-attachments/assets/092cad89-0e93-4e8c-ac0b-f257418d46a2" />
