### PR TITLE
chore: support private notes and dimensions for bulk edit

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5556,6 +5556,12 @@ input BulkUpdateArtworksMetadataInput {
   # Array of dates as numbers to be assigned
   dates: [Int]
 
+  # Depth of the artwork
+  depth: String
+
+  # Diameter of the artwork
+  diameter: String
+
   # Set artwork price visibility to price range
   displayPriceRange: Boolean
 
@@ -5577,6 +5583,9 @@ input BulkUpdateArtworksMetadataInput {
   # Whether a certificate of authenticity is provided for these artworks.
   hasCertificateOfAuthenticity: Boolean
 
+  # Height of the artwork
+  height: String
+
   # The image rights to be assigned
   imageRights: String
 
@@ -5591,6 +5600,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # The medium (materials) to be assigned, E.g. Oil on Canvas
   medium: String
+
+  # Metric unit for dimensions (in or cm)
+  metric: String
 
   # Whether the artworks must be listed as Make Offer
   offer: Boolean
@@ -5613,6 +5625,9 @@ input BulkUpdateArtworksMetadataInput {
   # The price in minor units, targeting the catalog artwork field
   priceMinor: Int
 
+  # Private notes about the artwork
+  privateNotes: String
+
   # The provenance to be assigned
   provenance: String
 
@@ -5627,6 +5642,9 @@ input BulkUpdateArtworksMetadataInput {
 
   # The title of the artwork
   title: String
+
+  # Width of the artwork
+  width: String
 }
 
 type BulkUpdateArtworksMetadataMutationFailure {

--- a/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
+++ b/src/schema/v2/partner/BulkOperation/__tests__/bulkUpdateArtworksMetadataMutation.test.ts
@@ -631,6 +631,86 @@ describe("BulkUpdateArtworksMetadataMutation", () => {
     )
   })
 
+  it("updates artworks with dimension fields", async () => {
+    const dimensionMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            metadata: {
+              height: "24"
+              width: "36"
+              depth: "2"
+              diameter: "10"
+              metric: "in"
+            }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: { count: 0, ids: [] },
+      }),
+    }
+
+    await runAuthenticatedQuery(dimensionMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          height: "24",
+          width: "36",
+          depth: "2",
+          diameter: "10",
+          metric: "in",
+        },
+      }
+    )
+  })
+
+  it("updates artworks with privateNotes field", async () => {
+    const privateNotesMutation = gql`
+      mutation {
+        bulkUpdateArtworksMetadata(
+          input: {
+            id: "partner123"
+            metadata: { privateNotes: "Internal note about condition" }
+          }
+        ) {
+          bulkUpdateArtworksMetadataOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerArtworksMetadataLoader: jest.fn().mockResolvedValue({
+        success: 1,
+        errors: { count: 0, ids: [] },
+      }),
+    }
+
+    await runAuthenticatedQuery(privateNotesMutation, context)
+
+    expect(context.updatePartnerArtworksMetadataLoader).toHaveBeenCalledWith(
+      "partner123",
+      {
+        metadata: {
+          private_notes: "Internal note about condition",
+        },
+      }
+    )
+  })
+
   it("passes artsy_listing in metadata when provided", async () => {
     const artsyListingMutation = gql`
       mutation {

--- a/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
+++ b/src/schema/v2/partner/BulkOperation/bulkUpdateArtworksMetadataMutation.ts
@@ -41,16 +41,20 @@ interface Input {
     coaByGallery?: boolean
     coaByAuthenticatingBody?: boolean
     conditionDescription?: string
+    depth?: string
+    diameter?: string
     displayPriceRange?: boolean
     domesticShippingFeeCents?: number
     ecommerce: boolean
     exactPrice?: boolean
     exhibitionHistory?: string
+    height?: string
     imageRights?: string
     internationalShippingFeeCents?: number
     literature?: string
     locationId?: string
     medium?: string
+    metric?: string
     offer: boolean
     pickupAvailable?: boolean
     priceAdjustment?: number
@@ -58,10 +62,12 @@ interface Input {
     priceHidden?: boolean
     priceListed?: number
     priceMinor?: number
+    privateNotes?: string
     provenance?: string
     published?: boolean
     signature?: string
     title?: string
+    width?: string
   }
   filters?: {
     artistId?: string
@@ -133,6 +139,14 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "The artwork condition to be assigned",
     },
+    depth: {
+      type: GraphQLString,
+      description: "Depth of the artwork",
+    },
+    diameter: {
+      type: GraphQLString,
+      description: "Diameter of the artwork",
+    },
     displayPriceRange: {
       type: GraphQLBoolean,
       description: "Set artwork price visibility to price range",
@@ -154,6 +168,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       type: GraphQLString,
       description: "The exhibition history to be assigned",
     },
+    height: {
+      type: GraphQLString,
+      description: "Height of the artwork",
+    },
     imageRights: {
       type: GraphQLString,
       description: "The image rights to be assigned",
@@ -174,6 +192,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     medium: {
       type: GraphQLString,
       description: "The medium (materials) to be assigned, E.g. Oil on Canvas",
+    },
+    metric: {
+      type: GraphQLString,
+      description: "Metric unit for dimensions (in or cm)",
     },
     offer: {
       type: GraphQLBoolean,
@@ -206,6 +228,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
       description:
         "The price in minor units, targeting the catalog artwork field",
     },
+    privateNotes: {
+      type: GraphQLString,
+      description: "Private notes about the artwork",
+    },
     provenance: {
       type: GraphQLString,
       description: "The provenance to be assigned",
@@ -225,6 +251,10 @@ const BulkUpdateArtworksMetadataInput = new GraphQLInputObjectType({
     title: {
       type: GraphQLString,
       description: "The title of the artwork",
+    },
+    width: {
+      type: GraphQLString,
+      description: "Width of the artwork",
     },
   },
 })
@@ -358,16 +388,20 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         coa_by_gallery: metadata.coaByGallery,
         coa_by_authenticating_body: metadata.coaByAuthenticatingBody,
         condition_description: metadata.conditionDescription,
+        depth: metadata.depth,
+        diameter: metadata.diameter,
         domestic_shipping_fee_cents: metadata.domesticShippingFeeCents,
         ecommerce: metadata.ecommerce,
         exact_price: metadata.exactPrice,
         exhibition_history: metadata.exhibitionHistory,
+        height: metadata.height,
         image_rights: metadata.imageRights,
         international_shipping_fee_cents:
           metadata.internationalShippingFeeCents,
         literature: metadata.literature,
         location_id: metadata.locationId,
         medium: metadata.medium,
+        metric: metadata.metric,
         offer: metadata.offer,
         pickup_available: metadata.pickupAvailable,
         display_price_range: metadata.displayPriceRange,
@@ -376,11 +410,13 @@ export const bulkUpdateArtworksMetadataMutation = mutationWithClientMutationId<
         price_hidden: metadata.priceHidden,
         price_listed: metadata.priceListed,
         price_minor: metadata.priceMinor,
+        private_notes: metadata.privateNotes,
         provenance: metadata.provenance,
         published: metadata.published,
         signature: metadata.signature,
         ...transformSignatureFieldsToGravityFields(metadata.signatureTypes),
         title: metadata.title,
+        width: metadata.width,
       }
     }
 


### PR DESCRIPTION
Adds the remaining fields, private notes and dimensions (https://github.com/artsy/gravity/pull/20071) for the bulk edit mutation.