### PR TITLE
chore: add collector profile endpoints to non-authenticated loaders

### DIFF
--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -76,6 +76,12 @@ export default (opts) => {
       { headers: true }
     ),
     collectionLoader: gravityLoader((id) => `collection/${id}`),
+    collectorProfilesLoader: gravityLoader(
+      "collector_profiles",
+      {},
+      { headers: true }
+    ),
+    collectorProfileSummaryLoader: gravityLoader("collector_profile_summary"),
     createInvoicePaymentLoader: gravityLoader(
       (id) => `invoice/${id}/payment`,
       {},


### PR DESCRIPTION
### Description

Part of the flow that will support [EMI-2804](https://artsyproduct.atlassian.net/browse/EMI-2804)

#### Changes
- Adds `collector_profiles` and `collector_profile_summary` endpoints to `loaders_without_authentication`.

Allows for requests for `collectorProfile` and `summaryAttributes` to be called without `X-ACCESS-TOKEN`. Instead, we'll pass `X-XAPP-TOKEN` and gate on gravity's side.

<img width="1198" height="947" alt="Screenshot 2025-09-29 at 10 25 58 AM" src="https://github.com/user-attachments/assets/0c25a11d-9b8a-463b-9281-a535f4c6f53b" />
<img width="474" height="312" alt="Screenshot 2025-09-29 at 10 26 26 AM" src="https://github.com/user-attachments/assets/43bc6153-7b7a-4837-99e0-b7350eb20c57" />


[EMI-2804]: https://artsyproduct.atlassian.net/browse/EMI-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ