### PR TITLE
chore(AMBER-1963): add term param to allow search for partner location

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17835,6 +17835,9 @@ type Partner implements Node {
     # Return all partner-authenticated locations.
     private: Boolean
     size: Int
+
+    # Search term for locations.
+    term: String
   ): LocationConnection
   merchantAccount: PartnerMerchantAccount
   meta: PartnerMeta

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1121,6 +1121,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
               },
             }),
           },
+          term: {
+            type: GraphQLString,
+            description: "Search term for locations.",
+          },
         }),
         resolve: async (
           { id },
@@ -1147,6 +1151,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             total_count: true,
             offset,
             size,
+            term: args.term,
           })
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 


### PR DESCRIPTION
This PR is in service of [AMBER-1963](https://artsyproduct.atlassian.net/browse/AMBER-1963).

cc @artsy/amber-devs 

Allows the `locationConnection` query under `partner` field to take `term` as a search term:

```
{
  partner(id: "4f5228a1de92d1000100076e") {
    locationsConnection(
      first: 10
      private: true
      term: "bermondsey"
    ) {
      totalCount
      edges {
        node {
          internalID
          address
          address2
          city
          country
          postalCode
          display
          addressType
        }
      }
    }
  }
}
```

All locations:


<img width="1207" height="1590" alt="Screenshot 2025-09-23 at 12 18 51 PM" src="https://github.com/user-attachments/assets/bfca3987-4d98-4acf-b47d-37eae7f68d3c" />


With search `term` passed:

<img width="600" height="800" alt="Screenshot 2025-09-23 at 12 19 09 PM" src="https://github.com/user-attachments/assets/8f8089ba-857e-477e-9cf2-775546018ebd" />


<img width="600" height="800" alt="Screenshot 2025-09-23 at 12 09 22 PM" src="https://github.com/user-attachments/assets/191efdd0-fdd9-40c9-a1dc-3e05bc2879f9" />


[AMBER-1963]: https://artsyproduct.atlassian.net/browse/AMBER-1963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ