### PR TITLE
chore: Add Brand Kit queries and mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5355,6 +5355,35 @@ type BidderPositionSuggestedNextBid {
 # exceed the size of a 32-bit integer, it's encoded as a string.
 scalar BigInt
 
+type BrandKit {
+  backgroundColor: String
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  ctaColor: String
+  fontFamily: String
+  fontStyle: String
+  fontWeight: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  logo: Image
+  partnerID: String
+  textColor: String
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+}
+
 type BulkAddArtworksToPartnerListFailure {
   mutationError: GravityMutationError
 }
@@ -10237,6 +10266,48 @@ type CreateBidderPayload {
   clientMutationId: String
 }
 
+type CreateBrandKitFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateBrandKitInput {
+  # Background color hex code (e.g. #FF0000)
+  backgroundColor: String
+  clientMutationId: String
+
+  # CTA color hex code (e.g. #FF0000)
+  ctaColor: String
+
+  # Font family name
+  fontFamily: String
+
+  # Font style
+  fontStyle: String
+
+  # Font weight
+  fontWeight: String
+
+  # The partner ID to create the brand kit for
+  partnerId: String!
+
+  # Text color hex code (e.g. #FF0000)
+  textColor: String
+}
+
+type CreateBrandKitPayload {
+  # On success: the created brand kit
+  brandKitOrError: CreateBrandKitResponseOrError
+  clientMutationId: String
+}
+
+union CreateBrandKitResponseOrError =
+    CreateBrandKitFailure
+  | CreateBrandKitSuccess
+
+type CreateBrandKitSuccess {
+  brandKit: BrandKit
+}
+
 type CreateCanonicalArtistFailure {
   mutationError: GravityMutationError
 }
@@ -11853,6 +11924,56 @@ type DeleteBankAccountPayload {
   bankAccountOrError: BankAccountMutationType
   clientMutationId: String
   me: Me
+}
+
+type DeleteBrandKitFailure {
+  mutationError: GravityMutationError
+}
+
+input DeleteBrandKitInput {
+  clientMutationId: String
+
+  # The internal ID of the brand kit to delete
+  id: String!
+}
+
+type DeleteBrandKitLogoFailure {
+  mutationError: GravityMutationError
+}
+
+input DeleteBrandKitLogoInput {
+  clientMutationId: String
+
+  # The internal ID of the brand kit
+  id: String!
+}
+
+type DeleteBrandKitLogoPayload {
+  # On success: the brand kit with the logo removed
+  brandKitOrError: DeleteBrandKitLogoResponseOrError
+  clientMutationId: String
+}
+
+union DeleteBrandKitLogoResponseOrError =
+    DeleteBrandKitLogoFailure
+  | DeleteBrandKitLogoSuccess
+
+type DeleteBrandKitLogoSuccess {
+  brandKit: BrandKit
+}
+
+type DeleteBrandKitPayload {
+  # On success: a boolean indicating the brand kit was deleted
+  brandKitOrError: DeleteBrandKitResponseOrError
+  clientMutationId: String
+}
+
+union DeleteBrandKitResponseOrError =
+    DeleteBrandKitFailure
+  | DeleteBrandKitSuccess
+
+type DeleteBrandKitSuccess {
+  success: Boolean
 }
 
 type DeleteCareerHighlightFailure {
@@ -18219,6 +18340,9 @@ type Mutation {
   # Creates a bidder position
   createBidderPosition(input: BidderPositionInput!): BidderPositionPayload
 
+  # Create a brand kit for a partner
+  createBrandKit(input: CreateBrandKitInput!): CreateBrandKitPayload
+
   # Create a buyer offer on an order
   createBuyerOffer(input: createBuyerOfferInput!): createBuyerOfferPayload
 
@@ -18460,6 +18584,12 @@ type Mutation {
 
   # Remove a bank account
   deleteBankAccount(input: DeleteBankAccountInput!): DeleteBankAccountPayload
+
+  # Delete a partner's brand kit
+  deleteBrandKit(input: DeleteBrandKitInput!): DeleteBrandKitPayload
+
+  # Remove the logo from a brand kit
+  deleteBrandKitLogo(input: DeleteBrandKitLogoInput!): DeleteBrandKitLogoPayload
 
   # Delete an artist career highlight
   deleteCareerHighlight(
@@ -18888,6 +19018,12 @@ type Mutation {
   updateArtworkImportRowImages(
     input: UpdateArtworkImportRowImagesInput!
   ): UpdateArtworkImportRowImagesPayload
+
+  # Update a partner's brand kit
+  updateBrandKit(input: UpdateBrandKitInput!): UpdateBrandKitPayload
+
+  # Upload or replace the logo for a brand kit
+  updateBrandKitLogo(input: UpdateBrandKitLogoInput!): UpdateBrandKitLogoPayload
 
   # Update a buyer offer
   updateBuyerOffer(input: updateBuyerOfferInput!): updateBuyerOfferPayload
@@ -20287,6 +20423,9 @@ type Partner implements Node {
     query: String!
     size: Int
   ): ArtworkConnection
+
+  # The partner's brand kit — colors, fonts, and logo used for branded surfaces
+  brandKit: BrandKit
   cached: Int
   categories: [PartnerCategory]
 
@@ -26823,6 +26962,79 @@ type UpdateArtworkMutationPayload {
   # On success: the artwork updated.
   artworkOrError: updateArtworkResponseOrError
   clientMutationId: String
+}
+
+type UpdateBrandKitFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateBrandKitInput {
+  # Background color hex code (e.g. #FF0000)
+  backgroundColor: String
+  clientMutationId: String
+
+  # CTA color hex code (e.g. #FF0000)
+  ctaColor: String
+
+  # Font family name
+  fontFamily: String
+
+  # Font style
+  fontStyle: String
+
+  # Font weight
+  fontWeight: String
+
+  # The internal ID of the brand kit to update
+  id: String!
+
+  # Text color hex code (e.g. #FF0000)
+  textColor: String
+}
+
+type UpdateBrandKitLogoFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdateBrandKitLogoInput {
+  clientMutationId: String
+
+  # The internal ID of the brand kit
+  id: String!
+
+  # S3 bucket containing the logo image to upload
+  remoteImageS3Bucket: String!
+
+  # S3 key of the logo image to upload
+  remoteImageS3Key: String!
+}
+
+type UpdateBrandKitLogoPayload {
+  # On success: the brand kit with the updated logo
+  brandKitOrError: UpdateBrandKitLogoResponseOrError
+  clientMutationId: String
+}
+
+union UpdateBrandKitLogoResponseOrError =
+    UpdateBrandKitLogoFailure
+  | UpdateBrandKitLogoSuccess
+
+type UpdateBrandKitLogoSuccess {
+  brandKit: BrandKit
+}
+
+type UpdateBrandKitPayload {
+  # On success: the updated brand kit
+  brandKitOrError: UpdateBrandKitResponseOrError
+  clientMutationId: String
+}
+
+union UpdateBrandKitResponseOrError =
+    UpdateBrandKitFailure
+  | UpdateBrandKitSuccess
+
+type UpdateBrandKitSuccess {
+  brandKit: BrandKit
 }
 
 type UpdateCMSLastAccessTimestampFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1781,6 +1781,30 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
 
+    // Brand Kit Loaders
+    brandKitLoader: gravityLoader("brand_kit"),
+    createBrandKitLoader: gravityLoader("brand_kit", {}, { method: "POST" }),
+    updateBrandKitLoader: gravityLoader(
+      (id) => `brand_kit/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteBrandKitLoader: gravityLoader(
+      (id) => `brand_kit/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    uploadBrandKitLogoLoader: gravityLoader(
+      (id) => `brand_kit/${id}/logo`,
+      {},
+      { method: "POST" }
+    ),
+    deleteBrandKitLogoLoader: gravityLoader(
+      (id) => `brand_kit/${id}/logo`,
+      {},
+      { method: "DELETE" }
+    ),
+
     // Partner List Loaders
     partnerListsLoader: gravityLoader("partner_lists", {}, { headers: true }),
     partnerListLoader: gravityLoader((id) => `partner_list/${id}`),

--- a/src/schema/v2/partner/Mutations/__tests__/createBrandKitMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/createBrandKitMutation.test.ts
@@ -1,0 +1,128 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    createBrandKit(input: {
+      partnerId: "partner-1"
+      textColor: "#FF0000"
+      backgroundColor: "#00FF00"
+      ctaColor: "#0000FF"
+      fontFamily: "Helvetica"
+      fontWeight: "bold"
+      fontStyle: "normal"
+    }) {
+      brandKitOrError {
+        ... on CreateBrandKitSuccess {
+          brandKit {
+            internalID
+            partnerID
+            textColor
+            backgroundColor
+            ctaColor
+            fontFamily
+            fontWeight
+            fontStyle
+          }
+        }
+
+        ... on CreateBrandKitFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("createBrandKit", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "brand-kit-1",
+      partner_id: "partner-1",
+      text_color: "#FF0000",
+      background_color: "#00FF00",
+      cta_color: "#0000FF",
+      font_family: "Helvetica",
+      font_weight: "bold",
+      font_style: "normal",
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        createBrandKitLoader: jest.fn().mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("passes snake_cased args to Gravity", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(context.createBrandKitLoader as jest.Mock).toHaveBeenCalledWith({
+        partner_id: "partner-1",
+        text_color: "#FF0000",
+        background_color: "#00FF00",
+        cta_color: "#0000FF",
+        font_family: "Helvetica",
+        font_weight: "bold",
+        font_style: "normal",
+      })
+    })
+
+    it("returns the created brand kit", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "createBrandKit": {
+            "brandKitOrError": {
+              "brandKit": {
+                "backgroundColor": "#00FF00",
+                "ctaColor": "#0000FF",
+                "fontFamily": "Helvetica",
+                "fontStyle": "normal",
+                "fontWeight": "bold",
+                "internalID": "brand-kit-1",
+                "partnerID": "partner-1",
+                "textColor": "#FF0000",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "param_error",
+      message: "Partner already has a brand kit.",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      400,
+      gravityResponseBody
+    )
+    const context = {
+      createBrandKitLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "createBrandKit": {
+          "brandKitOrError": {
+            "mutationError": {
+              "message": "Partner already has a brand kit.",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/partner/Mutations/__tests__/deleteBrandKitLogoMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/deleteBrandKitLogoMutation.test.ts
@@ -1,0 +1,96 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    deleteBrandKitLogo(input: { id: "brand-kit-1" }) {
+      brandKitOrError {
+        ... on DeleteBrandKitLogoSuccess {
+          brandKit {
+            internalID
+          }
+        }
+
+        ... on DeleteBrandKitLogoFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("deleteBrandKitLogo", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "brand-kit-1",
+      partner_id: "partner-1",
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        deleteBrandKitLogoLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("calls loader with id", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(
+        context.deleteBrandKitLogoLoader as jest.Mock
+      ).toHaveBeenCalledWith("brand-kit-1")
+    })
+
+    it("returns the brand kit", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "deleteBrandKitLogo": {
+            "brandKitOrError": {
+              "brandKit": {
+                "internalID": "brand-kit-1",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "param_error",
+      message: "Forbidden",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      403,
+      gravityResponseBody
+    )
+    const context = {
+      deleteBrandKitLogoLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "deleteBrandKitLogo": {
+          "brandKitOrError": {
+            "mutationError": {
+              "message": "Forbidden",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/partner/Mutations/__tests__/deleteBrandKitMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/deleteBrandKitMutation.test.ts
@@ -1,0 +1,87 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    deleteBrandKit(input: { id: "brand-kit-1" }) {
+      brandKitOrError {
+        ... on DeleteBrandKitSuccess {
+          success
+        }
+
+        ... on DeleteBrandKitFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("deleteBrandKit", () => {
+  describe("valid query", () => {
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        deleteBrandKitLoader: jest
+          .fn()
+          .mockResolvedValue({ id: "brand-kit-1" }),
+      }
+    })
+
+    it("calls loader with id", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(context.deleteBrandKitLoader as jest.Mock).toHaveBeenCalledWith(
+        "brand-kit-1"
+      )
+    })
+
+    it("returns success: true on success", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "deleteBrandKit": {
+            "brandKitOrError": {
+              "success": true,
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "param_error",
+      message: "Forbidden",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      403,
+      gravityResponseBody
+    )
+    const context = {
+      deleteBrandKitLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "deleteBrandKit": {
+          "brandKitOrError": {
+            "mutationError": {
+              "message": "Forbidden",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/partner/Mutations/__tests__/updateBrandKitLogoMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/updateBrandKitLogoMutation.test.ts
@@ -1,0 +1,106 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    updateBrandKitLogo(input: {
+      id: "brand-kit-1"
+      remoteImageS3Key: "uploads/logo.png"
+      remoteImageS3Bucket: "artsy-uploads"
+    }) {
+      brandKitOrError {
+        ... on UpdateBrandKitLogoSuccess {
+          brandKit {
+            internalID
+          }
+        }
+
+        ... on UpdateBrandKitLogoFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("updateBrandKitLogo", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "brand-kit-1",
+      partner_id: "partner-1",
+      image: {
+        id: "ar-image-1",
+      },
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        uploadBrandKitLogoLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("calls loader with id and snake_cased S3 params", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(
+        context.uploadBrandKitLogoLoader as jest.Mock
+      ).toHaveBeenCalledWith("brand-kit-1", {
+        remote_image_s3_key: "uploads/logo.png",
+        remote_image_s3_bucket: "artsy-uploads",
+      })
+    })
+
+    it("returns the brand kit", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "updateBrandKitLogo": {
+            "brandKitOrError": {
+              "brandKit": {
+                "internalID": "brand-kit-1",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "param_error",
+      message: "Something went wrong.",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      400,
+      gravityResponseBody
+    )
+    const context = {
+      uploadBrandKitLogoLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "updateBrandKitLogo": {
+          "brandKitOrError": {
+            "mutationError": {
+              "message": "Something went wrong.",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/partner/Mutations/__tests__/updateBrandKitMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/updateBrandKitMutation.test.ts
@@ -1,0 +1,112 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    updateBrandKit(input: {
+      id: "brand-kit-1"
+      textColor: "#FF0000"
+      fontFamily: "Courier"
+    }) {
+      brandKitOrError {
+        ... on UpdateBrandKitSuccess {
+          brandKit {
+            internalID
+            textColor
+            fontFamily
+          }
+        }
+
+        ... on UpdateBrandKitFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("updateBrandKit", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "brand-kit-1",
+      partner_id: "partner-1",
+      text_color: "#FF0000",
+      font_family: "Courier",
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        updateBrandKitLoader: jest.fn().mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("passes id and snake_cased attrs to Gravity", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(context.updateBrandKitLoader as jest.Mock).toHaveBeenCalledWith(
+        "brand-kit-1",
+        {
+          text_color: "#FF0000",
+          background_color: undefined,
+          cta_color: undefined,
+          font_family: "Courier",
+          font_weight: undefined,
+          font_style: undefined,
+        }
+      )
+    })
+
+    it("returns the updated brand kit", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "updateBrandKit": {
+            "brandKitOrError": {
+              "brandKit": {
+                "fontFamily": "Courier",
+                "internalID": "brand-kit-1",
+                "textColor": "#FF0000",
+              },
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "param_error",
+      message: "Text color must be a valid hex color (e.g. #FF0000).",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      400,
+      gravityResponseBody
+    )
+    const context = {
+      updateBrandKitLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "updateBrandKit": {
+          "brandKitOrError": {
+            "mutationError": {
+              "message": "Text color must be a valid hex color (e.g. #FF0000).",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/partner/Mutations/createBrandKitMutation.ts
+++ b/src/schema/v2/partner/Mutations/createBrandKitMutation.ts
@@ -1,0 +1,137 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { BrandKitType } from "../brandKit"
+
+interface Input {
+  partnerId: string
+  textColor?: string
+  backgroundColor?: string
+  ctaColor?: string
+  fontFamily?: string
+  fontWeight?: string
+  fontStyle?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateBrandKitSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    brandKit: {
+      type: BrandKitType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateBrandKitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateBrandKitResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "CreateBrandKitFailure"
+    }
+    return "CreateBrandKitSuccess"
+  },
+})
+
+export const createBrandKitMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreateBrandKit",
+  description: "Create a brand kit for a partner",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The partner ID to create the brand kit for",
+    },
+    textColor: {
+      type: GraphQLString,
+      description: "Text color hex code (e.g. #FF0000)",
+    },
+    backgroundColor: {
+      type: GraphQLString,
+      description: "Background color hex code (e.g. #FF0000)",
+    },
+    ctaColor: {
+      type: GraphQLString,
+      description: "CTA color hex code (e.g. #FF0000)",
+    },
+    fontFamily: {
+      type: GraphQLString,
+      description: "Font family name",
+    },
+    fontWeight: {
+      type: GraphQLString,
+      description: "Font weight",
+    },
+    fontStyle: {
+      type: GraphQLString,
+      description: "Font style",
+    },
+  },
+  outputFields: {
+    brandKitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the created brand kit",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      partnerId,
+      textColor,
+      backgroundColor,
+      ctaColor,
+      fontFamily,
+      fontWeight,
+      fontStyle,
+    },
+    { createBrandKitLoader }
+  ) => {
+    if (!createBrandKitLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await createBrandKitLoader({
+        partner_id: partnerId,
+        text_color: textColor,
+        background_color: backgroundColor,
+        cta_color: ctaColor,
+        font_family: fontFamily,
+        font_weight: fontWeight,
+        font_style: fontStyle,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/deleteBrandKitLogoMutation.ts
+++ b/src/schema/v2/partner/Mutations/deleteBrandKitLogoMutation.ts
@@ -1,0 +1,88 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { BrandKitType } from "../brandKit"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteBrandKitLogoSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    brandKit: {
+      type: BrandKitType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteBrandKitLogoFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteBrandKitLogoResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "DeleteBrandKitLogoFailure"
+    }
+    return "DeleteBrandKitLogoSuccess"
+  },
+})
+
+export const deleteBrandKitLogoMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "DeleteBrandKitLogo",
+  description: "Remove the logo from a brand kit",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The internal ID of the brand kit",
+    },
+  },
+  outputFields: {
+    brandKitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the brand kit with the logo removed",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deleteBrandKitLogoLoader }) => {
+    if (!deleteBrandKitLogoLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await deleteBrandKitLogoLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/deleteBrandKitMutation.ts
+++ b/src/schema/v2/partner/Mutations/deleteBrandKitMutation.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteBrandKitSuccess",
+  fields: () => ({
+    success: {
+      type: GraphQLBoolean,
+      resolve: () => true,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeleteBrandKitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeleteBrandKitResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "DeleteBrandKitFailure"
+    }
+    return "DeleteBrandKitSuccess"
+  },
+})
+
+export const deleteBrandKitMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "DeleteBrandKit",
+  description: "Delete a partner's brand kit",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The internal ID of the brand kit to delete",
+    },
+  },
+  outputFields: {
+    brandKitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: a boolean indicating the brand kit was deleted",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deleteBrandKitLoader }) => {
+    if (!deleteBrandKitLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await deleteBrandKitLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/updateBrandKitLogoMutation.ts
+++ b/src/schema/v2/partner/Mutations/updateBrandKitLogoMutation.ts
@@ -1,0 +1,104 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { BrandKitType } from "../brandKit"
+
+interface Input {
+  id: string
+  remoteImageS3Key: string
+  remoteImageS3Bucket: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateBrandKitLogoSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    brandKit: {
+      type: BrandKitType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateBrandKitLogoFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateBrandKitLogoResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "UpdateBrandKitLogoFailure"
+    }
+    return "UpdateBrandKitLogoSuccess"
+  },
+})
+
+export const updateBrandKitLogoMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "UpdateBrandKitLogo",
+  description: "Upload or replace the logo for a brand kit",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The internal ID of the brand kit",
+    },
+    remoteImageS3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 key of the logo image to upload",
+    },
+    remoteImageS3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 bucket containing the logo image to upload",
+    },
+  },
+  outputFields: {
+    brandKitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the brand kit with the updated logo",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { id, remoteImageS3Key, remoteImageS3Bucket },
+    { uploadBrandKitLogoLoader }
+  ) => {
+    if (!uploadBrandKitLogoLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await uploadBrandKitLogoLoader(id, {
+        remote_image_s3_key: remoteImageS3Key,
+        remote_image_s3_bucket: remoteImageS3Bucket,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/updateBrandKitMutation.ts
+++ b/src/schema/v2/partner/Mutations/updateBrandKitMutation.ts
@@ -1,0 +1,136 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { BrandKitType } from "../brandKit"
+
+interface Input {
+  id: string
+  textColor?: string
+  backgroundColor?: string
+  ctaColor?: string
+  fontFamily?: string
+  fontWeight?: string
+  fontStyle?: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateBrandKitSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    brandKit: {
+      type: BrandKitType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdateBrandKitFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdateBrandKitResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "UpdateBrandKitFailure"
+    }
+    return "UpdateBrandKitSuccess"
+  },
+})
+
+export const updateBrandKitMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "UpdateBrandKit",
+  description: "Update a partner's brand kit",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The internal ID of the brand kit to update",
+    },
+    textColor: {
+      type: GraphQLString,
+      description: "Text color hex code (e.g. #FF0000)",
+    },
+    backgroundColor: {
+      type: GraphQLString,
+      description: "Background color hex code (e.g. #FF0000)",
+    },
+    ctaColor: {
+      type: GraphQLString,
+      description: "CTA color hex code (e.g. #FF0000)",
+    },
+    fontFamily: {
+      type: GraphQLString,
+      description: "Font family name",
+    },
+    fontWeight: {
+      type: GraphQLString,
+      description: "Font weight",
+    },
+    fontStyle: {
+      type: GraphQLString,
+      description: "Font style",
+    },
+  },
+  outputFields: {
+    brandKitOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the updated brand kit",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      id,
+      textColor,
+      backgroundColor,
+      ctaColor,
+      fontFamily,
+      fontWeight,
+      fontStyle,
+    },
+    { updateBrandKitLoader }
+  ) => {
+    if (!updateBrandKitLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await updateBrandKitLoader(id, {
+        text_color: textColor,
+        background_color: backgroundColor,
+        cta_color: ctaColor,
+        font_family: fontFamily,
+        font_weight: fontWeight,
+        font_style: fontStyle,
+      })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/__tests__/brandKit.test.ts
+++ b/src/schema/v2/partner/__tests__/brandKit.test.ts
@@ -1,0 +1,104 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("Partner brandKit field", () => {
+  const query = gql`
+    {
+      partner(id: "catty-partner") {
+        brandKit {
+          internalID
+          partnerID
+          textColor
+          backgroundColor
+          ctaColor
+          fontFamily
+          fontWeight
+          fontStyle
+        }
+      }
+    }
+  `
+
+  it("resolves the partner's brand kit", async () => {
+    const partnerData = {
+      _id: "partner-internal-id",
+      id: "catty-partner",
+    }
+
+    const brandKitData = {
+      id: "brand-kit-1",
+      partner_id: "partner-internal-id",
+      text_color: "#111111",
+      background_color: "#FFFFFF",
+      cta_color: "#0000FF",
+      font_family: "Helvetica",
+      font_weight: "bold",
+      font_style: "normal",
+    }
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      brandKitLoader: jest.fn().mockResolvedValue(brandKitData),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(context.brandKitLoader).toHaveBeenCalledWith({
+      partner_id: "partner-internal-id",
+    })
+    expect(data).toEqual({
+      partner: {
+        brandKit: {
+          internalID: "brand-kit-1",
+          partnerID: "partner-internal-id",
+          textColor: "#111111",
+          backgroundColor: "#FFFFFF",
+          ctaColor: "#0000FF",
+          fontFamily: "Helvetica",
+          fontWeight: "bold",
+          fontStyle: "normal",
+        },
+      },
+    })
+  })
+
+  it("returns null when the partner has no brand kit", async () => {
+    const partnerData = {
+      _id: "partner-internal-id",
+      id: "catty-partner",
+    }
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      brandKitLoader: jest.fn().mockResolvedValue({}),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        brandKit: null,
+      },
+    })
+  })
+
+  it("returns null when the brand kit loader rejects", async () => {
+    const partnerData = {
+      _id: "partner-internal-id",
+      id: "catty-partner",
+    }
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      brandKitLoader: jest.fn().mockRejectedValue(new Error("boom")),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        brandKit: null,
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/brandKit.ts
+++ b/src/schema/v2/partner/brandKit.ts
@@ -1,0 +1,46 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "../object_identification"
+import { date } from "../fields/date"
+import Image, { normalizeImageData } from "../image"
+
+export const BrandKitType = new GraphQLObjectType<any, ResolverContext>({
+  name: "BrandKit",
+  fields: () => ({
+    ...InternalIDFields,
+    partnerID: {
+      type: GraphQLString,
+      resolve: ({ partner_id }) => partner_id,
+    },
+    textColor: {
+      type: GraphQLString,
+      resolve: ({ text_color }) => text_color,
+    },
+    backgroundColor: {
+      type: GraphQLString,
+      resolve: ({ background_color }) => background_color,
+    },
+    ctaColor: {
+      type: GraphQLString,
+      resolve: ({ cta_color }) => cta_color,
+    },
+    fontFamily: {
+      type: GraphQLString,
+      resolve: ({ font_family }) => font_family,
+    },
+    fontWeight: {
+      type: GraphQLString,
+      resolve: ({ font_weight }) => font_weight,
+    },
+    fontStyle: {
+      type: GraphQLString,
+      resolve: ({ font_style }) => font_style,
+    },
+    logo: {
+      type: Image.type,
+      resolve: ({ image }) => normalizeImageData(image),
+    },
+    createdAt: date(),
+    updatedAt: date(),
+  }),
+})

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -74,6 +74,7 @@ import {
   EXAMPLE_TEMPLATES,
 } from "schema/v2/conversationMessageTemplate/conversationMessageTemplateExample"
 import { ArtworkTemplatesConnection } from "schema/v2/artworkTemplate/artworkTemplatesConnection"
+import { BrandKitType } from "./brandKit"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
@@ -1366,6 +1367,18 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: Profile.type,
         resolve: ({ default_profile_id }, _options, { profileLoader }) =>
           profileLoader(default_profile_id).catch(() => null),
+      },
+      brandKit: {
+        type: BrandKitType,
+        description:
+          "The partner's brand kit — colors, fonts, and logo used for branded surfaces",
+        resolve: async ({ _id }, _args, { brandKitLoader }) => {
+          if (!brandKitLoader) return null
+          const response = await brandKitLoader({ partner_id: _id }).catch(
+            () => null
+          )
+          return response && Object.keys(response).length > 0 ? response : null
+        },
       },
       analyticsPageTimeFrame: {
         description: "Time frame selected for analytics page",

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -245,6 +245,11 @@ import { authorizeMailchimpAccountMutation } from "./me/authorizeMailchimpAccoun
 import { completeMailchimpOAuthMutation } from "./me/completeMailchimpOAuthMutation"
 import { deleteMailchimpAccountMutation } from "./me/deleteMailchimpAccountMutation"
 import { createMailchimpCampaignMutation } from "./createMailchimpCampaignMutation"
+import { createBrandKitMutation } from "./partner/Mutations/createBrandKitMutation"
+import { updateBrandKitMutation } from "./partner/Mutations/updateBrandKitMutation"
+import { deleteBrandKitMutation } from "./partner/Mutations/deleteBrandKitMutation"
+import { updateBrandKitLogoMutation } from "./partner/Mutations/updateBrandKitLogoMutation"
+import { deleteBrandKitLogoMutation } from "./partner/Mutations/deleteBrandKitLogoMutation"
 import { createInstagramPostMutation } from "./createInstagramPostMutation"
 import { instagramPost, instagramPostsConnection } from "./instagramPost"
 import {
@@ -648,6 +653,11 @@ export default new GraphQLSchema({
       completeMailchimpOAuth: completeMailchimpOAuthMutation,
       deleteMailchimpAccount: deleteMailchimpAccountMutation,
       createMailchimpCampaign: createMailchimpCampaignMutation,
+      createBrandKit: createBrandKitMutation,
+      updateBrandKit: updateBrandKitMutation,
+      deleteBrandKit: deleteBrandKitMutation,
+      updateBrandKitLogo: updateBrandKitLogoMutation,
+      deleteBrandKitLogo: deleteBrandKitLogoMutation,
       createPurchase: createPurchaseMutation,
       createSaleAgreement: CreateSaleAgreementMutation,
       createSmsSecondFactor: createSmsSecondFactorMutation,


### PR DESCRIPTION
Brand kit modelling and API endpoints were added to Gravity during https://github.com/artsy/gravity/pull/20038

Add the queries and mutations here to support Brand Kit and Brand Kit logo management.

cc @artsy/amber-devs 