### PR TITLE
fix(DIA-93): Update discover daily cover image

### DIFF
--- a/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
+++ b/src/schema/v2/homeView/sections/InfiniteDiscovery.ts
@@ -19,7 +19,7 @@ export const InfiniteDiscovery: HomeViewSection = {
       subtitle:
         "Effortless discovery, expert curation — find art you love, one swipe at a time.",
       buttonText: "Try It",
-      image_url: "https://files.artsy.net/images/discover_daily_cover.webp",
+      image_url: "https://files.artsy.net/images/discover-daily-asset.webp",
       entityType: "Page",
       entityID: parent.ownerType,
       badgeText: "New",


### PR DESCRIPTION
This PR addresses [DIA-93], updating the homeview image

<img width="361" height="652" alt="Screenshot 2025-09-29 at 3 03 34 PM" src="https://github.com/user-attachments/assets/ec8ebe07-4d84-4169-ba0c-fe14f953aaee" />


[DIA-93]: https://artsyproduct.atlassian.net/browse/DIA-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ