### PR TITLE
fix: set ignore engine check flag for eigen

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -96,6 +96,7 @@ const supportedRepos = {
   },
   eigen: {
     body: `${defaultBody} #nochangelog`,
+    skipDeprecatedEngineCheck: true,
   },
   energy: {},
   prediction: {},


### PR DESCRIPTION
sets flag to ignore failing engine check now that eigen is on yarn 4

Based on @ansor4  previous pr for similar failures in volt and force:
https://github.com/artsy/metaphysics/pull/7082