### PR TITLE
feat(genomebot): enable impression tracking on two more home view artwork rails

### DIFF
--- a/src/schema/v2/homeView/sections/BasedOnYourRecentSaves.ts
+++ b/src/schema/v2/homeView/sections/BasedOnYourRecentSaves.ts
@@ -1,16 +1,16 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { HomeViewSection } from "."
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { map } from "lodash"
 import { paginationResolver } from "schema/v2/fields/pagination"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
 
 const SAVED_ARTWORKS_SIZE = 3
 const SIMILAR_ARTWORKS_SIZE = 10
 const TIMEOUT_MS = 6000
 
-export const BasedOnYourRecentSaves: HomeViewSection = {
+export const BasedOnYourRecentSaves: HomeViewArtworksSection = {
   id: "home-view-section-based-on-your-recent-saves",
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.basedOnYourRecentSavesRail,
@@ -19,6 +19,7 @@ export const BasedOnYourRecentSaves: HomeViewSection = {
   },
   ownerType: OwnerType.basedOnYourRecentSaves,
   requiresAuthentication: true,
+  trackItemImpressions: true,
   resolver: withHomeViewTimeout(
     async (
       _parent,

--- a/src/schema/v2/homeView/sections/SimilarToRecentlyViewedArtworks.ts
+++ b/src/schema/v2/homeView/sections/SimilarToRecentlyViewedArtworks.ts
@@ -1,11 +1,11 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
-import { HomeViewSection } from "."
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewSectionTypeNames } from "../sectionTypes/names"
 import { SimilarToRecentlyViewed } from "schema/v2/me/similarToRecentlyViewed"
 import { emptyConnection } from "schema/v2/fields/pagination"
+import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
 
-export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
+export const SimilarToRecentlyViewedArtworks: HomeViewArtworksSection = {
   id: "home-view-section-similar-to-recently-viewed-artworks",
   type: HomeViewSectionTypeNames.HomeViewSectionArtworks,
   contextModule: ContextModule.similarToWorksYouViewedRail,
@@ -19,6 +19,7 @@ export const SimilarToRecentlyViewedArtworks: HomeViewSection = {
   },
   ownerType: OwnerType.similarToRecentlyViewed,
   requiresAuthentication: true,
+  trackItemImpressions: true,
 
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
     if (!context.meLoader) return emptyConnection

--- a/src/schema/v2/homeView/sections/__tests__/BasedOnYourRecentSaves.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/BasedOnYourRecentSaves.test.ts
@@ -30,6 +30,9 @@ describe("BasedOnYourRecentSaves", () => {
                 }
               }
             }
+            ... on HomeViewSectionArtworks {
+              trackItemImpressions
+            }
           }
         }
       }
@@ -53,6 +56,7 @@ describe("BasedOnYourRecentSaves", () => {
           "contextModule": "basedOnYourRecentSavesRail",
           "internalID": "home-view-section-based-on-your-recent-saves",
           "ownerType": "basedOnYourRecentSaves",
+          "trackItemImpressions": true,
         },
       }
     `)

--- a/src/schema/v2/homeView/sections/__tests__/SimilarToRecentlyViewedArtworks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/SimilarToRecentlyViewedArtworks.test.ts
@@ -22,6 +22,9 @@ describe("SimilarToRecentlyViewed", () => {
                 }
               }
             }
+            ... on HomeViewSectionArtworks {
+              trackItemImpressions
+            }
           }
         }
       }
@@ -50,6 +53,7 @@ describe("SimilarToRecentlyViewed", () => {
         "contextModule": "similarToWorksYouViewedRail",
         "internalID": "home-view-section-similar-to-recently-viewed-artworks",
         "ownerType": "similarToRecentlyViewed",
+        "trackItemImpressions": true,
       }
     `)
   })


### PR DESCRIPTION
In order to have useful metrics for the genomebot rollout we want to start tracking item impressions for the Eigen home view rails that rely on genome data.

Since Eigen [already requests](https://github.com/artsy/eigen/blob/d3a75dae627a70c472c12ab6bcd7648391afba23/src/app/Scenes/HomeView/Sections/HomeViewSectionArtworks.tsx#L155) the `trackItemImpressions` field in its artwork section component, all that's needed is to set that flag to `true` for the sections in question.


