### PR TITLE
chore: Forward includeNonArtsyListed param to Gravity for partner artworks

### DIFF
--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1176,6 +1176,48 @@ describe("Partner type", () => {
           await runAuthenticatedQuery(query, context)
           expect(partnerArtworksAllLoader).toHaveBeenCalled()
         })
+
+        it("forwards include_non_artsy_listed to partnerArtworksAllLoader when set", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(
+                  first: 3
+                  shallow: false
+                  includeNonArtsyListed: true
+                ) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          await runAuthenticatedQuery(query, context)
+          const loaderArgs = partnerArtworksAllLoader.mock.calls[0][1]
+          expect(loaderArgs).toHaveProperty("include_non_artsy_listed", true)
+        })
+
+        it("does not forward include_non_artsy_listed when not set", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 3, shallow: false) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          await runAuthenticatedQuery(query, context)
+          const loaderArgs = partnerArtworksAllLoader.mock.calls[0][1]
+          expect(loaderArgs).not.toHaveProperty("include_non_artsy_listed")
+        })
       })
       describe("when shallow is true", () => {
         it("does not call partnerArtworksAllLoader", async () => {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -731,9 +731,17 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             artworkIds.length > 0 &&
             partnerArtworksAllLoader
           ) {
-            const gravityArtworkArgs = {
+            const gravityArtworkArgs: {
+              artwork_id: string[]
+              include_non_artsy_listed?: boolean
+              sort: string
+            } = {
               artwork_id: artworkIds,
               sort: args.sort,
+            }
+
+            if (args.includeNonArtsyListed) {
+              gravityArtworkArgs.include_non_artsy_listed = true
             }
 
             const { body: artworks } = await partnerArtworksAllLoader(


### PR DESCRIPTION
We're trying to surface catalog artwork data within the Materials PDF files, but the response is always empty.

This happens because we recently swapped the query used in Volt from the filtered one (OpenSearch-based) to `partner/:id/artworks` (for ref: https://github.com/artsy/volt/pull/11296)

Apply on this PR similar changes to what was already done in the top-level query by @MrSltun during https://github.com/artsy/metaphysics/pull/7577, but now applied to the partner-scoped version (the one we're sure it never hits the OpenSearch-based endpoints). It only affects the `partnerArtworksAllLoader`, so we don't need any additional checks to be performed regarding authorization/permissions.

See below the response differences for the same query:

```graphql
query {
  partner(id: "570bf4a6cd530e6591000ac4") {
    internalID
    artworksConnection(
      first: 1,
      artworkIDs: ["698f3590009443000f39e63e"],
      shallow: false,
      includeNonArtsyListed: true,
    ) {
      totalCount
      edges {
        node {
          internalID
          title
          catalogArtwork {
            medium
            priceListed {
              display
            }
          }
        }   
      }
    }
  }
}
```

## Before

```json
{
  "data": {
    "partner": {
      "internalID": "570bf4a6cd530e6591000ac4",
      "artworksConnection": {
        "totalCount": 1,
        "edges": [
          {
            "node": {
              "internalID": "698f3590009443000f39e63e",
              "title": "Testing artwork",
              "catalogArtwork": null
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/570bf4a6cd530e6591000ac4": {
            "time": "0s 344.848ms",
            "cache": false,
            "length": "0 B"
          },
          "partner/rogallery/artworks?page=1&published=true&size=1&total_count=true&visibility_levels%5B0%5D=listed&include_non_artsy_listed=true&artwork_id%5B0%5D=698f3590009443000f39e63e": {
            "time": "0s 156.068ms",
            "cache": false,
            "length": "0 B"
          },
          "partner/rogallery/artworks/all?artwork_id%5B0%5D=698f3590009443000f39e63e": {
            "time": "0s 167.887ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "ddda69f0-4258-11f1-97ea-896bde60424c"
  }
}
```

## After

```json
{
  "data": {
    "partner": {
      "internalID": "570bf4a6cd530e6591000ac4",
      "artworksConnection": {
        "totalCount": 1,
        "edges": [
          {
            "node": {
              "internalID": "698f3590009443000f39e63e",
              "title": "Testing artwork",
              "catalogArtwork": {
                "medium": "Textile Arts",
                "priceListed": {
                  "display": "US$25"
                }
              }
            }
          }
        ]
      }
    }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "partner/570bf4a6cd530e6591000ac4": {
            "time": "0s 381.749ms",
            "cache": false,
            "length": "0 B"
          },
          "partner/rogallery/artworks?page=1&published=true&size=1&total_count=true&visibility_levels%5B0%5D=listed&include_non_artsy_listed=true&artwork_id%5B0%5D=698f3590009443000f39e63e": {
            "time": "0s 160.976ms",
            "cache": false,
            "length": "0 B"
          },
          "partner/rogallery/artworks/all?artwork_id%5B0%5D=698f3590009443000f39e63e&include_non_artsy_listed=true": {
            "time": "0s 179.332ms",
            "cache": false,
            "length": "0 B"
          }
        }
      }
    },
    "requestID": "bbdb85b0-4257-11f1-97ea-896bde60424c"
  }
}
```

cc @artsy/amber-devs 