### PR TITLE
fix: Forward the size param to gravity for shallow: false artworks

### DIFF
--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -1218,6 +1218,25 @@ describe("Partner type", () => {
           const loaderArgs = partnerArtworksAllLoader.mock.calls[0][1]
           expect(loaderArgs).not.toHaveProperty("include_non_artsy_listed")
         })
+
+        it("forwards size matching the number of resolved artwork ids", async () => {
+          const query = gql`
+            {
+              partner(id: "bau-xi-gallery") {
+                artworksConnection(first: 50, shallow: false) {
+                  edges {
+                    node {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          `
+          await runAuthenticatedQuery(query, context)
+          const loaderArgs = partnerArtworksAllLoader.mock.calls[0][1]
+          expect(loaderArgs).toHaveProperty("size", artworksResponse.length)
+        })
       })
       describe("when shallow is true", () => {
         it("does not call partnerArtworksAllLoader", async () => {

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -734,9 +734,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             const gravityArtworkArgs: {
               artwork_id: string[]
               include_non_artsy_listed?: boolean
+              size: number
               sort: string
             } = {
               artwork_id: artworkIds,
+              size: artworkIds.length,
               sort: args.sort,
             }
 


### PR DESCRIPTION
@olerichter00 noticed while testing the Materials feature that selecting a higher number of artworks would lead us to lose some data caused by default size/pagination.

Changes here allow the size param to be set for partner/:id/artworks/all loader in the same way we already do for partner/:id/artworks loader, so we can fetch the same number of artworks as we're requesting through the IDs array passed.

Difference on the response body while querying 50 artworks through artworks connection:

## Before
<img width="1030" height="178" alt="Screenshot 2026-04-28 at 15 28 43" src="https://github.com/user-attachments/assets/576ce06f-97ac-4ef7-9ca2-99f7de2359ac" />

## After
<img width="1160" height="293" alt="Screenshot 2026-04-28 at 15 29 04" src="https://github.com/user-attachments/assets/ded4fa1e-3811-41d7-8b6f-0008b6313185" />

cc @artsy/amber-devs 