### PR TITLE
chore(EMI-3191): expose shipping radius

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19905,6 +19905,9 @@ type Order {
   # Display short version of order's artwork location
   shippingOrigin: String
 
+  # Whether the order ships domestically or internationally
+  shippingRadius: String
+
   # The total amount for shipping
   shippingTotal: Money
 

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -48,6 +48,7 @@ describe("Me", () => {
       shipping_address_line2: "Apt 4B",
       tax_total_cents: 4299,
       shipping_origin: "Marfa, TX, US",
+      shipping_radius: "domestic",
       submitted_offers: [],
     }
     artwork = artwork || {
@@ -133,6 +134,7 @@ describe("Me", () => {
                 type
               }
               shippingOrigin
+              shippingRadius
               shippingTotal {
                 minor
               }
@@ -242,6 +244,7 @@ describe("Me", () => {
           type: "DOMESTIC_FLAT",
         },
         shippingOrigin: "Marfa, TX, US",
+        shippingRadius: "domestic",
         shippingTotal: {
           minor: 2000,
         },

--- a/src/schema/v2/order/types/OrderType.ts
+++ b/src/schema/v2/order/types/OrderType.ts
@@ -465,6 +465,11 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       description: "Display short version of order's artwork location",
       resolve: ({ shipping_origin }) => shipping_origin,
     },
+    shippingRadius: {
+      type: GraphQLString,
+      description: "Whether the order ships domestically or internationally",
+      resolve: ({ shipping_radius }) => shipping_radius,
+    },
     shippingTotal: {
       type: Money,
       description: "The total amount for shipping",

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -114,6 +114,7 @@ export interface OrderJSON {
   shipping_country?: string
   shipping_name?: string
   shipping_origin?: string
+  shipping_radius?: string
   shipping_postal_code?: string
   shipping_region?: string
   shipping_total_cents?: number


### PR DESCRIPTION
Exposing `shipping_radius` to determine if we show "Additional processing times may vary by destination" on the client. 