### PR TITLE
chore: update display name for one of the profile summary checks

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13315,6 +13315,7 @@ type HomeViewCard {
   entityType: String
   href: String
   image: Image
+  images: [Image]
   subtitle: String
   title: String!
 }

--- a/src/schema/v2/CollectorProfile/collectorProfile.ts
+++ b/src/schema/v2/CollectorProfile/collectorProfile.ts
@@ -278,7 +278,7 @@ export const CollectorProfileFields: GraphQLFieldConfigMap<
       const checks = [
         {
           flag: raw_attributes.has_demonstrated_budget,
-          text: "Budget similar to artwork",
+          text: "Demonstrated a budget in line with this artwork's price",
         },
         {
           flag: raw_attributes.has_bought_works_from_partner,

--- a/src/schema/v2/me/__tests__/collector_profile.test.js
+++ b/src/schema/v2/me/__tests__/collector_profile.test.js
@@ -208,7 +208,7 @@ describe("Me", () => {
         return runAuthenticatedQuery(query, context).then(
           ({ me: { collectorProfile } }) => {
             expect(collectorProfile.summaryAttributes).toEqual([
-              "Budget similar to artwork",
+              "Demonstrated a budget in line with this artwork's price",
               "Purchased from your gallery before",
               "Follows your gallery",
             ])
@@ -295,7 +295,7 @@ describe("Me", () => {
           ({ me: { collectorProfile } }) => {
             expect(collectorProfile.summaryAttributes).toEqual([
               "New user",
-              "Budget similar to artwork",
+              "Demonstrated a budget in line with this artwork's price",
             ])
           }
         )


### PR DESCRIPTION
This one just updates the strings that will be passed as 'summary_attributes" for collector profiles. Adress one point in https://artsyproduct.atlassian.net/browse/EMI-2849

Not sure why/how I have a change in HomeViewCard? Did not change anything there but this file is auto-generated? Think it's safe as this prop exists on the type. Not sure why it was not generated whenever that was added.