### PR TITLE
fix: Adds artlogic, artcloud, and batch upload to import source types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3449,6 +3449,9 @@ type ArtworkImportRowImage {
 }
 
 enum ArtworkImportSource {
+  ARTCLOUD
+  ARTLOGIC
+  BATCH_UPLOAD
   CONVECTION
   MY_COLLECTION
 }

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -112,6 +112,9 @@ const has_multiple_editions = (edition_sets) => {
 const IMPORT_SOURCES = {
   CONVECTION: { value: "convection" },
   MY_COLLECTION: { value: "my collection" },
+  ARTLOGIC: { value: "artlogic" },
+  ARTCLOUD: { value: "artcloud" },
+  BATCH_UPLOAD: { value: "BATCH_UPLOAD" },
 } as const
 
 const ARTIST_IN_HIGH_DEMAND_RANK = 9


### PR DESCRIPTION
fix: Adds `artlogic`, `artcloud`, and `BATCH_UPLOAD` to import source types
Resolves a portion of [AMBER-2032](https://artsyproduct.atlassian.net/browse/AMBER-2032)

This is needed as Volt relies on `ArtworkImportSource` Enum type for import source related filtering


Examples

## Before
Note `importSource` is `null` despite having import sources in the DB and thus hiding the Import source filter 🐛 

https://github.com/user-attachments/assets/717a6eaf-1f36-4b98-ac70-0b66e8cfe97d



## After
Note `importSource` value is present and filtering works as expected ✅ 


https://github.com/user-attachments/assets/282e3052-d079-4fd2-bd15-cea6782f0219



cc @artsy/amber-devs 

[AMBER-2032]: https://artsyproduct.atlassian.net/browse/AMBER-2032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ