### PR TITLE
feat: update inquiry request message formatting

### DIFF
--- a/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
+++ b/src/schema/v2/conversation/__tests__/__snapshots__/conversation.test.js.snap
@@ -41,7 +41,7 @@ exports[`Me Conversation concerning unread indicator returns the right unread st
 `;
 
 exports[`Me Conversation inquiry request returns the formatted first message as just the formatted questions if no message is present 1`] = `
-"I would like to request the following information about this artwork:
+"I'm interested in information regarding:
 • Condition & Provenance"
 `;
 
@@ -67,11 +67,11 @@ exports[`Me Conversation inquiry request returns the formatted first message, qu
 `;
 
 exports[`Me Conversation inquiry request returns the formatted first message, questions, and shipping location when present 3`] = `
-"Hello world!
-
-I would like to request the following information about this artwork:
+"I'm interested in information regarding:
 • Shipping Quote to New York City, US
-• Condition & Provenance"
+• Condition & Provenance
+
+Hello world!"
 `;
 
 exports[`Me Conversation returns a conversation 1`] = `

--- a/src/schema/v2/partner/partnerInquiryRequest.ts
+++ b/src/schema/v2/partner/partnerInquiryRequest.ts
@@ -29,9 +29,7 @@ export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
           const stateOrCountry = country === "United States" ? state : country
           return `• Shipping Quote to ${[city, stateOrCountry].join(", ")}`
         }
-        const lines = [
-          "I would like to request the following information about this artwork:",
-        ]
+        const lines = ["I'm interested in information regarding:"]
 
         inquiry_questions.forEach((question) => {
           lines.push(
@@ -40,7 +38,7 @@ export const InquiryRequestType = new GraphQLObjectType<any, ResolverContext>({
               : `• ${question?.question}`
           )
         })
-        if (message) lines.unshift(`${message}\n`)
+        if (message) lines.push("", message)
         return lines.join("\n")
       },
     },


### PR DESCRIPTION
Related to [EMI-2814]

### Description
Updates inquiry request formatting to use more conversational language and reorganize message structure:
- Changes "I would like to request the following information about this artwork:" to "I'm interested in information regarding:"
- Places custom messages after the questions list instead of before

### Implementation
- Updated `src/schema/v2/partner/partnerInquiryRequest.ts` to modify the inquiry formatting logic
- Updated test snapshots to reflect the new message structure

cc @artsy/emerald-devs 

[EMI-2814]: https://artsyproduct.atlassian.net/browse/EMI-2814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ