### PR TITLE
chore: public url for catalog documents

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5705,6 +5705,7 @@ type CatalogArtworkDocument {
 
   # A type-specific ID likely used as a database ID.
   internalID: ID!
+  publicURL: String!
   title: String
   updatedAt(
     format: String
@@ -5712,7 +5713,6 @@ type CatalogArtworkDocument {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
-  url: String!
 }
 
 type CausalityLotState {

--- a/src/schema/v2/catalogArtworkDocument.ts
+++ b/src/schema/v2/catalogArtworkDocument.ts
@@ -4,6 +4,7 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
+import config from "config"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
 import { date } from "./fields/date"
@@ -29,8 +30,12 @@ export const CatalogArtworkDocumentType = new GraphQLObjectType<
       type: GraphQLInt,
       resolve: ({ file_size }) => file_size,
     },
-    url: {
+    publicURL: {
       type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ id, filename, catalog_artwork_id }) => {
+        const ext = filename.split(".").pop()
+        return `${config.GRAVITY_API_BASE}/catalog_artwork_document/${id}.${ext}?catalog_artwork_id=${catalog_artwork_id}`
+      },
     },
     createdAt: date(),
     updatedAt: date(),

--- a/src/schema/v2/partner/Mutations/CatalogArtwork/__tests__/createCatalogArtworkDocumentMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/CatalogArtwork/__tests__/createCatalogArtworkDocumentMutation.test.ts
@@ -20,7 +20,7 @@ describe("CreateCatalogArtworkDocumentMutation", () => {
               internalID
               filename
               title
-              url
+              publicURL
             }
           }
           ... on CreateCatalogArtworkDocumentFailure {
@@ -66,8 +66,8 @@ describe("CreateCatalogArtworkDocumentMutation", () => {
             internalID: "document-abc",
             filename: "document.pdf",
             title: "Provenance",
-            url:
-              "https://s3.amazonaws.com/artsy-uploads/catalog_artworks/catalog-artwork-123/document.pdf",
+            publicURL:
+              "https://api.artsy.test/api/v1/catalog_artwork_document/document-abc.pdf?catalog_artwork_id=catalog-artwork-123",
           },
         },
       },

--- a/src/schema/v2/partner/Mutations/CatalogArtwork/__tests__/deleteCatalogArtworkDocumentMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/CatalogArtwork/__tests__/deleteCatalogArtworkDocumentMutation.test.ts
@@ -17,7 +17,7 @@ describe("DeleteCatalogArtworkDocumentMutation", () => {
               internalID
               filename
               title
-              url
+              publicURL
             }
           }
           ... on DeleteCatalogArtworkDocumentFailure {
@@ -60,8 +60,8 @@ describe("DeleteCatalogArtworkDocumentMutation", () => {
             internalID: "document-abc",
             filename: "document.pdf",
             title: "Provenance",
-            url:
-              "https://s3.amazonaws.com/artsy-uploads/catalog_artworks/catalog-artwork-123/document.pdf",
+            publicURL:
+              "https://api.artsy.test/api/v1/catalog_artwork_document/document-abc.pdf?catalog_artwork_id=catalog-artwork-123",
           },
         },
       },


### PR DESCRIPTION
Follow up for https://github.com/artsy/gravity/pull/20033 to make things consistent across document management, gating the document access through a Gravity endpoint

@artsy/amber-devs 