### PR TITLE
chore: some schema updates for lists/bulk edit

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3544,6 +3544,7 @@ type ArtworkImport implements Node {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   locationID: String
+  partnerListID: String
   rawDataMapping: JSON!
   rowsConnection(
     after: String
@@ -5566,6 +5567,9 @@ input BulkUpdateArtworksMetadataMutationInput {
 
   # Source of the mutation being triggered, E.g. admin, artworks_list
   source: BulkUpdateSourceEnum
+
+  # When true, catalog-eligible fields are routed to CatalogArtwork records instead of Artwork
+  updateCatalog: Boolean
 }
 
 type BulkUpdateArtworksMetadataMutationPayload {
@@ -10128,6 +10132,7 @@ input CreateArtworkImportInput {
   parseWithAI: Boolean
   parseWithAIModel: String
   partnerID: String!
+  partnerListID: String
   s3Bucket: String!
   s3Key: String!
 
@@ -10912,6 +10917,9 @@ input CreatePartnerListMutationInput {
 
   # End date for the list.
   endAt: String
+
+  # The ID of the fair to associate with this list.
+  fairID: String
 
   # The type of list (show, fair, or other).
   listType: PartnerListTypeEnum
@@ -21390,6 +21398,7 @@ type PartnerList {
     # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: String
   ): String
+  fair: Fair
 
   # A globally unique ID.
   id: ID!
@@ -27696,6 +27705,9 @@ input UpdatePartnerListMutationInput {
 
   # End date for the list.
   endAt: String
+
+  # The ID of the fair to associate with this list.
+  fairID: String
 
   # The ID of the partner list.
   id: String!

--- a/src/schema/v2/ArtworkImport/artworkImport.ts
+++ b/src/schema/v2/ArtworkImport/artworkImport.ts
@@ -713,6 +713,10 @@ export const ArtworkImportType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ location_id }) => location_id,
     },
+    partnerListID: {
+      type: GraphQLString,
+      resolve: ({ partner_list_id }) => partner_list_id,
+    },
     source: {
       type: GraphQLString,
       description: "Source of the import: 'bulk_import' or 'multi_add'",

--- a/src/schema/v2/ArtworkImport/mutations/__tests__/createArtworkImportMutation.test.ts
+++ b/src/schema/v2/ArtworkImport/mutations/__tests__/createArtworkImportMutation.test.ts
@@ -2,6 +2,56 @@ import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("CreateArtworkImportMutation", () => {
+  it("passes partnerListID to gravity", async () => {
+    const createArtworkImportLoader = jest.fn().mockResolvedValue({
+      id: "artwork-import-1",
+      file_name: "import.csv",
+      partner_list_id: "list-123",
+    })
+
+    const mutation = gql`
+      mutation {
+        createArtworkImport(
+          input: {
+            partnerID: "partner-1"
+            s3Key: "/some/path/uuid.csv"
+            s3Bucket: "someBucket"
+            partnerListID: "list-123"
+          }
+        ) {
+          artworkImportOrError {
+            ... on CreateArtworkImportSuccess {
+              artworkImport {
+                internalID
+                partnerListID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = { createArtworkImportLoader }
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(createArtworkImportLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partner_list_id: "list-123",
+      })
+    )
+
+    expect(result).toEqual({
+      createArtworkImport: {
+        artworkImportOrError: {
+          artworkImport: {
+            internalID: "artwork-import-1",
+            partnerListID: "list-123",
+          },
+        },
+      },
+    })
+  })
+
   it("creates an artwork import successfully", async () => {
     const createArtworkImportLoader = jest.fn().mockResolvedValue({
       id: "artwork-import-1",

--- a/src/schema/v2/ArtworkImport/mutations/createArtworkImportMutation.ts
+++ b/src/schema/v2/ArtworkImport/mutations/createArtworkImportMutation.ts
@@ -79,6 +79,9 @@ export const CreateArtworkImportMutation = mutationWithClientMutationId<
     locationID: {
       type: GraphQLString,
     },
+    partnerListID: {
+      type: GraphQLString,
+    },
     source: {
       type: GraphQLString,
       defaultValue: "bulk_import",
@@ -106,6 +109,7 @@ export const CreateArtworkImportMutation = mutationWithClientMutationId<
       parse_with_ai: args.parseWithAI,
       parse_with_ai_model: args.parseWithAIModel,
       location_id: args.locationID,
+      partner_list_id: args.partnerListID,
       source: args.source,
     }
 

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -596,6 +596,41 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
     )
   })
 
+  it("passes update_catalog when provided", async () => {
+    const updateCatalogMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            updateCatalog: true
+            metadata: { category: "Painting" }
+            filters: { artworkIds: ["artwork1"] }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: { count: 0, ids: [] },
+      }),
+    }
+
+    await runAuthenticatedQuery(updateCatalogMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      expect.objectContaining({
+        update_catalog: true,
+      })
+    )
+  })
+
   it("passes artsy_listing in metadata when provided", async () => {
     const artsyListingMutation = gql`
       mutation {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -26,6 +26,7 @@ import { BulkArtworkFilterInput } from "./shared"
 interface Input {
   id: string
   source: string
+  updateCatalog?: boolean
   metadata?: {
     editionSetsCount?: number
     artistIds?: string[]
@@ -295,6 +296,11 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
       description:
         "Source of the mutation being triggered, E.g. admin, artworks_list",
     },
+    updateCatalog: {
+      type: GraphQLBoolean,
+      description:
+        "When true, catalog-eligible fields are routed to CatalogArtwork records instead of Artwork",
+    },
     metadata: {
       type: BulkUpdateArtworksMetadataInput,
       description: "Metadata to be updated",
@@ -323,11 +329,12 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, filters, metadata, source },
+    { id, filters, metadata, source, updateCatalog },
     { updatePartnerArtworksMetadataLoader }
   ) => {
     const gravityOptions: any = {
       source,
+      update_catalog: updateCatalog,
     }
 
     if (metadata) {

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/createPartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/createPartnerListMutation.test.ts
@@ -72,6 +72,44 @@ describe("CreatePartnerListMutation", () => {
     })
   })
 
+  it("passes fairID to gravity when provided", async () => {
+    const fairMutation = gql`
+      mutation {
+        createPartnerList(
+          input: {
+            partnerID: "partner-123"
+            name: "Art Basel 2026"
+            listType: FAIR
+            fairID: "fair-abc"
+          }
+        ) {
+          partnerListOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      createPartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-xyz",
+        name: "Art Basel 2026",
+        list_type: "fair",
+        artworks_count: 0,
+        fair_id: "fair-abc",
+      }),
+    }
+
+    await runAuthenticatedQuery(fairMutation, context)
+
+    expect(context.createPartnerListLoader).toHaveBeenCalledWith({
+      partner_id: "partner-123",
+      name: "Art Basel 2026",
+      list_type: "fair",
+      fair_id: "fair-abc",
+    })
+  })
+
   it("returns a mutation error on failure", async () => {
     const context = {
       createPartnerListLoader: jest.fn().mockRejectedValue({

--- a/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/__tests__/updatePartnerListMutation.test.ts
@@ -59,6 +59,34 @@ describe("UpdatePartnerListMutation", () => {
     })
   })
 
+  it("passes fairID to gravity when provided", async () => {
+    const fairMutation = gql`
+      mutation {
+        updatePartnerList(input: { id: "list-abc", fairID: "fair-xyz" }) {
+          partnerListOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "Updated Name",
+        list_type: "fair",
+        artworks_count: 5,
+        fair_id: "fair-xyz",
+      }),
+    }
+
+    await runAuthenticatedQuery(fairMutation, context)
+
+    expect(context.updatePartnerListLoader).toHaveBeenCalledWith("list-abc", {
+      fair_id: "fair-xyz",
+    })
+  })
+
   it("returns a mutation error on failure", async () => {
     const context = {
       updatePartnerListLoader: jest.fn().mockRejectedValue({

--- a/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
@@ -18,6 +18,7 @@ interface CreatePartnerListMutationInputProps {
   listType?: string
   startAt?: string
   endAt?: string
+  fairID?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -75,6 +76,10 @@ export const createPartnerListMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "End date for the list.",
     },
+    fairID: {
+      type: GraphQLString,
+      description: "The ID of the fair to associate with this list.",
+    },
   },
   outputFields: {
     partnerListOrError: {
@@ -85,7 +90,7 @@ export const createPartnerListMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { partnerID, name, listType, startAt, endAt },
+    { partnerID, name, listType, startAt, endAt, fairID },
     { createPartnerListLoader }
   ) => {
     if (!createPartnerListLoader) {
@@ -100,6 +105,7 @@ export const createPartnerListMutation = mutationWithClientMutationId<
     if (listType !== undefined) gravityArgs.list_type = listType
     if (startAt !== undefined) gravityArgs.start_at = startAt
     if (endAt !== undefined) gravityArgs.end_at = endAt
+    if (fairID !== undefined) gravityArgs.fair_id = fairID
 
     try {
       return await createPartnerListLoader(gravityArgs)

--- a/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
@@ -18,6 +18,7 @@ interface UpdatePartnerListMutationInputProps {
   listType?: string
   startAt?: string
   endAt?: string
+  fairID?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -75,6 +76,10 @@ export const updatePartnerListMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "End date for the list.",
     },
+    fairID: {
+      type: GraphQLString,
+      description: "The ID of the fair to associate with this list.",
+    },
   },
   outputFields: {
     partnerListOrError: {
@@ -85,7 +90,7 @@ export const updatePartnerListMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { id, name, listType, startAt, endAt },
+    { id, name, listType, startAt, endAt, fairID },
     { updatePartnerListLoader }
   ) => {
     if (!updatePartnerListLoader) {
@@ -98,6 +103,7 @@ export const updatePartnerListMutation = mutationWithClientMutationId<
     if (listType !== undefined) gravityArgs.list_type = listType
     if (startAt !== undefined) gravityArgs.start_at = startAt
     if (endAt !== undefined) gravityArgs.end_at = endAt
+    if (fairID !== undefined) gravityArgs.fair_id = fairID
 
     try {
       return await updatePartnerListLoader(id, gravityArgs)

--- a/src/schema/v2/partnerList.ts
+++ b/src/schema/v2/partnerList.ts
@@ -9,6 +9,7 @@ import { pageable } from "relay-cursor-paging"
 import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
+import { FairType } from "./fair"
 import { date } from "./fields/date"
 import {
   connectionWithCursorInfo,
@@ -59,6 +60,14 @@ export const PartnerListType = new GraphQLObjectType<any, ResolverContext>({
       partnerShowID: {
         type: GraphQLString,
         resolve: ({ partner_show_id }) => partner_show_id,
+      },
+      fair: {
+        type: FairType,
+        resolve: async ({ fair_id }, _args, { fairLoader }) => {
+          if (!fair_id) return null
+
+          return fairLoader(fair_id)
+        },
       },
       distributedAt: date(({ distributed_at }) => distributed_at),
       createdAt: date(),


### PR DESCRIPTION
- Supporting the `updateCatalog` param when doing the bulk metadata update
- Supporting the `partnerListID` param when creating an artwork import
- Supporting the `fairID` param when creating/updating a partner list