### PR TITLE
feat: Use `name` in Location query and mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10985,6 +10985,7 @@ input CreatePartnerLocationInput {
 
   # Primary email of given location
   email: String
+  name: String
 
   # ID of the partner
   partnerId: String!
@@ -16329,6 +16330,7 @@ type Location {
 
   # A type-specific ID.
   internalID: ID!
+  name: String
 
   # Union returning opening hours in formatted structure or a string
   openingHours: OpeningHoursUnion

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -64,6 +64,9 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     ...IDFields,
     cached,
+    name: {
+      type: GraphQLString,
+    },
     address: {
       type: GraphQLString,
     },

--- a/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
+++ b/src/schema/v2/partner/Settings/createPartnerLocationMutation.ts
@@ -15,6 +15,7 @@ import { LocationType } from "../../location"
 
 interface Input {
   partnerId: string
+  name: string
   addressType: string
   country: string
   address: string
@@ -66,6 +67,9 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "ID of the partner",
     },
+    name: {
+      type: GraphQLString,
+    },
     addressType: {
       type: GraphQLString,
     },
@@ -109,6 +113,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
   },
   mutateAndGetPayload: async (
     {
+      name,
       addressType,
       address,
       address2,
@@ -129,6 +134,7 @@ export const CreatePartnerLocationMutation = mutationWithClientMutationId<
 
     try {
       const response = await createPartnerLocationLoader(partnerId, {
+        name,
         address,
         address_2: address2,
         address_type: addressType,


### PR DESCRIPTION
### Description
This PR includes the name field in the Location query and mutation
