### PR TITLE
chore: support partner list bulk edits

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5437,6 +5437,9 @@ input BulkArtworkFilterInput {
   # Filter artworks by partner artist id
   partnerArtistId: String
 
+  # Filter artworks by partner list id
+  partnerListId: String
+
   # Filter artworks by published status
   published: Boolean
 }
@@ -5589,6 +5592,7 @@ enum BulkUpdateSourceEnum {
   ADMIN
   ARTWORKS_LIST
   PARTNER_ARTIST_ARTWORKS_LIST
+  PARTNER_LIST
   SHOW_ARTWORKS_LIST
 }
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -118,6 +118,7 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
           availability: "for sale",
           location_id: "oldLocation",
           partner_artist_id: "artist789",
+          partner_list_id: undefined,
           published: true,
         },
         source: "artworks_list",
@@ -139,6 +140,50 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
         },
       },
     })
+  })
+
+  it("respects the partnerListId filter parameter", async () => {
+    const mutationWithPartnerListFilter = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            source: PARTNER_LIST
+            metadata: { category: "Painting" }
+            filters: { partnerListId: "list-uuid-123" }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 3,
+        errors: {
+          count: 0,
+          ids: [],
+        },
+      }),
+    }
+
+    await runAuthenticatedQuery(mutationWithPartnerListFilter, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        source: "partner_list",
+        metadata: {
+          category: "Painting",
+        },
+        filters: {
+          partner_list_id: "list-uuid-123",
+        },
+      }
+    )
   })
 
   it("respects the filter parameters", async () => {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -67,6 +67,7 @@ interface Input {
     artworkIds?: string[]
     locationId?: string
     partnerArtistId?: string
+    partnerListId?: string
     published?: boolean
   }
 }
@@ -376,6 +377,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         artwork_ids: filters.artworkIds,
         location_id: filters.locationId,
         partner_artist_id: filters.partnerArtistId,
+        partner_list_id: filters.partnerListId,
         published: filters.published,
       }
     }

--- a/src/schema/v2/partner/BulkOperation/shared.ts
+++ b/src/schema/v2/partner/BulkOperation/shared.ts
@@ -29,6 +29,10 @@ export const BulkArtworkFilterInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "Filter artworks by partner artist id",
     },
+    partnerListId: {
+      type: GraphQLString,
+      description: "Filter artworks by partner list id",
+    },
     published: {
       type: GraphQLBoolean,
       description: "Filter artworks by published status",

--- a/src/schema/v2/partner/BulkUpdateSourceEnum.ts
+++ b/src/schema/v2/partner/BulkUpdateSourceEnum.ts
@@ -8,5 +8,6 @@ export const BulkUpdateSourceEnum = new GraphQLEnumType({
     ARTWORKS_LIST: { value: "artworks_list" },
     PARTNER_ARTIST_ARTWORKS_LIST: { value: "partner_artist_artworks_list" },
     SHOW_ARTWORKS_LIST: { value: "show_artworks_list" },
+    PARTNER_LIST: { value: "partner_list" },
   },
 })


### PR DESCRIPTION
The schema updates needed with https://github.com/artsy/gravity/pull/20030 to enable bulk edits on a partner list (just passing those values down to the mutation).