### PR TITLE
chore: Cleanup imageUrl from slides in favor of s3 key

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15918,11 +15918,8 @@ input InstagramPostSlideInput {
   # The ID of the artwork for this slide
   artworkId: String!
 
-  # Custom image URL to use instead of the artwork's default image
-  imageUrl: String @deprecated(reason: "Use s3Key instead")
-
   # S3 object key for this slide's custom image
-  s3Key: String
+  s3Key: String!
 }
 
 enum InstagramPostStatus {

--- a/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
+++ b/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
@@ -153,50 +153,6 @@ describe("createInstagramPost", () => {
     })
   })
 
-  describe("with deprecated imageUrl", () => {
-    const mutationWithImageUrl = `
-      mutation {
-        createInstagramPost(input: {
-          instagramAccountId: "ig-account-1"
-          slides: [{ artworkId: "artwork-1", imageUrl: "https://example.com/img.jpg" }]
-        }) {
-          instagramPostOrError {
-            __typename
-            ... on CreateInstagramPostSuccess {
-              instagramPost {
-                internalID
-              }
-            }
-          }
-        }
-      }
-    `
-
-    it("falls back to image_url when s3Key is not provided", async () => {
-      const context: Partial<ResolverContext> = {
-        createInstagramPostLoader: jest
-          .fn()
-          .mockResolvedValue(mockGravityResponse),
-      }
-
-      await runAuthenticatedQuery(mutationWithImageUrl, context)
-
-      expect(
-        context.createInstagramPostLoader as jest.Mock
-      ).toHaveBeenCalledWith({
-        instagram_account_id: "ig-account-1",
-        slides: [
-          {
-            artwork_id: "artwork-1",
-            image_url: "https://example.com/img.jpg",
-          },
-        ],
-        caption: undefined,
-        collaborators: undefined,
-      })
-    })
-  })
-
   it("throws when slides is empty", async () => {
     const mutationWithEmptySlides = `
       mutation {

--- a/src/schema/v2/createInstagramPostMutation.ts
+++ b/src/schema/v2/createInstagramPostMutation.ts
@@ -16,8 +16,7 @@ import { InstagramPostType } from "./instagramPost"
 
 interface SlideInput {
   artworkId: string
-  s3Key?: string
-  imageUrl?: string
+  s3Key: string
 }
 
 interface Input {
@@ -37,14 +36,8 @@ const InstagramPostSlideInput = new GraphQLInputObjectType({
       description: "The ID of the artwork for this slide",
     },
     s3Key: {
-      type: GraphQLString,
+      type: new GraphQLNonNull(GraphQLString),
       description: "S3 object key for this slide's custom image",
-    },
-    imageUrl: {
-      type: GraphQLString,
-      deprecationReason: "Use s3Key instead",
-      description:
-        "Custom image URL to use instead of the artwork's default image",
     },
   },
 })
@@ -135,9 +128,7 @@ export const createInstagramPostMutation = mutationWithClientMutationId<
         instagram_account_id: instagramAccountId,
         slides: slides.map((slide) => ({
           artwork_id: slide.artworkId,
-          ...(slide.s3Key
-            ? { s3_key: slide.s3Key }
-            : { image_url: slide.imageUrl }),
+          s3_key: slide.s3Key,
         })),
         caption,
         collaborators,


### PR DESCRIPTION
The switch in Volt was already done during https://github.com/artsy/volt/pull/11191, so it's now safe to remove it.

cc @artsy/amber-devs 