### PR TITLE
chore: add a preview of a bulk update operation to the schema

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20525,7 +20525,7 @@ type Partner implements Node {
   # Preview counts of artworks affected by a bulk metadata update.
   bulkUpdateMetadataPreview(
     # IDs of artworks to include in the preview.
-    artworkIds: [String]
+    artworkIds: [String!]
 
     # ID of a partner list to filter artworks.
     partnerListId: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5653,6 +5653,18 @@ type BulkUpdateArtworksMetadataResponse {
   ids: [String]
 }
 
+type BulkUpdateMetadataPreview {
+  counts: BulkUpdateMetadataPreviewCounts!
+}
+
+type BulkUpdateMetadataPreviewCounts {
+  editable: Int!
+
+  # Number of artworks that cannot be edited (total - editable).
+  nonEditable: Int!
+  total: Int!
+}
+
 # Possible sources of the bulk operation
 enum BulkUpdateSourceEnum {
   ADMIN
@@ -20509,6 +20521,18 @@ type Partner implements Node {
 
   # The partner's brand kit — colors, fonts, and logo used for branded surfaces
   brandKit: BrandKit
+
+  # Preview counts of artworks affected by a bulk metadata update.
+  bulkUpdateMetadataPreview(
+    # IDs of artworks to include in the preview.
+    artworkIds: [String]
+
+    # ID of a partner list to filter artworks.
+    partnerListId: String
+
+    # When true, excludes live artworks from the editable count.
+    updateCatalog: Boolean
+  ): BulkUpdateMetadataPreview
   cached: Int
   categories: [PartnerCategory]
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1509,6 +1509,9 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    bulkUpdateMetadataPreviewLoader: gravityLoader(
+      (id) => `partner/${id}/bulk_operations/update_metadata/preview`
+    ),
     addArtworksToShowLoader: gravityLoader(
       (id) => `partner/${id}/bulk_operations/add_artworks_to_show`,
       {},

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateMetadataPreview.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateMetadataPreview.test.ts
@@ -138,6 +138,52 @@ describe("bulkUpdateMetadataPreview", () => {
     )
   })
 
+  it("passes all args together to the loader", async () => {
+    const queryWithArgs = gql`
+      {
+        partner(id: "catty-partner") {
+          bulkUpdateMetadataPreview(
+            artworkIds: ["artwork1"]
+            partnerListId: "list-456"
+            updateCatalog: true
+          ) {
+            counts {
+              total
+              editable
+              nonEditable
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      bulkUpdateMetadataPreviewLoader: jest.fn().mockResolvedValue({
+        counts: { total: 3, editable: 1 },
+      }),
+    }
+
+    const data = await runAuthenticatedQuery(queryWithArgs, context)
+
+    expect(context.bulkUpdateMetadataPreviewLoader).toHaveBeenCalledWith(
+      "catty-partner",
+      {
+        artwork_ids: ["artwork1"],
+        partner_list_id: "list-456",
+        update_catalog: true,
+      }
+    )
+
+    expect(data).toEqual({
+      partner: {
+        bulkUpdateMetadataPreview: {
+          counts: { total: 3, editable: 1, nonEditable: 2 },
+        },
+      },
+    })
+  })
+
   it("returns null when not authenticated", async () => {
     const context = {
       partnerLoader: jest.fn().mockResolvedValue(partnerData),

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateMetadataPreview.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateMetadataPreview.test.ts
@@ -1,0 +1,154 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+describe("bulkUpdateMetadataPreview", () => {
+  const query = gql`
+    {
+      partner(id: "catty-partner") {
+        bulkUpdateMetadataPreview {
+          counts {
+            total
+            editable
+            nonEditable
+          }
+        }
+      }
+    }
+  `
+
+  const partnerData = {
+    _id: "partner-internal-id",
+    id: "catty-partner",
+  }
+
+  it("returns counts with default args", async () => {
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      bulkUpdateMetadataPreviewLoader: jest.fn().mockResolvedValue({
+        counts: { total: 10, editable: 8 },
+      }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(context.bulkUpdateMetadataPreviewLoader).toHaveBeenCalledWith(
+      "catty-partner",
+      {}
+    )
+
+    expect(data).toEqual({
+      partner: {
+        bulkUpdateMetadataPreview: {
+          counts: { total: 10, editable: 8, nonEditable: 2 },
+        },
+      },
+    })
+  })
+
+  it("passes artworkIds as artwork_ids to the loader", async () => {
+    const queryWithArgs = gql`
+      {
+        partner(id: "catty-partner") {
+          bulkUpdateMetadataPreview(artworkIds: ["artwork1", "artwork2"]) {
+            counts {
+              total
+              editable
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      bulkUpdateMetadataPreviewLoader: jest.fn().mockResolvedValue({
+        counts: { total: 5, editable: 3 },
+      }),
+    }
+
+    await runAuthenticatedQuery(queryWithArgs, context)
+
+    expect(context.bulkUpdateMetadataPreviewLoader).toHaveBeenCalledWith(
+      "catty-partner",
+      {
+        artwork_ids: ["artwork1", "artwork2"],
+      }
+    )
+  })
+
+  it("passes partnerListId as partner_list_id to the loader", async () => {
+    const queryWithArgs = gql`
+      {
+        partner(id: "catty-partner") {
+          bulkUpdateMetadataPreview(partnerListId: "list-123") {
+            counts {
+              total
+              editable
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      bulkUpdateMetadataPreviewLoader: jest.fn().mockResolvedValue({
+        counts: { total: 20, editable: 15 },
+      }),
+    }
+
+    await runAuthenticatedQuery(queryWithArgs, context)
+
+    expect(context.bulkUpdateMetadataPreviewLoader).toHaveBeenCalledWith(
+      "catty-partner",
+      {
+        partner_list_id: "list-123",
+      }
+    )
+  })
+
+  it("passes updateCatalog as update_catalog to the loader", async () => {
+    const queryWithArgs = gql`
+      {
+        partner(id: "catty-partner") {
+          bulkUpdateMetadataPreview(updateCatalog: true) {
+            counts {
+              total
+              editable
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+      bulkUpdateMetadataPreviewLoader: jest.fn().mockResolvedValue({
+        counts: { total: 12, editable: 7 },
+      }),
+    }
+
+    await runAuthenticatedQuery(queryWithArgs, context)
+
+    expect(context.bulkUpdateMetadataPreviewLoader).toHaveBeenCalledWith(
+      "catty-partner",
+      {
+        update_catalog: true,
+      }
+    )
+  })
+
+  it("returns null when not authenticated", async () => {
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue(partnerData),
+    }
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      partner: {
+        bulkUpdateMetadataPreview: null,
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
@@ -1,0 +1,74 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+const BulkUpdateMetadataPreviewCountsType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "BulkUpdateMetadataPreviewCounts",
+  fields: {
+    total: { type: new GraphQLNonNull(GraphQLInt) },
+    editable: { type: new GraphQLNonNull(GraphQLInt) },
+    nonEditable: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description:
+        "Number of artworks that cannot be edited (total - editable).",
+      resolve: ({ total, editable }) => total - editable,
+    },
+  },
+})
+
+const BulkUpdateMetadataPreviewType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "BulkUpdateMetadataPreview",
+  fields: {
+    counts: { type: new GraphQLNonNull(BulkUpdateMetadataPreviewCountsType) },
+  },
+})
+
+export const bulkUpdateMetadataPreview: GraphQLFieldConfig<
+  { id: string },
+  ResolverContext
+> = {
+  type: BulkUpdateMetadataPreviewType,
+  description: "Preview counts of artworks affected by a bulk metadata update.",
+  args: {
+    artworkIds: {
+      type: new GraphQLList(GraphQLString),
+      description: "IDs of artworks to include in the preview.",
+    },
+    partnerListId: {
+      type: GraphQLString,
+      description: "ID of a partner list to filter artworks.",
+    },
+    updateCatalog: {
+      type: GraphQLBoolean,
+      description: "When true, excludes live artworks from the editable count.",
+    },
+  },
+  resolve: async (
+    { id },
+    { artworkIds, partnerListId, updateCatalog },
+    { bulkUpdateMetadataPreviewLoader }
+  ) => {
+    if (!bulkUpdateMetadataPreviewLoader) return null
+
+    const params: Record<string, unknown> = {}
+
+    if (artworkIds) params.artwork_ids = artworkIds
+    if (partnerListId) params.partner_list_id = partnerListId
+    if (updateCatalog != null) params.update_catalog = updateCatalog
+
+    return bulkUpdateMetadataPreviewLoader(id, params)
+  },
+}

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
@@ -44,7 +44,7 @@ export const bulkUpdateMetadataPreview: GraphQLFieldConfig<
   description: "Preview counts of artworks affected by a bulk metadata update.",
   args: {
     artworkIds: {
-      type: new GraphQLList(GraphQLString),
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
       description: "IDs of artworks to include in the preview.",
     },
     partnerListId: {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateMetadataPreview.ts
@@ -65,7 +65,7 @@ export const bulkUpdateMetadataPreview: GraphQLFieldConfig<
 
     const params: Record<string, unknown> = {}
 
-    if (artworkIds) params.artwork_ids = artworkIds
+    if (artworkIds?.length) params.artwork_ids = artworkIds
     if (partnerListId) params.partner_list_id = partnerListId
     if (updateCatalog != null) params.update_catalog = updateCatalog
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -75,6 +75,7 @@ import {
 } from "schema/v2/conversationMessageTemplate/conversationMessageTemplateExample"
 import { ArtworkTemplatesConnection } from "schema/v2/artworkTemplate/artworkTemplatesConnection"
 import { BrandKitType } from "./brandKit"
+import { bulkUpdateMetadataPreview } from "./BulkOperation/bulkUpdateMetadataPreview"
 
 const isFairOrganizer = (type) => type === "FairOrganizer"
 const isGallery = (type) => type === "PartnerGallery"
@@ -1467,6 +1468,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       showsSearchConnection: partnerShowsMatchConnection,
+      bulkUpdateMetadataPreview,
       partnerList: {
         description: "A single partner list by its ID.",
         type: PartnerListType,


### PR DESCRIPTION
Based on https://github.com/artsy/gravity/pull/20059 - adds the 'preview' of a bulk update operation to the schema, currently returning the counts of artworks that will be edited/skipped in a selection.