### PR TITLE
chore: schema + mutations for partner lists (gallery OS)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -122,6 +122,34 @@ type AckTaskSuccess {
   task: Task!
 }
 
+type AddArtworkToPartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input AddArtworkToPartnerListMutationInput {
+  # The ID of the artwork to add.
+  artworkId: String!
+  clientMutationId: String
+
+  # The ID of the partner list.
+  listId: String!
+}
+
+type AddArtworkToPartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: AddArtworkToPartnerListResponseOrError
+}
+
+union AddArtworkToPartnerListResponseOrError =
+    AddArtworkToPartnerListFailure
+  | AddArtworkToPartnerListSuccess
+
+type AddArtworkToPartnerListSuccess {
+  partnerList: PartnerList
+}
+
 type AddArtworkToPartnerShowFailure {
   mutationError: GravityMutationError
 }
@@ -5325,6 +5353,34 @@ type BidderPositionSuggestedNextBid {
 # Represents non-fractional signed whole numeric values. Since the value may
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
+
+type BulkAddArtworksToPartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input BulkAddArtworksToPartnerListMutationInput {
+  # The IDs of the artworks to add.
+  artworkIds: [String!]!
+  clientMutationId: String
+
+  # The ID of the partner list.
+  listId: String!
+}
+
+type BulkAddArtworksToPartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: BulkAddArtworksToPartnerListResponseOrError
+}
+
+union BulkAddArtworksToPartnerListResponseOrError =
+    BulkAddArtworksToPartnerListFailure
+  | BulkAddArtworksToPartnerListSuccess
+
+type BulkAddArtworksToPartnerListSuccess {
+  partnerList: PartnerList
+}
 
 type BulkAddArtworksToShowMutationFailure {
   mutationError: GravityMutationError
@@ -10843,6 +10899,44 @@ type CreatePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type CreatePartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerListMutationInput {
+  clientMutationId: String
+
+  # End date for the list.
+  endAt: String
+
+  # The type of list (show, fair, or other).
+  listType: PartnerListTypeEnum
+
+  # The name of the list.
+  name: String!
+
+  # The ID of the partner.
+  partnerID: String!
+
+  # Start date for the list.
+  startAt: String
+}
+
+type CreatePartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the created partner list. On error: the error that occurred.
+  partnerListOrError: CreatePartnerListResponseOrError
+}
+
+union CreatePartnerListResponseOrError =
+    CreatePartnerListFailure
+  | CreatePartnerListSuccess
+
+type CreatePartnerListSuccess {
+  partnerList: PartnerList
+}
+
 type CreatePartnerLocationDaySchedulesFailure {
   mutationError: GravityMutationError
 }
@@ -12099,6 +12193,32 @@ type DeletePartnerContactSuccess {
   partnerContact: Contact
 }
 
+type DeletePartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input DeletePartnerListMutationInput {
+  clientMutationId: String
+
+  # The ID of the partner list.
+  id: String!
+}
+
+type DeletePartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the deleted partner list. On error: the error that occurred.
+  partnerListOrError: DeletePartnerListResponseOrError
+}
+
+union DeletePartnerListResponseOrError =
+    DeletePartnerListFailure
+  | DeletePartnerListSuccess
+
+type DeletePartnerListSuccess {
+  partnerList: PartnerList
+}
+
 type DeletePartnerLocationFailure {
   mutationError: GravityMutationError
 }
@@ -12745,6 +12865,32 @@ enum DisplayTextsMessageTypeEnum {
   SUBMITTED_OFFER
   SUBMITTED_ORDER
   UNKNOWN
+}
+
+type DistributePartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input DistributePartnerListMutationInput {
+  clientMutationId: String
+
+  # The ID of the partner list.
+  id: String!
+}
+
+type DistributePartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the distributed partner list. On error: the error that occurred.
+  partnerListOrError: DistributePartnerListResponseOrError
+}
+
+union DistributePartnerListResponseOrError =
+    DistributePartnerListFailure
+  | DistributePartnerListSuccess
+
+type DistributePartnerListSuccess {
+  partnerList: PartnerList
 }
 
 # The type of domestic shipping option
@@ -17713,6 +17859,11 @@ type Mutation {
   # Updates a Task on the logged in User
   ackTask(input: AckTaskMutationInput!): AckTaskMutationPayload
 
+  # Adds an artwork to a partner list.
+  addArtworkToPartnerList(
+    input: AddArtworkToPartnerListMutationInput!
+  ): AddArtworkToPartnerListMutationPayload
+
   # Adds an artwork to a partner show.
   addArtworkToPartnerShow(
     input: AddArtworkToPartnerShowMutationInput!
@@ -17790,6 +17941,11 @@ type Mutation {
   batchArtworkImportImages(
     input: BatchArtworkImportImagesInput!
   ): BatchArtworkImportImagesPayload
+
+  # Bulk adds artworks to a partner list.
+  bulkAddArtworksToPartnerList(
+    input: BulkAddArtworksToPartnerListMutationInput!
+  ): BulkAddArtworksToPartnerListMutationPayload
 
   # Bulk add artworks to a show
   bulkAddArtworksToShow(
@@ -18175,6 +18331,11 @@ type Mutation {
     input: CreatePartnerContactInput!
   ): CreatePartnerContactPayload
 
+  # Creates a new partner list.
+  createPartnerList(
+    input: CreatePartnerListMutationInput!
+  ): CreatePartnerListMutationPayload
+
   # Creates a new location for a partner
   createPartnerLocation(
     input: CreatePartnerLocationInput!
@@ -18376,6 +18537,11 @@ type Mutation {
     input: DeletePartnerContactMutationInput!
   ): DeletePartnerContactMutationPayload
 
+  # Deletes a partner list.
+  deletePartnerList(
+    input: DeletePartnerListMutationInput!
+  ): DeletePartnerListMutationPayload
+
   # Deletes a location for a partner
   deletePartnerLocation(
     input: DeletePartnerLocationMutationInput!
@@ -18458,6 +18624,11 @@ type Mutation {
 
   # Updates a Task on the logged in User
   dismissTask(input: DismissTaskMutationInput!): DismissTaskMutationPayload
+
+  # Distributes a partner list to Artsy, creating a draft show.
+  distributePartnerList(
+    input: DistributePartnerListMutationInput!
+  ): DistributePartnerListMutationPayload
   enableSecondFactor(input: EnableSecondFactorInput!): EnableSecondFactorPayload
 
   # Mark sale as ended.
@@ -18532,6 +18703,11 @@ type Mutation {
     input: RefreshInstagramAccountInput!
   ): RefreshInstagramAccountPayload
 
+  # Removes an artwork from a partner list.
+  removeArtworkFromPartnerList(
+    input: RemoveArtworkFromPartnerListMutationInput!
+  ): RemoveArtworkFromPartnerListMutationPayload
+
   # Removes an artwork from a partner show.
   removeArtworkFromPartnerShow(
     input: RemoveArtworkFromPartnerShowMutationInput!
@@ -18571,6 +18747,11 @@ type Mutation {
   repositionPartnerArtistArtworks(
     input: RepositionPartnerArtistArtworksMutationInput!
   ): RepositionPartnerArtistArtworksMutationPayload
+
+  # Repositions all artworks in a partner list.
+  repositionPartnerListArtworks(
+    input: RepositionPartnerListArtworksMutationInput!
+  ): RepositionPartnerListArtworksMutationPayload
 
   # Reposition partners locations in various CMS surfaces, settings, Artwork Form, etc.
   repositionPartnerLocations(
@@ -18827,6 +19008,16 @@ type Mutation {
   updatePartnerFlags(
     input: UpdatePartnerFlagsMutationInput!
   ): UpdatePartnerFlagsMutationPayload
+
+  # Updates an existing partner list.
+  updatePartnerList(
+    input: UpdatePartnerListMutationInput!
+  ): UpdatePartnerListMutationPayload
+
+  # Updates the position of an artwork in a partner list.
+  updatePartnerListArtworkPosition(
+    input: UpdatePartnerListArtworkPositionMutationInput!
+  ): UpdatePartnerListArtworkPositionMutationPayload
 
   # Updates a new location for a partner
   updatePartnerLocation(
@@ -20335,6 +20526,17 @@ type Partner implements Node {
     page: Int
     size: Int
   ): PartnerAlertHitsConnection
+
+  # A connection of lists from a Partner.
+  partnerListsConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # Filter by list type.
+    listType: PartnerListTypeEnum
+  ): PartnerListConnection
   partnerPageEligible: Boolean
   partnerType: String
   profile: Profile
@@ -21150,6 +21352,102 @@ type PartnerInquiryRequest {
   internalID: ID!
   questions: [InquiryQuestion]
   shippingLocation: Location
+}
+
+type PartnerList {
+  artworksConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): PartnerListArtworkConnection
+  artworksCount: Int!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  distributedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  endAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  listType: PartnerListTypeEnum!
+  name: String!
+  partnerShowID: String
+  startAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+}
+
+# A connection to a list of items.
+type PartnerListArtworkConnection {
+  # A list of edges.
+  edges: [PartnerListArtworkEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerListArtworkEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: Artwork
+  position: Int!
+}
+
+# A connection to a list of items.
+type PartnerListConnection {
+  # A list of edges.
+  edges: [PartnerListEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type PartnerListEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: PartnerList
+}
+
+enum PartnerListTypeEnum {
+  FAIR
+  OTHER
+  SHOW
 }
 
 type PartnerMerchantAccount {
@@ -23666,6 +23964,34 @@ type RelatedArtworkGrid implements ArtworkContextGrid {
   title: String
 }
 
+type RemoveArtworkFromPartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input RemoveArtworkFromPartnerListMutationInput {
+  # The ID of the artwork to remove.
+  artworkId: String!
+  clientMutationId: String
+
+  # The ID of the partner list.
+  listId: String!
+}
+
+type RemoveArtworkFromPartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: RemoveArtworkFromPartnerListResponseOrError
+}
+
+union RemoveArtworkFromPartnerListResponseOrError =
+    RemoveArtworkFromPartnerListFailure
+  | RemoveArtworkFromPartnerListSuccess
+
+type RemoveArtworkFromPartnerListSuccess {
+  partnerList: PartnerList
+}
+
 type RemoveArtworkFromPartnerShowFailure {
   mutationError: GravityMutationError
 }
@@ -23884,6 +24210,34 @@ union RepositionPartnerArtistArtworksResponseOrError =
 
 type RepositionPartnerArtistArtworksSuccess {
   partner: Partner
+}
+
+type RepositionPartnerListArtworksFailure {
+  mutationError: GravityMutationError
+}
+
+input RepositionPartnerListArtworksMutationInput {
+  # The ordered list of artwork IDs representing the new positions.
+  artworkIds: [String!]!
+  clientMutationId: String
+
+  # The ID of the partner list.
+  listId: String!
+}
+
+type RepositionPartnerListArtworksMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: RepositionPartnerListArtworksResponseOrError
+}
+
+union RepositionPartnerListArtworksResponseOrError =
+    RepositionPartnerListArtworksFailure
+  | RepositionPartnerListArtworksSuccess
+
+type RepositionPartnerListArtworksSuccess {
+  partnerList: PartnerList
 }
 
 type RepositionPartnerLocationsFailure {
@@ -27272,6 +27626,75 @@ union UpdatePartnerFlagsResponseOrError =
 
 type UpdatePartnerFlagsSuccess {
   partner: Partner
+}
+
+type UpdatePartnerListArtworkPositionFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerListArtworkPositionMutationInput {
+  # The ID of the artwork.
+  artworkId: String!
+  clientMutationId: String
+
+  # The ID of the partner list.
+  listId: String!
+
+  # The new position of the artwork.
+  position: Int!
+}
+
+type UpdatePartnerListArtworkPositionMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: UpdatePartnerListArtworkPositionResponseOrError
+}
+
+union UpdatePartnerListArtworkPositionResponseOrError =
+    UpdatePartnerListArtworkPositionFailure
+  | UpdatePartnerListArtworkPositionSuccess
+
+type UpdatePartnerListArtworkPositionSuccess {
+  partnerList: PartnerList
+}
+
+type UpdatePartnerListFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerListMutationInput {
+  clientMutationId: String
+
+  # End date for the list.
+  endAt: String
+
+  # The ID of the partner list.
+  id: String!
+
+  # The type of list (show, fair, or other).
+  listType: PartnerListTypeEnum
+
+  # The name of the list.
+  name: String
+
+  # Start date for the list.
+  startAt: String
+}
+
+type UpdatePartnerListMutationPayload {
+  clientMutationId: String
+
+  # On success: the updated partner list. On error: the error that occurred.
+  partnerListOrError: UpdatePartnerListResponseOrError
+}
+
+union UpdatePartnerListResponseOrError =
+    UpdatePartnerListFailure
+  | UpdatePartnerListSuccess
+
+type UpdatePartnerListSuccess {
+  partnerList: PartnerList
 }
 
 type UpdatePartnerLocationFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1780,5 +1780,68 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+
+    // Partner List Loaders
+    partnerListsLoader: gravityLoader("partner_lists", {}, { headers: true }),
+    partnerListLoader: gravityLoader((id) => `partner_list/${id}`),
+    partnerListArtworksLoader: gravityLoader(
+      (id) => `partner_list/${id}/artworks`,
+      {},
+      { headers: true }
+    ),
+    createPartnerListLoader: gravityLoader(
+      "partner_list",
+      {},
+      { method: "POST" }
+    ),
+    updatePartnerListLoader: gravityLoader(
+      (id) => `partner_list/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deletePartnerListLoader: gravityLoader(
+      (id) => `partner_list/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    distributePartnerListLoader: gravityLoader(
+      (id) => `partner_list/${id}/distribute`,
+      {},
+      { method: "POST" }
+    ),
+    addArtworkToPartnerListLoader: gravityLoader<
+      any,
+      { listId: string; artworkId: string }
+    >(
+      ({ listId, artworkId }) => `partner_list/${listId}/artwork/${artworkId}`,
+      {},
+      { method: "POST" }
+    ),
+    updatePartnerListArtworkLoader: gravityLoader<
+      any,
+      { listId: string; artworkId: string }
+    >(
+      ({ listId, artworkId }) => `partner_list/${listId}/artwork/${artworkId}`,
+      {},
+      { method: "PUT" }
+    ),
+    removeArtworkFromPartnerListLoader: gravityLoader<
+      any,
+      { listId: string; artworkId: string }
+    >(
+      ({ listId, artworkId }) => `partner_list/${listId}/artwork/${artworkId}`,
+      {},
+      { method: "DELETE" }
+    ),
+    bulkAddArtworksToPartnerListLoader: gravityLoader(
+      (id) => `partner_list/${id}/artworks`,
+      {},
+      { method: "POST" }
+    ),
+    repositionPartnerListArtworksLoader: gravityLoader(
+      (id) => `partner_list/${id}/reposition`,
+      {},
+      { method: "POST" }
+    ),
   }
 }

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/addArtworkToPartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/addArtworkToPartnerListMutation.test.ts
@@ -1,0 +1,94 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("AddArtworkToPartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      addArtworkToPartnerList(
+        input: { listId: "list-abc", artworkId: "artwork-123" }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on AddArtworkToPartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              artworksCount
+            }
+          }
+          ... on AddArtworkToPartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("adds an artwork to a partner list", async () => {
+    const context = {
+      addArtworkToPartnerListLoader: jest.fn().mockResolvedValue({}),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 1,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.addArtworkToPartnerListLoader).toHaveBeenCalledWith({
+      listId: "list-abc",
+      artworkId: "artwork-123",
+    })
+    expect(context.partnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      addArtworkToPartnerList: {
+        partnerListOrError: {
+          __typename: "AddArtworkToPartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+            artworksCount: 1,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      addArtworkToPartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "Artwork not found" },
+      }),
+      partnerListLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      addArtworkToPartnerList: {
+        partnerListOrError: {
+          __typename: "AddArtworkToPartnerListFailure",
+          mutationError: {
+            message: "Artwork not found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        addArtworkToPartnerListLoader: undefined,
+        partnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/bulkAddArtworksToPartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/bulkAddArtworksToPartnerListMutation.test.ts
@@ -1,0 +1,99 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("BulkAddArtworksToPartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      bulkAddArtworksToPartnerList(
+        input: {
+          listId: "list-abc"
+          artworkIds: ["artwork-1", "artwork-2", "artwork-3"]
+        }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on BulkAddArtworksToPartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              artworksCount
+            }
+          }
+          ... on BulkAddArtworksToPartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("bulk adds artworks to a partner list", async () => {
+    const context = {
+      bulkAddArtworksToPartnerListLoader: jest.fn().mockResolvedValue({}),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 3,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.bulkAddArtworksToPartnerListLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        artwork_ids: ["artwork-1", "artwork-2", "artwork-3"],
+      }
+    )
+    expect(context.partnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      bulkAddArtworksToPartnerList: {
+        partnerListOrError: {
+          __typename: "BulkAddArtworksToPartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+            artworksCount: 3,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      bulkAddArtworksToPartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "Some artworks not found" },
+      }),
+      partnerListLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      bulkAddArtworksToPartnerList: {
+        partnerListOrError: {
+          __typename: "BulkAddArtworksToPartnerListFailure",
+          mutationError: {
+            message: "Some artworks not found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        bulkAddArtworksToPartnerListLoader: undefined,
+        partnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/createPartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/createPartnerListMutation.test.ts
@@ -1,0 +1,103 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CreatePartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      createPartnerList(
+        input: {
+          partnerID: "partner-123"
+          name: "Spring 2026 Show"
+          listType: SHOW
+          startAt: "2026-03-01"
+          endAt: "2026-06-01"
+        }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on CreatePartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              listType
+              artworksCount
+            }
+          }
+          ... on CreatePartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("creates a partner list", async () => {
+    const context = {
+      createPartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 0,
+        start_at: "2026-03-01T00:00:00+00:00",
+        end_at: "2026-06-01T00:00:00+00:00",
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.createPartnerListLoader).toHaveBeenCalledWith({
+      partner_id: "partner-123",
+      name: "Spring 2026 Show",
+      list_type: "show",
+      start_at: "2026-03-01",
+      end_at: "2026-06-01",
+    })
+
+    expect(result).toEqual({
+      createPartnerList: {
+        partnerListOrError: {
+          __typename: "CreatePartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+            listType: "SHOW",
+            artworksCount: 0,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      createPartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "Partner not found" },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      createPartnerList: {
+        partnerListOrError: {
+          __typename: "CreatePartnerListFailure",
+          mutationError: {
+            message: "Partner not found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        createPartnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/deletePartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/deletePartnerListMutation.test.ts
@@ -1,0 +1,83 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DeletePartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      deletePartnerList(input: { id: "list-abc" }) {
+        partnerListOrError {
+          __typename
+          ... on DeletePartnerListSuccess {
+            partnerList {
+              internalID
+              name
+            }
+          }
+          ... on DeletePartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("deletes a partner list", async () => {
+    const context = {
+      deletePartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 0,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.deletePartnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      deletePartnerList: {
+        partnerListOrError: {
+          __typename: "DeletePartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      deletePartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "List not found" },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      deletePartnerList: {
+        partnerListOrError: {
+          __typename: "DeletePartnerListFailure",
+          mutationError: {
+            message: "List not found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        deletePartnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/distributePartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/distributePartnerListMutation.test.ts
@@ -1,0 +1,89 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DistributePartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      distributePartnerList(input: { id: "list-abc" }) {
+        partnerListOrError {
+          __typename
+          ... on DistributePartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              distributedAt
+              partnerShowID
+            }
+          }
+          ... on DistributePartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("distributes a partner list", async () => {
+    const context = {
+      distributePartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 3,
+        distributed_at: "2026-01-15T00:00:00+00:00",
+        partner_show_id: "show-xyz",
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-15T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.distributePartnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      distributePartnerList: {
+        partnerListOrError: {
+          __typename: "DistributePartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+            distributedAt: "2026-01-15T00:00:00+00:00",
+            partnerShowID: "show-xyz",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      distributePartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "List has no artworks" },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      distributePartnerList: {
+        partnerListOrError: {
+          __typename: "DistributePartnerListFailure",
+          mutationError: {
+            message: "List has no artworks",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        distributePartnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/removeArtworkFromPartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/removeArtworkFromPartnerListMutation.test.ts
@@ -1,0 +1,94 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("RemoveArtworkFromPartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      removeArtworkFromPartnerList(
+        input: { listId: "list-abc", artworkId: "artwork-123" }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on RemoveArtworkFromPartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              artworksCount
+            }
+          }
+          ... on RemoveArtworkFromPartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("removes an artwork from a partner list", async () => {
+    const context = {
+      removeArtworkFromPartnerListLoader: jest.fn().mockResolvedValue({}),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 0,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.removeArtworkFromPartnerListLoader).toHaveBeenCalledWith({
+      listId: "list-abc",
+      artworkId: "artwork-123",
+    })
+    expect(context.partnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      removeArtworkFromPartnerList: {
+        partnerListOrError: {
+          __typename: "RemoveArtworkFromPartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+            artworksCount: 0,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      removeArtworkFromPartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "Artwork not in list" },
+      }),
+      partnerListLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      removeArtworkFromPartnerList: {
+        partnerListOrError: {
+          __typename: "RemoveArtworkFromPartnerListFailure",
+          mutationError: {
+            message: "Artwork not in list",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        removeArtworkFromPartnerListLoader: undefined,
+        partnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/repositionPartnerListArtworksMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/repositionPartnerListArtworksMutation.test.ts
@@ -1,0 +1,97 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("RepositionPartnerListArtworksMutation", () => {
+  const mutation = gql`
+    mutation {
+      repositionPartnerListArtworks(
+        input: {
+          listId: "list-abc"
+          artworkIds: ["artwork-3", "artwork-1", "artwork-2"]
+        }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on RepositionPartnerListArtworksSuccess {
+            partnerList {
+              internalID
+              name
+            }
+          }
+          ... on RepositionPartnerListArtworksFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("repositions artworks in a partner list", async () => {
+    const context = {
+      repositionPartnerListArtworksLoader: jest.fn().mockResolvedValue({}),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 3,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.repositionPartnerListArtworksLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        artwork_ids: ["artwork-3", "artwork-1", "artwork-2"],
+      }
+    )
+    expect(context.partnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      repositionPartnerListArtworks: {
+        partnerListOrError: {
+          __typename: "RepositionPartnerListArtworksSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      repositionPartnerListArtworksLoader: jest.fn().mockRejectedValue({
+        body: { message: "Invalid artwork IDs" },
+      }),
+      partnerListLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      repositionPartnerListArtworks: {
+        partnerListOrError: {
+          __typename: "RepositionPartnerListArtworksFailure",
+          mutationError: {
+            message: "Invalid artwork IDs",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        repositionPartnerListArtworksLoader: undefined,
+        partnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListArtworkPositionMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListArtworkPositionMutation.test.ts
@@ -1,0 +1,92 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerListArtworkPositionMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerListArtworkPosition(
+        input: { listId: "list-abc", artworkId: "artwork-123", position: 2 }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on UpdatePartnerListArtworkPositionSuccess {
+            partnerList {
+              internalID
+              name
+            }
+          }
+          ... on UpdatePartnerListArtworkPositionFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates the position of an artwork in a partner list", async () => {
+    const context = {
+      updatePartnerListArtworkLoader: jest.fn().mockResolvedValue({}),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Spring 2026 Show",
+        list_type: "show",
+        artworks_count: 3,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-01T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.updatePartnerListArtworkLoader).toHaveBeenCalledWith(
+      { listId: "list-abc", artworkId: "artwork-123" },
+      { position: 2 }
+    )
+    expect(context.partnerListLoader).toHaveBeenCalledWith("list-abc")
+
+    expect(result).toEqual({
+      updatePartnerListArtworkPosition: {
+        partnerListOrError: {
+          __typename: "UpdatePartnerListArtworkPositionSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Spring 2026 Show",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      updatePartnerListArtworkLoader: jest.fn().mockRejectedValue({
+        body: { message: "Artwork not in list" },
+      }),
+      partnerListLoader: jest.fn(),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updatePartnerListArtworkPosition: {
+        partnerListOrError: {
+          __typename: "UpdatePartnerListArtworkPositionFailure",
+          mutationError: {
+            message: "Artwork not in list",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        updatePartnerListArtworkLoader: undefined,
+        partnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListMutation.test.ts
@@ -1,0 +1,90 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerListMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerList(
+        input: { id: "list-abc", name: "Updated Name", listType: FAIR }
+      ) {
+        partnerListOrError {
+          __typename
+          ... on UpdatePartnerListSuccess {
+            partnerList {
+              internalID
+              name
+              listType
+            }
+          }
+          ... on UpdatePartnerListFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates a partner list", async () => {
+    const context = {
+      updatePartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Updated Name",
+        list_type: "fair",
+        artworks_count: 5,
+        created_at: "2026-01-01T00:00:00+00:00",
+        updated_at: "2026-01-02T00:00:00+00:00",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.updatePartnerListLoader).toHaveBeenCalledWith("list-abc", {
+      name: "Updated Name",
+      list_type: "fair",
+    })
+
+    expect(result).toEqual({
+      updatePartnerList: {
+        partnerListOrError: {
+          __typename: "UpdatePartnerListSuccess",
+          partnerList: {
+            internalID: "list-abc",
+            name: "Updated Name",
+            listType: "FAIR",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      updatePartnerListLoader: jest.fn().mockRejectedValue({
+        body: { message: "List not found" },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      updatePartnerList: {
+        partnerListOrError: {
+          __typename: "UpdatePartnerListFailure",
+          mutationError: {
+            message: "List not found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        updatePartnerListLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/addArtworkToPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/addArtworkToPartnerListMutation.ts
@@ -1,0 +1,92 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface AddArtworkToPartnerListMutationInputProps {
+  listId: string
+  artworkId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AddArtworkToPartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AddArtworkToPartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "AddArtworkToPartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const addArtworkToPartnerListMutation = mutationWithClientMutationId<
+  AddArtworkToPartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "AddArtworkToPartnerListMutation",
+  description: "Adds an artwork to a partner list.",
+  inputFields: {
+    listId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    artworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork to add.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { listId, artworkId },
+    { addArtworkToPartnerListLoader, partnerListLoader }
+  ) => {
+    if (!addArtworkToPartnerListLoader || !partnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await addArtworkToPartnerListLoader({ listId, artworkId })
+      return await partnerListLoader(listId)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/bulkAddArtworksToPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/bulkAddArtworksToPartnerListMutation.ts
@@ -1,0 +1,97 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface BulkAddArtworksToPartnerListMutationInputProps {
+  listId: string
+  artworkIds: string[]
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "BulkAddArtworksToPartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "BulkAddArtworksToPartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "BulkAddArtworksToPartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const bulkAddArtworksToPartnerListMutation = mutationWithClientMutationId<
+  BulkAddArtworksToPartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "BulkAddArtworksToPartnerListMutation",
+  description: "Bulk adds artworks to a partner list.",
+  inputFields: {
+    listId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    artworkIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description: "The IDs of the artworks to add.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { listId, artworkIds },
+    { bulkAddArtworksToPartnerListLoader, partnerListLoader }
+  ) => {
+    if (!bulkAddArtworksToPartnerListLoader || !partnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await bulkAddArtworksToPartnerListLoader(listId, {
+        artwork_ids: artworkIds,
+      })
+      return await partnerListLoader(listId)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
@@ -1,0 +1,115 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType, PartnerListTypeEnum } from "schema/v2/partnerList"
+
+interface CreatePartnerListMutationInputProps {
+  partnerID: string
+  name: string
+  listType?: string
+  startAt?: string
+  endAt?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createPartnerListMutation = mutationWithClientMutationId<
+  CreatePartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerListMutation",
+  description: "Creates a new partner list.",
+  inputFields: {
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner.",
+    },
+    name: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The name of the list.",
+    },
+    listType: {
+      type: PartnerListTypeEnum,
+      description: "The type of list (show, fair, or other).",
+    },
+    startAt: {
+      type: GraphQLString,
+      description: "Start date for the list.",
+    },
+    endAt: {
+      type: GraphQLString,
+      description: "End date for the list.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the created partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerID, name, listType, startAt, endAt },
+    { createPartnerListLoader }
+  ) => {
+    if (!createPartnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const gravityArgs: Record<string, unknown> = {
+      partner_id: partnerID,
+      name,
+    }
+
+    if (listType !== undefined) gravityArgs.list_type = listType
+    if (startAt !== undefined) gravityArgs.start_at = startAt
+    if (endAt !== undefined) gravityArgs.end_at = endAt
+
+    try {
+      return await createPartnerListLoader(gravityArgs)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/deletePartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/deletePartnerListMutation.ts
@@ -1,0 +1,83 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface DeletePartnerListMutationInputProps {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeletePartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const deletePartnerListMutation = mutationWithClientMutationId<
+  DeletePartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DeletePartnerListMutation",
+  description: "Deletes a partner list.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the deleted partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deletePartnerListLoader }) => {
+    if (!deletePartnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await deletePartnerListLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/distributePartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/distributePartnerListMutation.ts
@@ -1,0 +1,83 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface DistributePartnerListMutationInputProps {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DistributePartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DistributePartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DistributePartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const distributePartnerListMutation = mutationWithClientMutationId<
+  DistributePartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DistributePartnerListMutation",
+  description: "Distributes a partner list to Artsy, creating a draft show.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the distributed partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { distributePartnerListLoader }) => {
+    if (!distributePartnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await distributePartnerListLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/removeArtworkFromPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/removeArtworkFromPartnerListMutation.ts
@@ -1,0 +1,92 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface RemoveArtworkFromPartnerListMutationInputProps {
+  listId: string
+  artworkId: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RemoveArtworkFromPartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RemoveArtworkFromPartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RemoveArtworkFromPartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const removeArtworkFromPartnerListMutation = mutationWithClientMutationId<
+  RemoveArtworkFromPartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "RemoveArtworkFromPartnerListMutation",
+  description: "Removes an artwork from a partner list.",
+  inputFields: {
+    listId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    artworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork to remove.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { listId, artworkId },
+    { removeArtworkFromPartnerListLoader, partnerListLoader }
+  ) => {
+    if (!removeArtworkFromPartnerListLoader || !partnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await removeArtworkFromPartnerListLoader({ listId, artworkId })
+      return await partnerListLoader(listId)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/repositionPartnerListArtworksMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/repositionPartnerListArtworksMutation.ts
@@ -1,0 +1,98 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface RepositionPartnerListArtworksMutationInputProps {
+  listId: string
+  artworkIds: string[]
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerListArtworksSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RepositionPartnerListArtworksFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RepositionPartnerListArtworksResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const repositionPartnerListArtworksMutation = mutationWithClientMutationId<
+  RepositionPartnerListArtworksMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "RepositionPartnerListArtworksMutation",
+  description: "Repositions all artworks in a partner list.",
+  inputFields: {
+    listId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    artworkIds: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      description:
+        "The ordered list of artwork IDs representing the new positions.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { listId, artworkIds },
+    { repositionPartnerListArtworksLoader, partnerListLoader }
+  ) => {
+    if (!repositionPartnerListArtworksLoader || !partnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await repositionPartnerListArtworksLoader(listId, {
+        artwork_ids: artworkIds,
+      })
+      return await partnerListLoader(listId)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListArtworkPositionMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListArtworkPositionMutation.ts
@@ -1,0 +1,98 @@
+import {
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType } from "schema/v2/partnerList"
+
+interface UpdatePartnerListArtworkPositionMutationInputProps {
+  listId: string
+  artworkId: string
+  position: number
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerListArtworkPositionSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerListArtworkPositionFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerListArtworkPositionResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerListArtworkPositionMutation = mutationWithClientMutationId<
+  UpdatePartnerListArtworkPositionMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerListArtworkPositionMutation",
+  description: "Updates the position of an artwork in a partner list.",
+  inputFields: {
+    listId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    artworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork.",
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description: "The new position of the artwork.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { listId, artworkId, position },
+    { updatePartnerListArtworkLoader, partnerListLoader }
+  ) => {
+    if (!updatePartnerListArtworkLoader || !partnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      await updatePartnerListArtworkLoader({ listId, artworkId }, { position })
+      return await partnerListLoader(listId)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
@@ -1,0 +1,113 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListType, PartnerListTypeEnum } from "schema/v2/partnerList"
+
+interface UpdatePartnerListMutationInputProps {
+  id: string
+  name?: string
+  listType?: string
+  startAt?: string
+  endAt?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerListSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerList: {
+      type: PartnerListType,
+      resolve: (partnerList) => partnerList,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerListFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerListResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const updatePartnerListMutation = mutationWithClientMutationId<
+  UpdatePartnerListMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerListMutation",
+  description: "Updates an existing partner list.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list.",
+    },
+    name: {
+      type: GraphQLString,
+      description: "The name of the list.",
+    },
+    listType: {
+      type: PartnerListTypeEnum,
+      description: "The type of list (show, fair, or other).",
+    },
+    startAt: {
+      type: GraphQLString,
+      description: "Start date for the list.",
+    },
+    endAt: {
+      type: GraphQLString,
+      description: "End date for the list.",
+    },
+  },
+  outputFields: {
+    partnerListOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the updated partner list. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { id, name, listType, startAt, endAt },
+    { updatePartnerListLoader }
+  ) => {
+    if (!updatePartnerListLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const gravityArgs: Record<string, unknown> = {}
+
+    if (name !== undefined) gravityArgs.name = name
+    if (listType !== undefined) gravityArgs.list_type = listType
+    if (startAt !== undefined) gravityArgs.start_at = startAt
+    if (endAt !== undefined) gravityArgs.end_at = endAt
+
+    try {
+      return await updatePartnerListLoader(id, gravityArgs)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -47,6 +47,10 @@ import { articleConnection } from "schema/v2/article"
 import ArticleSorts, { ArticleSort } from "schema/v2/sorts/article_sorts"
 import { allViaLoader } from "lib/all"
 import { truncate } from "lib/helpers"
+import {
+  partnerListConnection,
+  PartnerListTypeEnum,
+} from "schema/v2/partnerList"
 import { setVersion } from "schema/v2/image/normalize"
 import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
@@ -1449,6 +1453,46 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       showsSearchConnection: partnerShowsMatchConnection,
+      partnerListsConnection: {
+        description: "A connection of lists from a Partner.",
+        type: partnerListConnection.connectionType,
+        args: pageable({
+          listType: {
+            type: PartnerListTypeEnum,
+            description: "Filter by list type.",
+          },
+        }),
+        resolve: async ({ id }, args, { partnerListsLoader }) => {
+          if (!partnerListsLoader) return null
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const gravityArgs: Record<string, unknown> = {
+            partner_id: id,
+            page,
+            size,
+            total_count: true,
+          }
+
+          if (args.listType) {
+            gravityArgs.list_type = args.listType
+          }
+
+          const { body, headers } = await partnerListsLoader(gravityArgs)
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+          })
+        },
+      },
       type: {
         type: GraphQLString,
         resolve: ({ name, type }) => {

--- a/src/schema/v2/partnerList.ts
+++ b/src/schema/v2/partnerList.ts
@@ -1,0 +1,101 @@
+import {
+  GraphQLEnumType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "./object_identification"
+import { date } from "./fields/date"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "./fields/pagination"
+
+export const PartnerListTypeEnum = new GraphQLEnumType({
+  name: "PartnerListTypeEnum",
+  values: {
+    SHOW: { value: "show" },
+    FAIR: { value: "fair" },
+    OTHER: { value: "other" },
+  },
+})
+
+export const PartnerListType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PartnerList",
+  fields: () => {
+    // Defer import to avoid circular dependency
+    const { ArtworkType } = require("./artwork")
+
+    const PartnerListArtworkConnection = connectionWithCursorInfo({
+      name: "PartnerListArtwork",
+      nodeType: ArtworkType,
+      edgeFields: {
+        position: {
+          type: new GraphQLNonNull(GraphQLInt),
+          resolve: ({ position }) => position,
+        },
+      },
+    })
+
+    return {
+      ...InternalIDFields,
+      name: {
+        type: new GraphQLNonNull(GraphQLString),
+      },
+      listType: {
+        type: new GraphQLNonNull(PartnerListTypeEnum),
+        resolve: ({ list_type }) => list_type,
+      },
+      artworksCount: {
+        type: new GraphQLNonNull(GraphQLInt),
+        resolve: ({ artworks_count }) => artworks_count,
+      },
+      startAt: date(({ start_at }) => start_at),
+      endAt: date(({ end_at }) => end_at),
+      partnerShowID: {
+        type: GraphQLString,
+        resolve: ({ partner_show_id }) => partner_show_id,
+      },
+      distributedAt: date(({ distributed_at }) => distributed_at),
+      createdAt: date(),
+      updatedAt: date(),
+      artworksConnection: {
+        type: PartnerListArtworkConnection.connectionType,
+        args: pageable({}),
+        resolve: async ({ id }, args, { partnerListArtworksLoader }) => {
+          if (!partnerListArtworksLoader) return null
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await partnerListArtworksLoader(id, {
+            page,
+            size,
+            total_count: true,
+          })
+
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            totalCount,
+            offset,
+            page,
+            size,
+            body,
+            args,
+            resolveNode: (node) => node.artwork,
+          })
+        },
+      },
+    }
+  },
+})
+
+export const partnerListConnection = connectionWithCursorInfo({
+  nodeType: PartnerListType,
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -294,6 +294,15 @@ import { updatePartnerShowEventMutation } from "./Show/updatePartnerShowEventMut
 import { updatePartnerShowDocumentMutation } from "./Show/updatePartnerShowDocumentMutation"
 import { createCatalogArtworkDocumentMutation } from "./partner/Mutations/CatalogArtwork/createCatalogArtworkDocumentMutation"
 import { deleteCatalogArtworkDocumentMutation } from "./partner/Mutations/CatalogArtwork/deleteCatalogArtworkDocumentMutation"
+import { createPartnerListMutation } from "./partner/Mutations/PartnerList/createPartnerListMutation"
+import { updatePartnerListMutation } from "./partner/Mutations/PartnerList/updatePartnerListMutation"
+import { deletePartnerListMutation } from "./partner/Mutations/PartnerList/deletePartnerListMutation"
+import { distributePartnerListMutation } from "./partner/Mutations/PartnerList/distributePartnerListMutation"
+import { addArtworkToPartnerListMutation } from "./partner/Mutations/PartnerList/addArtworkToPartnerListMutation"
+import { removeArtworkFromPartnerListMutation } from "./partner/Mutations/PartnerList/removeArtworkFromPartnerListMutation"
+import { bulkAddArtworksToPartnerListMutation } from "./partner/Mutations/PartnerList/bulkAddArtworksToPartnerListMutation"
+import { updatePartnerListArtworkPositionMutation } from "./partner/Mutations/PartnerList/updatePartnerListArtworkPositionMutation"
+import { repositionPartnerListArtworksMutation } from "./partner/Mutations/PartnerList/repositionPartnerListArtworksMutation"
 import { createShippingPresetMutation } from "./ShippingPreset/createShippingPresetMutation"
 import { updateShippingPresetMutation } from "./ShippingPreset/updateShippingPresetMutation"
 import { deleteShippingPresetMutation } from "./ShippingPreset/deleteShippingPresetMutation"
@@ -571,6 +580,7 @@ export default new GraphQLSchema({
     fields: {
       acceptPartnerAgreement: acceptPartnerAgreementMutation,
       ackTask: ackTaskMutation,
+      addArtworkToPartnerList: addArtworkToPartnerListMutation,
       addArtworkToPartnerShow: addArtworkToPartnerShowMutation,
       addInstallShotToPartnerShow: addInstallShotToPartnerShowMutation,
       createBuyerOffer: createBuyerOfferMutation,
@@ -583,6 +593,7 @@ export default new GraphQLSchema({
       adminUpdateFeatureFlag: updateFeatureFlagMutation,
       artsyShippingOptIn: artsyShippingOptInMutation,
       artworksCollectionsBatchUpdate: artworksCollectionsBatchUpdateMutation,
+      bulkAddArtworksToPartnerList: bulkAddArtworksToPartnerListMutation,
       bulkAddArtworksToShow: bulkAddArtworksToShowMutation,
       bulkUpdateArtworksMetadata: bulkUpdateArtworksMetadataMutation,
       confirmPassword: confirmPasswordMutation,
@@ -622,6 +633,7 @@ export default new GraphQLSchema({
       createPartnerLocationDaySchedules: CreatePartnerLocationDaySchedulesMutation,
       createPartnerArtistDocument: createPartnerArtistDocumentMutation,
       createPartnerArtworksExport: createPartnerArtworksExportMutation,
+      createPartnerList: createPartnerListMutation,
       createPartnerShow: createPartnerShowMutation,
       createPartnerShowDocument: createPartnerShowDocumentMutation,
       createPartnerShowEvent: createPartnerShowEventMutation,
@@ -670,6 +682,7 @@ export default new GraphQLSchema({
       deleteFeature: DeleteFeatureMutation,
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
+      deletePartnerList: deletePartnerListMutation,
       deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
       deletePartnerArtistDocument: deletePartnerArtistDocumentMutation,
@@ -696,6 +709,7 @@ export default new GraphQLSchema({
       deleteViewingRoom: deleteViewingRoomMutation,
       deliverSecondFactor: deliverSecondFactorMutation,
       disableSecondFactor: disableSecondFactorMutation,
+      distributePartnerList: distributePartnerListMutation,
       dislikeArtwork: dislikeArtworkMutation,
       dismissTask: dismissTaskMutation,
       enableSecondFactor: enableSecondFactorMutation,
@@ -714,12 +728,14 @@ export default new GraphQLSchema({
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
       publishNavigationDraft: publishNavigationDraftMutation,
       publishViewingRoom: publishViewingRoomMutation,
+      removeArtworkFromPartnerList: removeArtworkFromPartnerListMutation,
       removeArtworkFromPartnerShow: removeArtworkFromPartnerShowMutation,
       removeInstallShotFromPartnerShow: removeInstallShotFromPartnerShowMutation,
       repositionArtworkImages: repositionArtworkImagesMutation,
       repositionViewingRoomArtworks: repositionViewingRoomArtworksMutation,
       repositionArtworksInPartnerShow: repositionArtworksInPartnerShowMutation,
       repositionInstallShotsInPartnerShow: repositionInstallShotsInPartnerShowMutation,
+      repositionPartnerListArtworks: repositionPartnerListArtworksMutation,
       repositionPartnerArtistArtworks: repositionPartnerArtistArtworksMutation,
       repositionPartnerLocations: repositionPartnerLocationsMutation,
       recordArtworkView: recordArtworkViewMutation,
@@ -791,6 +807,8 @@ export default new GraphQLSchema({
       updatePartnerArtistDocument: updatePartnerArtistDocumentMutation,
       updatePartnerShowDocument: updatePartnerShowDocumentMutation,
       updatePartnerShowEvent: updatePartnerShowEventMutation,
+      updatePartnerList: updatePartnerListMutation,
+      updatePartnerListArtworkPosition: updatePartnerListArtworkPositionMutation,
       updatePartner: updatePartnerMutation,
       updatePartnerFlags: updatePartnerFlagsMutation,
       updateProfile: updateProfileMutation,


### PR DESCRIPTION
Adds the schema and mutations (boilerplate) for https://github.com/artsy/gravity/pull/20015 to support the client-facing stuff.