### PR TITLE
fix(yarn): set ignore-engines for repos with old yarn versions

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -40,6 +40,10 @@ async function updateSchemaFile({
     update: (repoDir) => {
       const repoConfig = supportedRepos[repo] || {}
 
+      if (!repoConfig.skipDeprecatedEngineCheck) {
+        execSync("yarn config set ignore-engines true", { cwd: repoDir })
+      }
+
       if (!repoConfig.skipInstall) {
         execSync("yarn install", { cwd: repoDir })
       }
@@ -94,9 +98,10 @@ const supportedRepos = {
   },
   energy: {},
   prediction: {},
-  force: {},
+  force: { skipDeprecatedEngineCheck: true },
   forque: {},
   volt: {
+    skipDeprecatedEngineCheck: true,
     destinations: [
       "vendor/graphql/schema/schema.graphql",
       "vendor/graphql/schema/metaphysics.json",


### PR DESCRIPTION
Previous [PR](https://github.com/artsy/metaphysics/pull/7081) fixed the `push-schema-changes` script for [Volt](https://github.com/artsy/volt) and [Force](https://github.com/artsy/force), which are both on yarn 4. However, it broke the script for all other repos that are currently on yarn 1. This adds a parameter to skip the `ignore-engines` step only for Volt and Force, but keep it for other repos.