### PR TITLE
chore: support filtering by partner list

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -492,6 +492,7 @@ type Alert {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -1924,6 +1925,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -2394,6 +2396,7 @@ type ArtistPartnerEdge {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -2565,6 +2568,7 @@ type ArtistSeries implements Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -3489,6 +3493,7 @@ type ArtworkFilterNode {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -13275,6 +13280,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -13608,6 +13614,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -14155,6 +14162,7 @@ input FilterArtworksInput {
   partnerCities: [String]
   partnerID: ID
   partnerIDs: [String]
+  partnerListID: String
   period: String
   periods: [String]
   priceRange: String
@@ -14726,6 +14734,7 @@ type Gene implements Node & Searchable {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -16932,6 +16941,7 @@ type MarketingCollection implements Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -20630,6 +20640,7 @@ type Partner implements Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -21027,6 +21038,7 @@ type PartnerArtist {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -21231,6 +21243,7 @@ type PartnerArtistEdge {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -22704,6 +22717,7 @@ type Query {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -23112,6 +23126,7 @@ type Query {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -25848,6 +25863,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -26426,6 +26442,7 @@ type Tag implements Node {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -29727,6 +29744,7 @@ type Viewer {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String
@@ -30009,6 +30027,7 @@ type Viewer {
     partnerCities: [String]
     partnerID: ID
     partnerIDs: [String]
+    partnerListID: String
     period: String
     periods: [String]
     priceRange: String

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1087,6 +1087,142 @@ describe("artworksConnection", () => {
     })
   })
 
+  describe("simple partner list CMS requests", () => {
+    it("uses partnerListArtworksLoader for simple partner list CMS requests", async () => {
+      const partnerListArtworks = [
+        { artwork: { id: "artwork1", title: "Artwork 1" } },
+        { artwork: { id: "artwork2", title: "Artwork 2" } },
+      ]
+
+      const mockPartnerListArtworksLoader = jest.fn(() =>
+        Promise.resolve({
+          body: partnerListArtworks,
+          headers: {
+            "x-total-count": "2",
+          },
+        })
+      )
+
+      const mockFilterArtworksLoader = jest.fn()
+
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: mockFilterArtworksLoader,
+        },
+        isCMSRequest: true,
+        partnerListArtworksLoader: mockPartnerListArtworksLoader,
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            input: {
+              partnerListID: "list123"
+              sort: "partner_list_position"
+              includeUnpublished: true
+              disableNotForSaleSorting: true
+              first: 10
+            }
+          ) {
+            edges {
+              node {
+                slug
+                title
+              }
+            }
+            counts {
+              total
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockPartnerListArtworksLoader).toHaveBeenCalledWith(
+        "list123",
+        expect.objectContaining({
+          size: 10,
+          page: 1,
+          total_count: true,
+        })
+      )
+
+      expect(mockFilterArtworksLoader).not.toHaveBeenCalled()
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "artwork1", title: "Artwork 1" } },
+        { node: { slug: "artwork2", title: "Artwork 2" } },
+      ])
+      expect(artworksConnection.counts.total).toEqual(2)
+    })
+
+    it("falls back to search for partner list requests with additional filters", async () => {
+      const mockFilterArtworksLoader = jest.fn(() =>
+        Promise.resolve({
+          hits: [
+            {
+              id: "artwork1",
+              title: "Artwork 1",
+            },
+          ],
+          aggregations: {
+            total: {
+              value: 1,
+            },
+          },
+        })
+      )
+
+      const mockPartnerListArtworksLoader = jest.fn()
+
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: mockFilterArtworksLoader,
+        },
+        isCMSRequest: true,
+        partnerListArtworksLoader: mockPartnerListArtworksLoader,
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            input: {
+              partnerListID: "list123"
+              sort: "partner_list_position"
+              includeUnpublished: true
+              disableNotForSaleSorting: true
+              priceRange: "1000-5000"
+              first: 10
+            }
+          ) {
+            edges {
+              node {
+                slug
+                title
+              }
+            }
+            counts {
+              total
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalled()
+      expect(mockPartnerListArtworksLoader).not.toHaveBeenCalled()
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "artwork1", title: "Artwork 1" } },
+      ])
+      expect(artworksConnection.counts.total).toEqual(1)
+    })
+  })
+
   describe("includeNonArtsyListed filter", () => {
     it("passes include_non_artsy_listed to the loader when provided", async () => {
       const mockFilterArtworksLoader = jest.fn(() =>

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -260,6 +260,9 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   showID: {
     type: GraphQLString,
   },
+  partnerListID: {
+    type: GraphQLString,
+  },
   sold: {
     type: GraphQLBoolean,
   },
@@ -493,6 +496,7 @@ const convertFilterArgs = ({
   partnerCities,
   partnerID,
   partnerIDs,
+  partnerListID,
   priceRange,
   saleID,
   showID,
@@ -535,6 +539,7 @@ const convertFilterArgs = ({
     partner_cities: partnerCities,
     partner_id: partnerID,
     partner_ids: partnerIDs,
+    partner_list_id: partnerListID,
     partner_show_id: showID,
     price_range: priceRange,
     sale_id: saleID,
@@ -563,6 +568,7 @@ const filterArtworksConnectionTypeFactory = (
       filterArtworksUncachedLoader,
       isCMSRequest,
       partnerArtworksAllLoader,
+      partnerListArtworksLoader,
     } = ctx
     const argsProvidedAtRoot = convertFilterArgs(rootArguments as any)
     removeEmptyValues(argsProvidedAtRoot)
@@ -676,17 +682,20 @@ const filterArtworksConnectionTypeFactory = (
 
     let hits, aggregations
 
-    // For simple CMS requests, use partnerArtworksAllLoader instead of search.
+    // For simple CMS requests, bypass search and use a direct loader instead.
     // This is a workaround to try to not use search if we don't need to (for resiliency).
     // We've seen search can not be stable and partners notice that in CMS.
-    // Currently, this will serve requests for the landing page of /artworks listings in CMS.
-    if (isCMSRequest && partnerArtworksAllLoader) {
+    // Currently, this will serve requests for the landing page of /artworks, OS catalog, and
+    // PartnerList artworks listings in CMS.
+    if (isCMSRequest) {
       const {
         partnerID,
+        partnerListID,
         sort,
         includeUnpublished,
         disableNotForSaleSorting,
         medium,
+        includeNonArtsyListed,
         // pagination arguments we want to exclude
         // from the check for other filters
         first,
@@ -695,9 +704,7 @@ const filterArtworksConnectionTypeFactory = (
         ...otherFilters
       } = input
 
-      const isSimpleRequest =
-        Boolean(partnerID) &&
-        sort === "-created_at" &&
+      const isSimpleCMSRequest =
         includeUnpublished &&
         disableNotForSaleSorting &&
         // medium must be either undefined/null or the wildcard "*"
@@ -706,22 +713,44 @@ const filterArtworksConnectionTypeFactory = (
         // (and ignored pagination args) were passed in
         Object.keys(otherFilters).length === 0
 
-      if (isSimpleRequest) {
-        const partnerArtworksOptions = {
+      if (
+        isSimpleCMSRequest &&
+        partnerArtworksAllLoader &&
+        Boolean(partnerID) &&
+        sort === "-created_at"
+      ) {
+        const { body, headers } = await partnerArtworksAllLoader(partnerID, {
           size: gravityOptions.size,
           page: gravityOptions.page,
           sort: "-created_at,-id",
           total_count: true,
-        }
-
-        const { body, headers } = await partnerArtworksAllLoader(
-          partnerID,
-          partnerArtworksOptions
-        )
+          include_non_artsy_listed: includeNonArtsyListed,
+        })
 
         const total = parseInt(headers["x-total-count"] || "0", 10)
         aggregations = { total: { value: total } }
         hits = body
+      } else if (
+        isSimpleCMSRequest &&
+        partnerListArtworksLoader &&
+        Boolean(partnerListID) &&
+        sort === "partner_list_position"
+      ) {
+        // After creating a list by adding artworks, the user will likely
+        // quickly navigate to that list page. In case the OS reindexing is
+        // delayed, serve the basic landing page directly.
+        const { body, headers } = await partnerListArtworksLoader(
+          partnerListID,
+          {
+            size: gravityOptions.size,
+            page: gravityOptions.page,
+            total_count: true,
+          }
+        )
+
+        const total = parseInt(headers["x-total-count"] || "0", 10)
+        aggregations = { total: { value: total } }
+        hits = body.map((node: any) => node.artwork)
       }
     }
 


### PR DESCRIPTION
Based on https://github.com/artsy/gravity/pull/20056 - threads through that argument to the filter endpoint.

Additionally, follows the pattern we took for the /artworks landing page in CMS, and for a partner list landing page in OS - when no other filters are applied (besides the 'custom' default sort) - we serve that request by the vanilla non-OpenSearch backed endpoint to ensure there's no delay when a user likely visits a list page immediately after creating/adding works (success toast even links them).