### PR TITLE
chore: add phoneNumberParsed to stitched user address

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -25015,6 +25015,9 @@ type UserAddress {
   # Phone number country code
   phoneNumberCountryCode: String
 
+  # Phone number with parsing and validation details
+  phoneNumberParsed: PhoneNumberType
+
   # Postal Code
   postalCode: String
 

--- a/src/lib/stitching/gravity/__tests__/stitching.test.ts
+++ b/src/lib/stitching/gravity/__tests__/stitching.test.ts
@@ -69,6 +69,20 @@ describe("gravity/stitching", () => {
       expect(userAddressField).toContain("id")
     })
 
+    it("extends the UserAddress type with a phoneNumberParsed field", async () => {
+      if (config.USE_UNSTITCHED_USER_ADDRESS) {
+        return
+      }
+
+      const mergedSchema = await getGravityMergedSchema()
+      const userAddressField = await getFieldsForTypeFromSchema(
+        "UserAddress",
+        mergedSchema
+      )
+
+      expect(userAddressField).toContain("phoneNumberParsed")
+    })
+
     it("includes stitched id resolver when stitching enabled", async () => {
       const { resolvers } = await getGravityStitchedSchema()
 
@@ -78,6 +92,38 @@ describe("gravity/stitching", () => {
 
       expect(resolvers.UserAddress).toBeDefined()
       expect(resolvers.UserAddress!.id).toBeDefined()
+    })
+
+    it("includes stitched phoneNumberParsed resolver when stitching enabled", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+
+      if (config.USE_UNSTITCHED_USER_ADDRESS) {
+        return
+      }
+
+      expect(resolvers.UserAddress).toBeDefined()
+      expect(resolvers.UserAddress!.phoneNumberParsed).toBeDefined()
+    })
+
+    it("phoneNumberParsed resolver returns parsed phone number data", async () => {
+      const { resolvers } = await getGravityStitchedSchema()
+
+      if (config.USE_UNSTITCHED_USER_ADDRESS) {
+        return
+      }
+
+      const mockUserAddress = {
+        phoneNumber: "+1 415 555-0132",
+        phoneNumberCountryCode: "us",
+      }
+
+      const result = resolvers.UserAddress!.phoneNumberParsed!.resolve(
+        mockUserAddress
+      )
+
+      expect(result).toBeDefined()
+      expect(result!.phoneNumber).toBe("+1 415 555-0132")
+      expect(result!.regionCode).toBe("us")
     })
   })
 })

--- a/src/lib/stitching/gravity/v2/stitching.ts
+++ b/src/lib/stitching/gravity/v2/stitching.ts
@@ -3,6 +3,7 @@ import { GraphQLSchema } from "graphql"
 import { toGlobalId } from "graphql-relay"
 import { GraphQLSchemaWithTransforms } from "graphql-tools"
 import config from "config"
+import { resolvePhoneNumber } from "../../../../schema/v2/phoneNumber"
 
 export const gravityStitchingEnvironment = (
   localSchema: GraphQLSchema,
@@ -25,6 +26,8 @@ export const gravityStitchingEnvironment = (
 
         extend type UserAddress {
           id: ID!
+          # Phone number with parsing and validation details
+          phoneNumberParsed: PhoneNumberType
         }
 
         # Mutation Payloads
@@ -81,6 +84,19 @@ export const gravityStitchingEnvironment = (
                 const internalID = parent.internalID
                 return toGlobalId("UserAddress", internalID)
               },
+            },
+            phoneNumberParsed: {
+              fragment: gql`
+              ... on UserAddress {
+                phoneNumber
+                phoneNumberCountryCode
+              }
+              `,
+              resolve: ({ phoneNumber, phoneNumberCountryCode }) =>
+                resolvePhoneNumber({
+                  phoneNumber,
+                  regionCode: phoneNumberCountryCode,
+                }),
             },
           },
 


### PR DESCRIPTION
Adds `phoneNumberParsed` to the stitched user address, allowing the client to query if user phone numbers are valid and get their `display` format. 

