### PR TITLE
chore: add priceMinor (catalog artwork) support to bulk update metadata mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5595,6 +5595,9 @@ input BulkUpdateArtworksMetadataInput {
   # The price for the artworks
   priceListed: Float
 
+  # The price in minor units, targeting the catalog artwork field
+  priceMinor: Int
+
   # The provenance to be assigned
   provenance: String
 

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -57,6 +57,7 @@ interface Input {
     priceCurrency?: string
     priceHidden?: boolean
     priceListed?: number
+    priceMinor?: number
     provenance?: string
     published?: boolean
     signature?: string
@@ -199,6 +200,11 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     priceListed: {
       type: GraphQLFloat,
       description: "The price for the artworks",
+    },
+    priceMinor: {
+      type: GraphQLInt,
+      description:
+        "The price in minor units, targeting the catalog artwork field",
     },
     provenance: {
       type: GraphQLString,
@@ -369,6 +375,7 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         price_currency: metadata.priceCurrency,
         price_hidden: metadata.priceHidden,
         price_listed: metadata.priceListed,
+        price_minor: metadata.priceMinor,
         provenance: metadata.provenance,
         published: metadata.published,
         signature: metadata.signature,


### PR DESCRIPTION
This is the field for catalog OS updates in bulk edit, so we need to make it available as an input.