### PR TITLE
chore: Include errorMessage among InstagramPost fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15868,6 +15868,7 @@ type InstagramPost {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  errorMessage: String
 
   # A globally unique ID.
   id: ID!

--- a/src/schema/v2/__tests__/instagramPost.test.ts
+++ b/src/schema/v2/__tests__/instagramPost.test.ts
@@ -14,6 +14,7 @@ describe("instagramPost", () => {
           permalink
           caption
           status
+          errorMessage
         }
       }
     `
@@ -28,6 +29,7 @@ describe("instagramPost", () => {
       permalink: "https://www.instagram.com/p/ABC123/",
       caption: "Beautiful artwork",
       status: "published",
+      error_message: "Some error occurred",
       published_at: "2026-03-10T12:00:00Z",
     }
 
@@ -57,6 +59,7 @@ describe("instagramPost", () => {
               "artwork-1",
             ],
             "caption": "Beautiful artwork",
+            "errorMessage": "Some error occurred",
             "instagramAccountId": "ig-account-1",
             "instagramMediaId": "media-123",
             "internalID": "post-1",

--- a/src/schema/v2/instagramPost.ts
+++ b/src/schema/v2/instagramPost.ts
@@ -56,6 +56,10 @@ export const InstagramPostType = new GraphQLObjectType<any, ResolverContext>({
     status: {
       type: InstagramPostStatusEnum,
     },
+    errorMessage: {
+      type: GraphQLString,
+      resolve: ({ error_message }) => error_message,
+    },
     publishedAt: date(),
     createdAt: date(),
     updatedAt: date(),


### PR DESCRIPTION
I just realised we're not returning potential error messages for Instagram posts.

It's not essential, since for user feedback we'll rely on the data coming from websockets rather than the mutation. Still, this is useful data for us (devs) to be able to fetch directly from graphl queries when testing / debugging issues, so it makes sense to have it exposed.

cc @artsy/amber-devs 