### PR TITLE
feat: Allow updating the certificate of authenticity in the update artwork mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -26546,6 +26546,15 @@ input UpdateArtworkEditionSetInput {
   # The availability of the artwork
   availability: String
 
+  # Whether the artwork has a certificate of authenticity
+  certificateOfAuthenticity: Boolean
+
+  # Whether the certificate of authenticity is issued by an authenticating body
+  coaByAuthenticatingBody: Boolean
+
+  # Whether the certificate of authenticity is issued by the gallery
+  coaByGallery: Boolean
+
   # The ID of the image to set as the default for this artwork
   defaultImageID: String
   delete: Boolean
@@ -26714,7 +26723,16 @@ input UpdateArtworkMutationInput {
 
   # The availability of the artwork
   availability: String
+
+  # Whether the artwork has a certificate of authenticity
+  certificateOfAuthenticity: Boolean
   clientMutationId: String
+
+  # Whether the certificate of authenticity is issued by an authenticating body
+  coaByAuthenticatingBody: Boolean
+
+  # Whether the certificate of authenticity is issued by the gallery
+  coaByGallery: Boolean
 
   # The date or year of the artwork
   date: String

--- a/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
@@ -803,6 +803,53 @@ describe("UpdateArtworkMutation", () => {
     })
   })
 
+  describe("certificate of authenticity fields", () => {
+    it("passes coa fields to the loader", async () => {
+      const updateArtworkLoader = jest.fn().mockResolvedValue({
+        id: "25",
+        _id: "25",
+      })
+
+      const context = {
+        updateArtworkLoader,
+        updateArtworkEditionSetLoader: jest.fn(),
+      }
+
+      const coaMutation = gql`
+        mutation {
+          updateArtwork(
+            input: {
+              id: "25"
+              certificateOfAuthenticity: true
+              coaByGallery: true
+              coaByAuthenticatingBody: false
+            }
+          ) {
+            artworkOrError {
+              __typename
+              ... on updateArtworkSuccess {
+                artwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      await runAuthenticatedQuery(coaMutation, context)
+
+      expect(updateArtworkLoader).toHaveBeenCalledWith(
+        "25",
+        expect.objectContaining({
+          certificate_of_authenticity: true,
+          coa_by_gallery: true,
+          coa_by_authenticating_body: false,
+        })
+      )
+    })
+  })
+
   describe("artsyListing field", () => {
     it("passes artsy_listing to the loader when provided", async () => {
       const updateArtworkLoader = jest.fn().mockResolvedValue({

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -56,6 +56,9 @@ interface UpdateArtworkMutationInputProps {
   artsyListing?: boolean
   artistProofs?: string
   availability?: string
+  certificateOfAuthenticity?: boolean
+  coaByGallery?: boolean
+  coaByAuthenticatingBody?: boolean
   mediumType?: string
   date?: string
   defaultImageID?: string
@@ -66,7 +69,12 @@ interface UpdateArtworkMutationInputProps {
   ecommerce?: boolean
   editionSets?: Omit<
     UpdateArtworkMutationInputProps,
-    "editionSets" | "artistIds" | "mediumType" | "date" | "inventoryId" | "provenance"
+    | "editionSets"
+    | "artistIds"
+    | "mediumType"
+    | "date"
+    | "inventoryId"
+    | "provenance"
   >[]
   editionSize?: string
   framed?: boolean
@@ -116,6 +124,20 @@ const inputFields = {
   availability: {
     type: GraphQLString,
     description: "The availability of the artwork",
+  },
+  certificateOfAuthenticity: {
+    type: GraphQLBoolean,
+    description: "Whether the artwork has a certificate of authenticity",
+  },
+  coaByGallery: {
+    type: GraphQLBoolean,
+    description:
+      "Whether the certificate of authenticity is issued by the gallery",
+  },
+  coaByAuthenticatingBody: {
+    type: GraphQLBoolean,
+    description:
+      "Whether the certificate of authenticity is issued by an authenticating body",
   },
   mediumType: {
     type: GraphQLString,
@@ -307,6 +329,9 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         artsy_listing: inputArgs.artsyListing,
         artist_proofs: inputArgs.artistProofs,
         availability: inputArgs.availability,
+        certificate_of_authenticity: inputArgs.certificateOfAuthenticity,
+        coa_by_gallery: inputArgs.coaByGallery,
+        coa_by_authenticating_body: inputArgs.coaByAuthenticatingBody,
         category: inputArgs.mediumType,
         date: inputArgs.date,
         delete: inputArgs.delete,


### PR DESCRIPTION
### Description

This PR updates the Update Artwork mutation to include the certificate of authenticity fields

cc @artsy/amber-devs 