### PR TITLE
chore: Enable the s3 key to be passed as Instagram post image

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15821,7 +15821,10 @@ input InstagramPostSlideInput {
   artworkId: String!
 
   # Custom image URL to use instead of the artwork's default image
-  imageUrl: String!
+  imageUrl: String @deprecated(reason: "Use s3Key instead")
+
+  # S3 object key for this slide's custom image
+  s3Key: String
 }
 
 enum InstagramPostStatus {

--- a/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
+++ b/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
@@ -7,8 +7,8 @@ const mutation = `
     createInstagramPost(input: {
       instagramAccountId: "ig-account-1"
       slides: [
-        { artworkId: "artwork-1", imageUrl: "https://example.com/custom1.jpg" }
-        { artworkId: "artwork-2", imageUrl: "https://example.com/custom2.jpg" }
+        { artworkId: "artwork-1", s3Key: "partner-1/composite/artwork-1/uuid1.png" }
+        { artworkId: "artwork-2", s3Key: "partner-1/composite/artwork-2/uuid2.png" }
       ]
       caption: "Beautiful artwork"
       collaborators: ["collab1", "collab2"]
@@ -60,7 +60,7 @@ describe("createInstagramPost", () => {
       }
     })
 
-    it("passes slides to Gravity", async () => {
+    it("passes s3_key slides to Gravity", async () => {
       await runAuthenticatedQuery(mutation, context)
 
       expect(
@@ -70,11 +70,11 @@ describe("createInstagramPost", () => {
         slides: [
           {
             artwork_id: "artwork-1",
-            image_url: "https://example.com/custom1.jpg",
+            s3_key: "partner-1/composite/artwork-1/uuid1.png",
           },
           {
             artwork_id: "artwork-2",
-            image_url: "https://example.com/custom2.jpg",
+            s3_key: "partner-1/composite/artwork-2/uuid2.png",
           },
         ],
         caption: "Beautiful artwork",
@@ -113,7 +113,7 @@ describe("createInstagramPost", () => {
       mutation {
         createInstagramPost(input: {
           instagramAccountId: "ig-account-1"
-          slides: [{ artworkId: "artwork-1", imageUrl: "https://example.com/img.jpg" }]
+          slides: [{ artworkId: "artwork-1", s3Key: "partner-1/composite/artwork-1/uuid.png" }]
         }) {
           instagramPostOrError {
             __typename
@@ -136,6 +136,50 @@ describe("createInstagramPost", () => {
       }
 
       await runAuthenticatedQuery(mutationWithoutOptionals, context)
+
+      expect(
+        context.createInstagramPostLoader as jest.Mock
+      ).toHaveBeenCalledWith({
+        instagram_account_id: "ig-account-1",
+        slides: [
+          {
+            artwork_id: "artwork-1",
+            s3_key: "partner-1/composite/artwork-1/uuid.png",
+          },
+        ],
+        caption: undefined,
+        collaborators: undefined,
+      })
+    })
+  })
+
+  describe("with deprecated imageUrl", () => {
+    const mutationWithImageUrl = `
+      mutation {
+        createInstagramPost(input: {
+          instagramAccountId: "ig-account-1"
+          slides: [{ artworkId: "artwork-1", imageUrl: "https://example.com/img.jpg" }]
+        }) {
+          instagramPostOrError {
+            __typename
+            ... on CreateInstagramPostSuccess {
+              instagramPost {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("falls back to image_url when s3Key is not provided", async () => {
+      const context: Partial<ResolverContext> = {
+        createInstagramPostLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+
+      await runAuthenticatedQuery(mutationWithImageUrl, context)
 
       expect(
         context.createInstagramPostLoader as jest.Mock

--- a/src/schema/v2/createInstagramPostMutation.ts
+++ b/src/schema/v2/createInstagramPostMutation.ts
@@ -16,7 +16,8 @@ import { InstagramPostType } from "./instagramPost"
 
 interface SlideInput {
   artworkId: string
-  imageUrl: string
+  s3Key?: string
+  imageUrl?: string
 }
 
 interface Input {
@@ -35,8 +36,13 @@ const InstagramPostSlideInput = new GraphQLInputObjectType({
       type: new GraphQLNonNull(GraphQLString),
       description: "The ID of the artwork for this slide",
     },
+    s3Key: {
+      type: GraphQLString,
+      description: "S3 object key for this slide's custom image",
+    },
     imageUrl: {
-      type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
+      deprecationReason: "Use s3Key instead",
       description:
         "Custom image URL to use instead of the artwork's default image",
     },
@@ -129,7 +135,9 @@ export const createInstagramPostMutation = mutationWithClientMutationId<
         instagram_account_id: instagramAccountId,
         slides: slides.map((slide) => ({
           artwork_id: slide.artworkId,
-          image_url: slide.imageUrl,
+          ...(slide.s3Key
+            ? { s3_key: slide.s3Key }
+            : { image_url: slide.imageUrl }),
         })),
         caption,
         collaborators,


### PR DESCRIPTION
Continue the work started on https://github.com/artsy/gravity/pull/20001

## Description

Add support to the s3 key to be passed as one of the `slide` params when creating an Instagram post.

To keep backward compatibility, add it as optional while still supporting `imageUrl` until we do the switch on the client-side.

Once we fully switch, I'll make it required and drop `imageUrl` field from slides.

cc @artsy/amber-devs 