### PR TITLE
feat: add summaryCheckmarks field to CollectorProfileType

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5365,6 +5365,12 @@ type CollectorProfileType implements Node {
   savedArtworksCount: Int!
   selfReportedPurchases: String
 
+  # Up to three checkmark strings describing the collector in relation to the artwork/partner.
+  summaryCheckmarks(
+    # This can be specified, and is injected in a conversation context for convenience.
+    artworkID: String
+  ): [String]
+
   # An artwork-specific paragraph describing the collector.
   summaryParagraph(
     # This can be specified, and is injected in a conversation context for convenience.
@@ -14147,6 +14153,12 @@ type InquirerCollectorProfile {
   ): String
   savedArtworksCount: Int!
   selfReportedPurchases: String
+
+  # Up to three checkmark strings describing the collector in relation to the artwork/partner.
+  summaryCheckmarks(
+    # This can be specified, and is injected in a conversation context for convenience.
+    artworkID: String
+  ): [String]
 
   # An artwork-specific paragraph describing the collector.
   summaryParagraph(

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -169,5 +169,181 @@ describe("Me", () => {
         )
       })
     })
+
+    describe("summaryCheckmarks", () => {
+      it("returns up to 3 checkmarks when many attributes are true", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                summaryCheckmarks(artworkID: "blah")
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+          collectorProfileSummaryLoader: () =>
+            Promise.resolve({
+              raw_attributes: {
+                has_demonstrated_budget: true,
+                has_bought_works_from_partner: true,
+                has_followed_partner: true,
+                has_inquired_about_works_from_partner: true,
+                has_inquired_about_works_from_artist: true,
+                has_enabled_alerts_on_artist: true,
+                has_enabled_alerts_on_a_represented_artist: true,
+                has_followed_a_represented_artist: true,
+                has_saved_works_from_partner: true,
+                is_recent_sign_up: false,
+              },
+            }),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.summaryCheckmarks).toEqual([
+              "Budget similar to artwork",
+              "Purchased from your gallery before",
+              "Follows your gallery",
+            ])
+          }
+        )
+      })
+
+      it("returns empty array when no attributes are true", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                summaryCheckmarks(artworkID: "blah")
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+          collectorProfileSummaryLoader: () =>
+            Promise.resolve({
+              raw_attributes: {
+                has_demonstrated_budget: false,
+                has_bought_works_from_partner: false,
+                has_followed_partner: false,
+                has_inquired_about_works_from_partner: false,
+                has_inquired_about_works_from_artist: false,
+                has_enabled_alerts_on_artist: false,
+                has_enabled_alerts_on_a_represented_artist: false,
+                has_followed_a_represented_artist: false,
+                has_saved_works_from_partner: false,
+                is_recent_sign_up: null,
+              },
+            }),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.summaryCheckmarks).toEqual([])
+          }
+        )
+      })
+
+      it("returns checkmarks with recent sign up fallback when few attributes are true", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                summaryCheckmarks(artworkID: "blah")
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+          collectorProfileSummaryLoader: () =>
+            Promise.resolve({
+              raw_attributes: {
+                has_demonstrated_budget: true,
+                has_bought_works_from_partner: false,
+                has_followed_partner: false,
+                has_inquired_about_works_from_partner: false,
+                has_inquired_about_works_from_artist: false,
+                has_enabled_alerts_on_artist: false,
+                has_enabled_alerts_on_a_represented_artist: false,
+                has_followed_a_represented_artist: false,
+                has_saved_works_from_partner: false,
+                is_recent_sign_up: true,
+              },
+            }),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.summaryCheckmarks).toEqual([
+              "Budget similar to artwork",
+              "New user",
+            ])
+          }
+        )
+      })
+
+      it("returns active user when is_recent_sign_up is false and few other attributes are true", () => {
+        const query = `
+          {
+            me {
+              collectorProfile {
+                summaryCheckmarks(artworkID: "blah")
+              }
+            }
+          }
+        `
+
+        const collectorProfile = {
+          id: "3",
+        }
+
+        const context = {
+          meCollectorProfileLoader: () => Promise.resolve(collectorProfile),
+          collectorProfileSummaryLoader: () =>
+            Promise.resolve({
+              raw_attributes: {
+                has_demonstrated_budget: false,
+                has_bought_works_from_partner: true,
+                has_followed_partner: false,
+                has_inquired_about_works_from_partner: false,
+                has_inquired_about_works_from_artist: false,
+                has_enabled_alerts_on_artist: false,
+                has_enabled_alerts_on_a_represented_artist: false,
+                has_followed_a_represented_artist: false,
+                has_saved_works_from_partner: false,
+                is_recent_sign_up: false,
+              },
+            }),
+        }
+
+        return runAuthenticatedQuery(query, context).then(
+          ({ me: { collectorProfile } }) => {
+            expect(collectorProfile.summaryCheckmarks).toEqual([
+              "Purchased from your gallery before",
+              "Active user",
+            ])
+          }
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
Thinks this is the best place to put this logic of selecting up to 3 most applicable summary checkmarks for a collector profile and artwork of interest. 

@starsirius - not exactly sure how we'll use it in impulse though as we'll need to make a separate call to MP for this I believe? Maybe we can pair on that part when you get a chance?