### PR TITLE
feat: create NWFY price re-ranking experiment

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -8,7 +8,10 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
  * Feature flags are defined within Unleash.
  * @see https://tools.artsy.net/feature-flags
  */
-const FEATURE_FLAGS_LIST = ["onyx_auctions_hub"] as const
+const FEATURE_FLAGS_LIST = [
+  "onyx_auctions_hub",
+  "onyx_nwfy-price-reranking-test",
+] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]
 

--- a/src/schema/v2/homeView/experiments/experiments.ts
+++ b/src/schema/v2/homeView/experiments/experiments.ts
@@ -4,4 +4,6 @@ import { FeatureFlag } from "lib/featureFlags"
  * Provide here the names of the Unleash experiment feature flags that
  * should be exposed as part of the current home view response
  */
-export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = []
+export const CURRENTLY_RUNNING_EXPERIMENTS: FeatureFlag[] = [
+  "onyx_nwfy-price-reranking-test",
+]

--- a/src/schema/v2/homeView/sections/NewWorksForYou.ts
+++ b/src/schema/v2/homeView/sections/NewWorksForYou.ts
@@ -1,4 +1,5 @@
 import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { getExperimentVariant } from "lib/featureFlags"
 import { artworksForUser } from "schema/v2/artworksForUser/artworksForUser"
 import { withHomeViewTimeout } from "../helpers/withHomeViewTimeout"
 import { HomeViewArtworksSection } from "../sectionTypes/Artworks"
@@ -20,7 +21,15 @@ export const NewWorksForYou: HomeViewArtworksSection = {
   requiresAuthentication: true,
   trackItemImpressions: true,
   resolver: withHomeViewTimeout(async (parent, args, context, info) => {
-    const recommendationsVersion = "C"
+    const variant = getExperimentVariant("onyx_nwfy-price-reranking-test", {
+      userId: context.userID,
+    })
+
+    let recommendationsVersion = "C"
+
+    if (variant && variant.enabled && variant.name === "variant-a") {
+      recommendationsVersion = "A"
+    }
 
     const finalArgs = {
       // formerly specified client-side

--- a/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/NewWorksForYou.test.ts
@@ -1,10 +1,13 @@
 import gql from "lib/gql"
 import { runQuery } from "schema/v2/test/utils"
+import { getExperimentVariant } from "lib/featureFlags"
 import "schema/v2/homeView/experiments/experiments"
 
 jest.mock("lib/featureFlags", () => ({
   getExperimentVariant: jest.fn(),
 }))
+
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("NewWorksForYou", () => {
   it("returns the section's metadata", async () => {
@@ -66,5 +69,111 @@ describe("NewWorksForYou", () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip("returns the section's connection data", async () => {
     // see artworksForUser.test.ts
+  })
+
+  describe("when the onyx_nwfy-price-reranking-test experiment is enabled", () => {
+    it("serves Version C to the control group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "control",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "C"')
+    })
+
+    it("serves Version A to the experiment group", async () => {
+      mockGetExperimentVariant.mockImplementation(() => ({
+        name: "variant-a",
+        enabled: true,
+      }))
+
+      const query = gql`
+        {
+          homeView {
+            section(id: "home-view-section-new-works-for-you") {
+              ... on HomeViewSectionArtworks {
+                artworksConnection(first: 20) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      type VortexGraphqlLoaderArgs = { query: string }
+      const mockVortexGraphqlLoader = jest.fn(
+        (_args: VortexGraphqlLoaderArgs) => () =>
+          Promise.resolve({ data: { newForYouRecommendations: [{}] } })
+      )
+
+      const context = {
+        accessToken: "424242",
+        userID: "vortex-user-id",
+        artworksLoader: jest.fn(() => Promise.resolve([])),
+        setsLoader: jest.fn(() => Promise.resolve({ body: [] })),
+        setItemsLoader: jest.fn(() => Promise.resolve({ body: [{}] })),
+        authenticatedLoaders: {
+          vortexGraphqlLoader: mockVortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: jest.fn(),
+        },
+      } as any
+
+      await runQuery(query, context)
+
+      const vortexGraphqlQuery =
+        mockVortexGraphqlLoader.mock.calls?.[0]?.[0]?.query
+
+      expect(vortexGraphqlQuery).toMatch('version: "A"')
+    })
   })
 })


### PR DESCRIPTION
This implements [price re-ranking home view experiment](https://github.com/artsy/zenith/pull/614/files) for New Works for You. It is based on the Unleash feature flag [onyx_nwfy-price-reranking-test](https://unleash.artsy.net/projects/default/features/onyx_nwfy-price-reranking-test).

`control` group receives version `C`, `experiment` group -- version `A`.

At the moment, the experiment is enabled on staging only.