### PR TITLE
feat(artwork): implement title variants based on Unleash flag

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -10,6 +10,7 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
  */
 const FEATURE_FLAGS_LIST = [
   "onyx_nwfy-artworks-card-test",
+  "diamond_artwork-title-experiment",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -1,4 +1,9 @@
 import { runQuery } from "schema/v2/test/utils"
+import * as featureFlags from "lib/featureFlags"
+
+jest.mock("lib/featureFlags", () => ({
+  getExperimentVariant: jest.fn(),
+}))
 
 describe("Meta", () => {
   const artworkData = {
@@ -91,6 +96,107 @@ describe("Meta", () => {
               "Check out Hans Hartung, P. 25-1975-H-8 (1975), From Galerie Michel Descours",
           },
         },
+      })
+    })
+  })
+
+  describe("title experiment", () => {
+    beforeEach(() => {
+      artworkData.sale_message = "Price on request"
+    })
+
+    const query = `
+      {
+        artwork(id:"hans-hartung-p-25-1975-h-8") {
+          meta {
+            title
+          }
+        }
+      }
+    `
+
+    test("control renders current title", async () => {
+      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+        enabled: true,
+        name: "control",
+      } as any)
+
+      const data = await runQuery(query, context as any)
+
+      expect(data.artwork.meta.title).toBe(
+        "Hans Hartung | P. 25-1975-H-8 (1975) | Available for Sale | Artsy"
+      )
+    })
+
+    test("variant-a shortens availability", async () => {
+      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+        enabled: true,
+        name: "variant-a",
+      } as any)
+
+      const data = await runQuery(query, context as any)
+
+      expect(data.artwork.meta.title).toBe(
+        "Hans Hartung | P. 25-1975-H-8 (1975) | For Sale | Artsy"
+      )
+    })
+
+    test("variant-b shortens availability and removes year", async () => {
+      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+        enabled: true,
+        name: "variant-b",
+      } as any)
+
+      const data = await runQuery(query, context as any)
+
+      expect(data.artwork.meta.title).toBe(
+        "Hans Hartung | P. 25-1975-H-8 | For Sale | Artsy"
+      )
+    })
+
+    describe("with a long title", () => {
+      beforeEach(() => {
+        artworkData.title =
+          "This title is very very very very very very very very very long"
+      })
+
+      test("control displays full title", async () => {
+        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+          enabled: true,
+          name: "control",
+        } as any)
+
+        const data = await runQuery(query, context as any)
+
+        expect(data.artwork.meta.title).toBe(
+          "Hans Hartung | This title is very very very very very very very very very long (1975) | Available for Sale | Artsy"
+        )
+      })
+
+      test("variant-a truncates title", async () => {
+        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+          enabled: true,
+          name: "variant-a",
+        } as any)
+
+        const data = await runQuery(query, context as any)
+
+        expect(data.artwork.meta.title).toBe(
+          "Hans Hartung | This title is very very very very very very very ver… (1975) | For Sale | Artsy"
+        )
+      })
+
+      test("variant-b truncates title", async () => {
+        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
+          enabled: true,
+          name: "variant-b",
+        } as any)
+
+        const data = await runQuery(query, context as any)
+
+        expect(data.artwork.meta.title).toBe(
+          "Hans Hartung | This title is very very very very very very very ver… | For Sale | Artsy"
+        )
       })
     })
   })

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -9,12 +9,19 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { getExperimentVariant } from "lib/featureFlags"
+
+const EXPERIMENT_NAME = "diamond_artwork-title-experiment"
+const TITLE_MAX_LENGTH = 52 // p95
 
 const isInquireAboutAvailability = (saleMessage) =>
   saleMessage == "Inquire about availability"
 
 const titleWithDate = ({ title, date }) =>
   join(" ", [title, date ? `(${date})` : undefined])
+
+const titleWithDateV2 = ({ title, date }) =>
+  join(" ", [truncate(title, TITLE_MAX_LENGTH), date ? `(${date})` : undefined])
 
 export const artistNames = (artwork) =>
   artwork.cultural_maker || map(artwork.artists, "name").join(", ")
@@ -23,6 +30,11 @@ const forSaleIndication = (artwork) =>
   artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
     ? "Available for Sale"
     : undefined
+
+const forSaleIndicationV2 = (artwork) =>
+  artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
+    ? "For Sale"
+    : "Art & Prints"
 
 const dimensions = (artwork) => artwork.dimensions[artwork.metric]
 
@@ -81,12 +93,12 @@ const ArtworkMetaType = new GraphQLObjectType<any, ResolverContext>({
     title: {
       type: GraphQLString,
       resolve: (artwork) => {
-        return join(" | ", [
-          artistNames(artwork),
-          titleWithDate(artwork),
-          forSaleIndication(artwork),
-          "Artsy",
-        ])
+        const variant = getExperimentVariant(EXPERIMENT_NAME, {
+          artworkId: artwork._id,
+        })
+        const variantName =
+          variant && variant.enabled ? variant.name : undefined
+        return generateTitle(artwork, variantName)
       },
     },
   },
@@ -98,3 +110,39 @@ const Meta: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export default Meta
+
+/**
+ * Generates a title for the artwork based on its properties and the
+ * experiment variant, resulting in different formats/lengths.
+ *
+ * ```
+ * control   ➡︎ Mevlana Lipp | Cups (2021) | Available for Sale | Artsy
+ * variant-a ➡︎ Mevlana Lipp | Cups (2021) | For Sale | Artsy
+ * variant-b ➡︎ Mevlana Lipp | Cups | For Sale | Artsy
+ * ```
+ */
+function generateTitle(artwork, variant) {
+  switch (variant) {
+    case "variant-a":
+      return join(" | ", [
+        artistNames(artwork),
+        titleWithDateV2(artwork),
+        forSaleIndicationV2(artwork),
+        "Artsy",
+      ])
+    case "variant-b":
+      return join(" | ", [
+        artistNames(artwork),
+        truncate(artwork.title, TITLE_MAX_LENGTH), // omits date
+        forSaleIndicationV2(artwork),
+        "Artsy",
+      ])
+    default:
+      return join(" | ", [
+        artistNames(artwork),
+        titleWithDate(artwork),
+        forSaleIndication(artwork),
+        "Artsy",
+      ])
+  }
+}


### PR DESCRIPTION
> [!NOTE]
>  This experiment introduces a new paradigm for Unleash variants: **artwork stickiness** as opposed to the default user/session stickiness. 
> 
> I.e. we segment the experiment _by artwork_, rather by user. Artwork X always consistently appears the same way to User 1 and User 2. Artwork Y may differ from Artwork X, but it also consistently appears the same way to User 1 and User 2.
>
> (See docs: [Unleash ➤ Stickiness ➤ Custom Stickiness](https://docs.getunleash.io/concepts/stickiness#custom-stickiness))

[DI-222](https://www.notion.so/artsy/Metaphysics-Serve-title-variants-based-on-experiment-flag-345cab0764a0805db596eb171854860b)

This PR implements the logic behind the [artwork title tag test](https://www.notion.so/artsy/Artwork-Title-Tag-Test-1-FS-Remove-Available-NFS-add-Art-Prints-336cab0764a081709078c67baf25a35e). 

For (unclear to me) historical reasons this title string is constructed in Metaphysics, therefore this variant logic is as well.

That turns out to be a boon perhaps, because we can render the correct title during the SSR phase, without any kind of flash on the frontend due to Unleash state changes.

cc @artsy/diamond-devs 