### PR TITLE
fix(push-schema): Update destination path for artsy-mcp schema

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -92,6 +92,7 @@ const supportedRepos = {
     skipInstall: true,
     skipRelay: true,
     skipPrettier: true,
+    destinations: ["apps/artsy-mcp/data/schema.graphql"],
   },
   eigen: {
     body: `${defaultBody} #nochangelog`,


### PR DESCRIPTION
This updates the push-schema destination config to account for the new artsy-mcp monorepo [setup](https://github.com/artsy/artsy-mcp/pull/16).