### PR TITLE
fix: enable skip deprecated engine check now that energy on yarn 4

### DIFF
--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -98,7 +98,9 @@ const supportedRepos = {
     body: `${defaultBody} #nochangelog`,
     skipDeprecatedEngineCheck: true,
   },
-  energy: {},
+  energy: {
+    skipDeprecatedEngineCheck: true,
+  },
   prediction: {},
   force: { skipDeprecatedEngineCheck: true },
   forque: {},


### PR DESCRIPTION
skip deprecated engine check to fix schema update failures in energy. 