### PR TITLE
chore: AMBER-2009 - add import source

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3485,6 +3485,7 @@ type ArtworkImportTransformedData {
   height: String
   imageFileNames: String
   imageRights: String
+  importSource: String
   inventoryId: String
   materials: String
   medium: String

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -308,6 +308,10 @@ const ArtworkImportRowType = new GraphQLObjectType({
               type: GraphQLString,
               resolve: ({ Bibliography }) => Bibliography,
             },
+            importSource: {
+              type: GraphQLString,
+              resolve: ({ ImportSource }) => ImportSource,
+            },
           },
         })
       ),


### PR DESCRIPTION
Partially solves [AMBER-2009]

Exposes the `ImportSource` field added in https://github.com/artsy/gravity/pull/19395

cc: @artsy/amber-devs 

[AMBER-2009]: https://artsyproduct.atlassian.net/browse/AMBER-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ