### PR TITLE
chore: add schema for artwork duplicates

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3419,6 +3419,93 @@ interface ArtworkContextGrid {
   title: String
 }
 
+input ArtworkDuplicateMergeFieldOverridesInput {
+  availability: String
+  date: String
+  depth: String
+  diameter: String
+  height: String
+  medium: String
+  metric: String
+  priceCurrency: String
+  priceMinor: Int
+  privateNotes: String
+  title: String
+  width: String
+}
+
+type ArtworkDuplicatePair {
+  artwork1: Artwork!
+  artwork2: Artwork!
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String!
+  detectionVersion: String!
+  dismissedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID.
+  internalID: ID!
+
+  # Metadata from the duplicate detection process, just typed as JSON (for debugging)
+  matchMetadata: JSON
+
+  # Details about the merge operation, just typed as JSON (for debugging)
+  mergeDetails: JSON
+  mergeable: Boolean!
+  mergedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  mergedIntoArtwork: Artwork
+  similarityScore: Float
+  status: ArtworkDuplicatePairStatus!
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String!
+}
+
+# A connection to a list of items.
+type ArtworkDuplicatePairConnection {
+  # A list of edges.
+  edges: [ArtworkDuplicatePairEdge]
+  pageCursors: PageCursors!
+
+  # Information to aid in pagination.
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+# An edge in a connection.
+type ArtworkDuplicatePairEdge {
+  # A cursor for use in pagination
+  cursor: String!
+
+  # The item at the end of the edge
+  node: ArtworkDuplicatePair
+}
+
+enum ArtworkDuplicatePairStatus {
+  DISMISSED
+  MERGED
+  OPEN
+}
+
 # An edge in a connection.
 type ArtworkEdge implements ArtworkEdgeInterface {
   # A cursor for use in pagination
@@ -12824,6 +12911,35 @@ type Department {
   name: String!
 }
 
+type DetectArtworkDuplicatesFailure {
+  mutationError: GravityMutationError
+}
+
+input DetectArtworkDuplicatesMutationInput {
+  clientMutationId: String
+
+  # Optional detection version to use
+  detectionVersion: String
+
+  # The ID of the partner
+  partnerId: String!
+}
+
+type DetectArtworkDuplicatesMutationPayload {
+  clientMutationId: String
+  detectArtworkDuplicatesResponseOrError: DetectArtworkDuplicatesResponseOrError
+}
+
+union DetectArtworkDuplicatesResponseOrError =
+    DetectArtworkDuplicatesFailure
+  | DetectArtworkDuplicatesSuccess
+
+type DetectArtworkDuplicatesSuccess {
+  detectionVersion: String
+  partnerId: String
+  status: String
+}
+
 type Device {
   # E.g., net.artsy.artsy
   appId: String!
@@ -13010,6 +13126,30 @@ type DislikeArtworkPayload {
   artwork: Artwork
   clientMutationId: String
   me: Me!
+}
+
+type DismissArtworkDuplicatePairFailure {
+  mutationError: GravityMutationError
+}
+
+input DismissArtworkDuplicatePairMutationInput {
+  clientMutationId: String
+
+  # The ID of the artwork duplicate pair
+  id: String!
+}
+
+type DismissArtworkDuplicatePairMutationPayload {
+  artworkDuplicatePairOrError: DismissArtworkDuplicatePairResponseOrError
+  clientMutationId: String
+}
+
+union DismissArtworkDuplicatePairResponseOrError =
+    DismissArtworkDuplicatePairFailure
+  | DismissArtworkDuplicatePairSuccess
+
+type DismissArtworkDuplicatePairSuccess {
+  artworkDuplicatePair: ArtworkDuplicatePair
 }
 
 type DismissTaskFailure {
@@ -17918,6 +18058,36 @@ type MergeArtistsSuccess {
   artist: Artist
 }
 
+type MergeArtworkDuplicatePairFailure {
+  mutationError: GravityMutationError
+}
+
+input MergeArtworkDuplicatePairMutationInput {
+  clientMutationId: String
+
+  # Optional field-level overrides for the merge
+  fieldOverrides: ArtworkDuplicateMergeFieldOverridesInput
+
+  # The ID of the artwork duplicate pair
+  id: String!
+
+  # The ID of the artwork to keep as primary
+  primaryArtworkId: String!
+}
+
+type MergeArtworkDuplicatePairMutationPayload {
+  artworkDuplicatePairOrError: MergeArtworkDuplicatePairResponseOrError
+  clientMutationId: String
+}
+
+union MergeArtworkDuplicatePairResponseOrError =
+    MergeArtworkDuplicatePairFailure
+  | MergeArtworkDuplicatePairSuccess
+
+type MergeArtworkDuplicatePairSuccess {
+  artworkDuplicatePair: ArtworkDuplicatePair
+}
+
 # A message in a conversation.
 type Message implements Node {
   attachments: [Attachment]
@@ -18912,6 +19082,11 @@ type Mutation {
   deliverSecondFactor(
     input: DeliverSecondFactorInput!
   ): DeliverSecondFactorPayload
+
+  # Trigger duplicate detection for a partner's artworks
+  detectArtworkDuplicates(
+    input: DetectArtworkDuplicatesMutationInput!
+  ): DetectArtworkDuplicatesMutationPayload
   disableSecondFactor(
     input: DisableSecondFactorInput!
   ): DisableSecondFactorPayload
@@ -18923,6 +19098,11 @@ type Mutation {
 
   # Add (or remove) an artwork to (from) a users dislikes.
   dislikeArtwork(input: DislikeArtworkInput!): DislikeArtworkPayload
+
+  # Dismiss an artwork duplicate pair
+  dismissArtworkDuplicatePair(
+    input: DismissArtworkDuplicatePairMutationInput!
+  ): DismissArtworkDuplicatePairMutationPayload
 
   # Updates a Task on the logged in User
   dismissTask(input: DismissTaskMutationInput!): DismissTaskMutationPayload
@@ -18975,6 +19155,11 @@ type Mutation {
 
   # Merge multiple artist records in order to deduplicate artists
   mergeArtists(input: MergeArtistsMutationInput!): MergeArtistsMutationPayload
+
+  # Merge an artwork duplicate pair
+  mergeArtworkDuplicatePair(
+    input: MergeArtworkDuplicatePairMutationInput!
+  ): MergeArtworkDuplicatePairMutationPayload
 
   # Moves artworks from one partner list to another.
   moveArtworksBetweenPartnerLists(
@@ -19034,6 +19219,11 @@ type Mutation {
   removeInstallShotFromPartnerShow(
     input: RemoveInstallShotFromPartnerShowMutationInput!
   ): RemoveInstallShotFromPartnerShowMutationPayload
+
+  # Reopen a dismissed artwork duplicate pair
+  reopenArtworkDuplicatePair(
+    input: ReopenArtworkDuplicatePairMutationInput!
+  ): ReopenArtworkDuplicatePairMutationPayload
 
   # Reposition artwork images, determining their display order.
   repositionArtworkImages(
@@ -22736,6 +22926,32 @@ type Query {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+
+  # Get a single artwork duplicate pair by ID
+  artworkDuplicatePair(
+    # The ID of the artwork duplicate pair
+    id: String!
+  ): ArtworkDuplicatePair
+
+  # List artwork duplicate pairs for a partner
+  artworkDuplicatePairsConnection(
+    after: String
+    before: String
+
+    # Filter by detection version
+    detectionVersion: String
+    first: Int
+    last: Int
+
+    # Filter by whether the pair can be merged (neither artwork is both published and listed on Artsy)
+    mergeable: Boolean
+
+    # The ID of the partner
+    partnerId: String!
+
+    # Filter by pair status
+    status: ArtworkDuplicatePairStatus
+  ): ArtworkDuplicatePairConnection
   artworkImport(id: String!): ArtworkImport
 
   # List of all artwork mediums
@@ -24462,6 +24678,30 @@ union RemoveInstallShotFromPartnerShowResponseOrError =
 
 type RemoveInstallShotFromPartnerShowSuccess {
   show: Show
+}
+
+type ReopenArtworkDuplicatePairFailure {
+  mutationError: GravityMutationError
+}
+
+input ReopenArtworkDuplicatePairMutationInput {
+  clientMutationId: String
+
+  # The ID of the artwork duplicate pair
+  id: String!
+}
+
+type ReopenArtworkDuplicatePairMutationPayload {
+  artworkDuplicatePairOrError: ReopenArtworkDuplicatePairResponseOrError
+  clientMutationId: String
+}
+
+union ReopenArtworkDuplicatePairResponseOrError =
+    ReopenArtworkDuplicatePairFailure
+  | ReopenArtworkDuplicatePairSuccess
+
+type ReopenArtworkDuplicatePairSuccess {
+  artworkDuplicatePair: ArtworkDuplicatePair
 }
 
 type RepositionArtworkImagesFailure {
@@ -29783,6 +30023,32 @@ type Viewer {
 
   # List of all artwork attribution classes
   artworkAttributionClasses: [AttributionClass]
+
+  # Get a single artwork duplicate pair by ID
+  artworkDuplicatePair(
+    # The ID of the artwork duplicate pair
+    id: String!
+  ): ArtworkDuplicatePair
+
+  # List artwork duplicate pairs for a partner
+  artworkDuplicatePairsConnection(
+    after: String
+    before: String
+
+    # Filter by detection version
+    detectionVersion: String
+    first: Int
+    last: Int
+
+    # Filter by whether the pair can be merged (neither artwork is both published and listed on Artsy)
+    mergeable: Boolean
+
+    # The ID of the partner
+    partnerId: String!
+
+    # Filter by pair status
+    status: ArtworkDuplicatePairStatus
+  ): ArtworkDuplicatePairConnection
   artworkImport(id: String!): ArtworkImport
 
   # List of all artwork mediums

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -180,6 +180,24 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     // End RESTful Artwork Import Loaders
+    artworkDuplicatePairsLoader: gravityLoader(
+      "artwork_duplicate_pairs",
+      {},
+      { headers: true }
+    ),
+    artworkDuplicatePairLoader: gravityLoader(
+      (id) => `artwork_duplicate_pair/${id}`
+    ),
+    detectArtworkDuplicatesLoader: gravityLoader(
+      "artwork_duplicate_pair/detect",
+      {},
+      { method: "POST" }
+    ),
+    updateArtworkDuplicatePairLoader: gravityLoader(
+      (id) => `artwork_duplicate_pair/${id}`,
+      {},
+      { method: "PUT" }
+    ),
     artworksCollectionsBatchUpdateLoader: gravityLoader(
       "artworks/collections/batch",
       {},

--- a/src/schema/v2/artworkDuplicatePair/__tests__/artworkDuplicatePair.test.ts
+++ b/src/schema/v2/artworkDuplicatePair/__tests__/artworkDuplicatePair.test.ts
@@ -1,0 +1,205 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mockPair = {
+  id: "pair-1",
+  artwork_1_id: "artwork-1",
+  artwork_2_id: "artwork-2",
+  status: "open",
+  similarity_score: 0.95,
+  detection_version: "v1",
+  match_metadata: { field: "title" },
+  mergeable: true,
+  dismissed_at: null,
+  merged_at: null,
+  merged_into_artwork_id: null,
+  merge_details: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+}
+
+const mockArtwork = {
+  id: "artwork-slug",
+  _id: "artwork-1",
+  title: "Test Artwork",
+}
+
+describe("artworkDuplicatePair", () => {
+  it("fetches a single pair by id", async () => {
+    const artworkDuplicatePairLoader = jest.fn().mockResolvedValue(mockPair)
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const query = gql`
+      query {
+        artworkDuplicatePair(id: "pair-1") {
+          internalID
+          status
+          similarityScore
+          detectionVersion
+          mergeable
+          createdAt
+          updatedAt
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(query, {
+      artworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(artworkDuplicatePairLoader).toHaveBeenCalledWith("pair-1")
+    expect(result).toEqual({
+      artworkDuplicatePair: {
+        internalID: "pair-1",
+        status: "OPEN",
+        similarityScore: 0.95,
+        detectionVersion: "v1",
+        mergeable: true,
+        createdAt: "2024-01-01T00:00:00Z",
+        updatedAt: "2024-01-01T00:00:00Z",
+      },
+    })
+  })
+
+  it("resolves artwork1 and artwork2", async () => {
+    const artworkDuplicatePairLoader = jest.fn().mockResolvedValue(mockPair)
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const query = gql`
+      query {
+        artworkDuplicatePair(id: "pair-1") {
+          artwork1 {
+            internalID
+          }
+          artwork2 {
+            internalID
+          }
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(query, {
+      artworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(artworkLoader).toHaveBeenCalledWith("artwork-1")
+    expect(artworkLoader).toHaveBeenCalledWith("artwork-2")
+  })
+})
+
+describe("artworkDuplicatePairsConnection", () => {
+  it("fetches a paginated list of pairs", async () => {
+    const artworkDuplicatePairsLoader = jest.fn().mockResolvedValue({
+      body: [mockPair],
+      headers: { "x-total-count": "1" },
+    })
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const query = gql`
+      query {
+        artworkDuplicatePairsConnection(partnerId: "partner-1", first: 10) {
+          totalCount
+          edges {
+            node {
+              internalID
+              status
+              similarityScore
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(query, {
+      artworkDuplicatePairsLoader,
+      artworkLoader,
+    })
+
+    expect(artworkDuplicatePairsLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partner_id: "partner-1",
+        size: 10,
+        total_count: true,
+      })
+    )
+
+    expect(result.artworkDuplicatePairsConnection.totalCount).toBe(1)
+    expect(result.artworkDuplicatePairsConnection.edges).toHaveLength(1)
+    expect(result.artworkDuplicatePairsConnection.edges[0].node).toEqual({
+      internalID: "pair-1",
+      status: "OPEN",
+      similarityScore: 0.95,
+    })
+  })
+
+  it("passes optional filters", async () => {
+    const artworkDuplicatePairsLoader = jest.fn().mockResolvedValue({
+      body: [],
+      headers: { "x-total-count": "0" },
+    })
+
+    const query = gql`
+      query {
+        artworkDuplicatePairsConnection(
+          partnerId: "partner-1"
+          status: DISMISSED
+          detectionVersion: "v2"
+          first: 5
+        ) {
+          totalCount
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(query, { artworkDuplicatePairsLoader })
+
+    expect(artworkDuplicatePairsLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partner_id: "partner-1",
+        status: "dismissed",
+        detection_version: "v2",
+        size: 5,
+      })
+    )
+  })
+
+  it("passes mergeable filter", async () => {
+    const artworkDuplicatePairsLoader = jest.fn().mockResolvedValue({
+      body: [],
+      headers: { "x-total-count": "0" },
+    })
+
+    const query = gql`
+      query {
+        artworkDuplicatePairsConnection(
+          partnerId: "partner-1"
+          mergeable: true
+          first: 10
+        ) {
+          totalCount
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(query, { artworkDuplicatePairsLoader })
+
+    expect(artworkDuplicatePairsLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        partner_id: "partner-1",
+        mergeable: true,
+      })
+    )
+  })
+})

--- a/src/schema/v2/artworkDuplicatePair/__tests__/detectArtworkDuplicatesMutation.test.ts
+++ b/src/schema/v2/artworkDuplicatePair/__tests__/detectArtworkDuplicatesMutation.test.ts
@@ -1,0 +1,83 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("detectArtworkDuplicatesMutation", () => {
+  it("triggers detection", async () => {
+    const detectArtworkDuplicatesLoader = jest.fn().mockResolvedValue({
+      status: "processing",
+      partner_id: "partner-1",
+      detection_version: "v1",
+    })
+
+    const mutation = gql`
+      mutation {
+        detectArtworkDuplicates(
+          input: { partnerId: "partner-1", detectionVersion: "v1" }
+        ) {
+          detectArtworkDuplicatesResponseOrError {
+            ... on DetectArtworkDuplicatesSuccess {
+              status
+              partnerId
+              detectionVersion
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      detectArtworkDuplicatesLoader,
+    })
+
+    expect(detectArtworkDuplicatesLoader).toHaveBeenCalledWith({
+      partner_id: "partner-1",
+      detection_version: "v1",
+    })
+
+    expect(
+      result.detectArtworkDuplicates.detectArtworkDuplicatesResponseOrError
+    ).toEqual({
+      status: "processing",
+      partnerId: "partner-1",
+      detectionVersion: "v1",
+    })
+  })
+
+  it("returns an error when gravity fails", async () => {
+    const detectArtworkDuplicatesLoader = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          `https://stagingapi.artsy.net/api/v1/artwork_duplicate_pair/detect - {"type":"param_error","message":"Partner not found"}`
+        )
+      )
+
+    const mutation = gql`
+      mutation {
+        detectArtworkDuplicates(input: { partnerId: "bad-partner" }) {
+          detectArtworkDuplicatesResponseOrError {
+            __typename
+            ... on DetectArtworkDuplicatesFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      detectArtworkDuplicatesLoader,
+    })
+
+    expect(
+      result.detectArtworkDuplicates.detectArtworkDuplicatesResponseOrError
+    ).toEqual({
+      __typename: "DetectArtworkDuplicatesFailure",
+      mutationError: {
+        message: "Partner not found",
+      },
+    })
+  })
+})

--- a/src/schema/v2/artworkDuplicatePair/__tests__/dismissArtworkDuplicatePairMutation.test.ts
+++ b/src/schema/v2/artworkDuplicatePair/__tests__/dismissArtworkDuplicatePairMutation.test.ts
@@ -1,0 +1,108 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mockPair = {
+  id: "pair-1",
+  artwork_1_id: "artwork-1",
+  artwork_2_id: "artwork-2",
+  status: "open",
+  similarity_score: 0.95,
+  detection_version: "v1",
+  match_metadata: null,
+  mergeable: true,
+  dismissed_at: null,
+  merged_at: null,
+  merged_into_artwork_id: null,
+  merge_details: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+}
+
+const mockArtwork = {
+  id: "artwork-slug",
+  _id: "artwork-1",
+  title: "Test Artwork",
+}
+
+describe("dismissArtworkDuplicatePairMutation", () => {
+  it("dismisses a pair", async () => {
+    const updateArtworkDuplicatePairLoader = jest.fn().mockResolvedValue({
+      ...mockPair,
+      status: "dismissed",
+      dismissed_at: "2024-01-02T00:00:00Z",
+    })
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const mutation = gql`
+      mutation {
+        dismissArtworkDuplicatePair(input: { id: "pair-1" }) {
+          artworkDuplicatePairOrError {
+            ... on DismissArtworkDuplicatePairSuccess {
+              artworkDuplicatePair {
+                internalID
+                status
+                dismissedAt
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(updateArtworkDuplicatePairLoader).toHaveBeenCalledWith("pair-1", {
+      status: "dismissed",
+    })
+
+    expect(
+      result.dismissArtworkDuplicatePair.artworkDuplicatePairOrError
+        .artworkDuplicatePair
+    ).toEqual({
+      internalID: "pair-1",
+      status: "DISMISSED",
+      dismissedAt: "2024-01-02T00:00:00Z",
+    })
+  })
+
+  it("returns an error when gravity fails", async () => {
+    const updateArtworkDuplicatePairLoader = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          `https://stagingapi.artsy.net/api/v1/artwork_duplicate_pair/pair-1 - {"type":"param_error","message":"Pair not found"}`
+        )
+      )
+
+    const mutation = gql`
+      mutation {
+        dismissArtworkDuplicatePair(input: { id: "pair-1" }) {
+          artworkDuplicatePairOrError {
+            __typename
+            ... on DismissArtworkDuplicatePairFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+    })
+
+    expect(
+      result.dismissArtworkDuplicatePair.artworkDuplicatePairOrError
+    ).toEqual({
+      __typename: "DismissArtworkDuplicatePairFailure",
+      mutationError: {
+        message: "Pair not found",
+      },
+    })
+  })
+})

--- a/src/schema/v2/artworkDuplicatePair/__tests__/mergeArtworkDuplicatePairMutation.test.ts
+++ b/src/schema/v2/artworkDuplicatePair/__tests__/mergeArtworkDuplicatePairMutation.test.ts
@@ -1,0 +1,165 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mockPair = {
+  id: "pair-1",
+  artwork_1_id: "artwork-1",
+  artwork_2_id: "artwork-2",
+  status: "open",
+  similarity_score: 0.95,
+  detection_version: "v1",
+  match_metadata: null,
+  mergeable: true,
+  dismissed_at: null,
+  merged_at: null,
+  merged_into_artwork_id: null,
+  merge_details: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+}
+
+const mockArtwork = {
+  id: "artwork-slug",
+  _id: "artwork-1",
+  title: "Test Artwork",
+}
+
+describe("mergeArtworkDuplicatePairMutation", () => {
+  it("merges a pair", async () => {
+    const updateArtworkDuplicatePairLoader = jest.fn().mockResolvedValue({
+      ...mockPair,
+      status: "merged",
+      merged_at: "2024-01-02T00:00:00Z",
+      merged_into_artwork_id: "artwork-1",
+    })
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const mutation = gql`
+      mutation {
+        mergeArtworkDuplicatePair(
+          input: { id: "pair-1", primaryArtworkId: "artwork-1" }
+        ) {
+          artworkDuplicatePairOrError {
+            ... on MergeArtworkDuplicatePairSuccess {
+              artworkDuplicatePair {
+                internalID
+                status
+                mergedAt
+                mergedIntoArtwork {
+                  internalID
+                  title
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(updateArtworkDuplicatePairLoader).toHaveBeenCalledWith("pair-1", {
+      status: "merged",
+      primary_artwork_id: "artwork-1",
+    })
+
+    expect(
+      result.mergeArtworkDuplicatePair.artworkDuplicatePairOrError
+        .artworkDuplicatePair
+    ).toEqual({
+      internalID: "pair-1",
+      status: "MERGED",
+      mergedAt: "2024-01-02T00:00:00Z",
+      mergedIntoArtwork: {
+        internalID: "artwork-1",
+        title: "Test Artwork",
+      },
+    })
+  })
+
+  it("merges with field overrides", async () => {
+    const updateArtworkDuplicatePairLoader = jest.fn().mockResolvedValue({
+      ...mockPair,
+      status: "merged",
+    })
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const mutation = gql`
+      mutation {
+        mergeArtworkDuplicatePair(
+          input: {
+            id: "pair-1"
+            primaryArtworkId: "artwork-1"
+            fieldOverrides: { title: "Preferred Title", priceMinor: 10000 }
+          }
+        ) {
+          artworkDuplicatePairOrError {
+            ... on MergeArtworkDuplicatePairSuccess {
+              artworkDuplicatePair {
+                internalID
+                status
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(updateArtworkDuplicatePairLoader).toHaveBeenCalledWith("pair-1", {
+      status: "merged",
+      primary_artwork_id: "artwork-1",
+      field_overrides: {
+        title: "Preferred Title",
+        price_minor: 10000,
+      },
+    })
+  })
+
+  it("returns an error when gravity fails", async () => {
+    const updateArtworkDuplicatePairLoader = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          `https://stagingapi.artsy.net/api/v1/artwork_duplicate_pair/pair-1 - {"type":"param_error","message":"Pair is not mergeable"}`
+        )
+      )
+
+    const mutation = gql`
+      mutation {
+        mergeArtworkDuplicatePair(
+          input: { id: "pair-1", primaryArtworkId: "artwork-1" }
+        ) {
+          artworkDuplicatePairOrError {
+            __typename
+            ... on MergeArtworkDuplicatePairFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+    })
+
+    expect(
+      result.mergeArtworkDuplicatePair.artworkDuplicatePairOrError
+    ).toEqual({
+      __typename: "MergeArtworkDuplicatePairFailure",
+      mutationError: {
+        message: "Pair is not mergeable",
+      },
+    })
+  })
+})

--- a/src/schema/v2/artworkDuplicatePair/__tests__/reopenArtworkDuplicatePairMutation.test.ts
+++ b/src/schema/v2/artworkDuplicatePair/__tests__/reopenArtworkDuplicatePairMutation.test.ts
@@ -1,0 +1,106 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const mockPair = {
+  id: "pair-1",
+  artwork_1_id: "artwork-1",
+  artwork_2_id: "artwork-2",
+  status: "dismissed",
+  similarity_score: 0.95,
+  detection_version: "v1",
+  match_metadata: null,
+  mergeable: true,
+  dismissed_at: "2024-01-02T00:00:00Z",
+  merged_at: null,
+  merged_into_artwork_id: null,
+  merge_details: null,
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
+}
+
+const mockArtwork = {
+  id: "artwork-slug",
+  _id: "artwork-1",
+  title: "Test Artwork",
+}
+
+describe("reopenArtworkDuplicatePairMutation", () => {
+  it("reopens a dismissed pair", async () => {
+    const updateArtworkDuplicatePairLoader = jest.fn().mockResolvedValue({
+      ...mockPair,
+      status: "open",
+      dismissed_at: null,
+    })
+    const artworkLoader = jest.fn().mockResolvedValue(mockArtwork)
+
+    const mutation = gql`
+      mutation {
+        reopenArtworkDuplicatePair(input: { id: "pair-1" }) {
+          artworkDuplicatePairOrError {
+            ... on ReopenArtworkDuplicatePairSuccess {
+              artworkDuplicatePair {
+                internalID
+                status
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+      artworkLoader,
+    })
+
+    expect(updateArtworkDuplicatePairLoader).toHaveBeenCalledWith("pair-1", {
+      status: "open",
+    })
+
+    expect(
+      result.reopenArtworkDuplicatePair.artworkDuplicatePairOrError
+        .artworkDuplicatePair
+    ).toEqual({
+      internalID: "pair-1",
+      status: "OPEN",
+    })
+  })
+
+  it("returns an error when gravity fails", async () => {
+    const updateArtworkDuplicatePairLoader = jest
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          `https://stagingapi.artsy.net/api/v1/artwork_duplicate_pair/pair-1 - {"type":"param_error","message":"Pair is already open"}`
+        )
+      )
+
+    const mutation = gql`
+      mutation {
+        reopenArtworkDuplicatePair(input: { id: "pair-1" }) {
+          artworkDuplicatePairOrError {
+            __typename
+            ... on ReopenArtworkDuplicatePairFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const result = await runAuthenticatedQuery(mutation, {
+      updateArtworkDuplicatePairLoader,
+    })
+
+    expect(
+      result.reopenArtworkDuplicatePair.artworkDuplicatePairOrError
+    ).toEqual({
+      __typename: "ReopenArtworkDuplicatePairFailure",
+      mutationError: {
+        message: "Pair is already open",
+      },
+    })
+  })
+})

--- a/src/schema/v2/artworkDuplicatePair/artworkDuplicatePair.ts
+++ b/src/schema/v2/artworkDuplicatePair/artworkDuplicatePair.ts
@@ -1,0 +1,21 @@
+import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { ArtworkDuplicatePairType } from "./artworkDuplicatePairType"
+
+export const artworkDuplicatePair: GraphQLFieldConfig<void, ResolverContext> = {
+  type: ArtworkDuplicatePairType,
+  description: "Get a single artwork duplicate pair by ID",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork duplicate pair",
+    },
+  },
+  resolve: async (_root, { id }, { artworkDuplicatePairLoader }) => {
+    if (!artworkDuplicatePairLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return artworkDuplicatePairLoader(id)
+  },
+}

--- a/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairType.ts
+++ b/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairType.ts
@@ -1,0 +1,83 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLFloat,
+  GraphQLBoolean,
+  GraphQLEnumType,
+} from "graphql"
+import { IDFields } from "../object_identification"
+import { ResolverContext } from "types/graphql"
+import { ArtworkType } from "../artwork"
+import { date } from "../fields/date"
+import GraphQLJSON from "graphql-type-json"
+
+export const ArtworkDuplicatePairStatusEnum = new GraphQLEnumType({
+  name: "ArtworkDuplicatePairStatus",
+  values: {
+    OPEN: { value: "open" },
+    DISMISSED: { value: "dismissed" },
+    MERGED: { value: "merged" },
+  },
+})
+
+export const ArtworkDuplicatePairType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworkDuplicatePair",
+  fields: () => ({
+    ...IDFields,
+    artwork1: {
+      type: new GraphQLNonNull(ArtworkType),
+      resolve: ({ artwork_1_id }, _args, { artworkLoader }) => {
+        return artworkLoader(artwork_1_id)
+      },
+    },
+    artwork2: {
+      type: new GraphQLNonNull(ArtworkType),
+      resolve: ({ artwork_2_id }, _args, { artworkLoader }) => {
+        return artworkLoader(artwork_2_id)
+      },
+    },
+    status: {
+      type: new GraphQLNonNull(ArtworkDuplicatePairStatusEnum),
+      resolve: ({ status }) => status,
+    },
+    similarityScore: {
+      type: GraphQLFloat,
+      resolve: ({ similarity_score }) => similarity_score,
+    },
+    detectionVersion: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ detection_version }) => detection_version,
+    },
+    matchMetadata: {
+      type: GraphQLJSON,
+      description:
+        "Metadata from the duplicate detection process, just typed as JSON (for debugging)",
+      resolve: ({ match_metadata }) => match_metadata,
+    },
+    mergeable: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ mergeable }) => mergeable,
+    },
+    dismissedAt: date(),
+    mergedAt: date(),
+    mergedIntoArtwork: {
+      type: ArtworkType,
+      resolve: ({ merged_into_artwork_id }, _args, { artworkLoader }) => {
+        if (!merged_into_artwork_id) return null
+        return artworkLoader(merged_into_artwork_id)
+      },
+    },
+    mergeDetails: {
+      type: GraphQLJSON,
+      description:
+        "Details about the merge operation, just typed as JSON (for debugging)",
+      resolve: ({ merge_details }) => merge_details,
+    },
+    createdAt: date(undefined, true),
+    updatedAt: date(undefined, true),
+  }),
+})

--- a/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairs.ts
+++ b/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairs.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "../fields/pagination"
+import {
+  ArtworkDuplicatePairType,
+  ArtworkDuplicatePairStatusEnum,
+} from "./artworkDuplicatePairType"
+
+const ArtworkDuplicatePairConnection = connectionWithCursorInfo({
+  nodeType: ArtworkDuplicatePairType,
+}).connectionType
+
+export const artworkDuplicatePairsConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: ArtworkDuplicatePairConnection,
+  description: "List artwork duplicate pairs for a partner",
+  args: pageable({
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner",
+    },
+    status: {
+      type: ArtworkDuplicatePairStatusEnum,
+      description: "Filter by pair status",
+    },
+    detectionVersion: {
+      type: GraphQLString,
+      description: "Filter by detection version",
+    },
+    mergeable: {
+      type: GraphQLBoolean,
+      description:
+        "Filter by whether the pair can be merged (neither artwork is both published and listed on Artsy)",
+    },
+  }),
+  resolve: async (_root, args, { artworkDuplicatePairsLoader }) => {
+    if (!artworkDuplicatePairsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs: Record<string, any> = {
+      partner_id: args.partnerId,
+      size,
+      page,
+      total_count: true,
+    }
+
+    if (args.status) {
+      gravityArgs.status = args.status
+    }
+
+    if (args.detectionVersion) {
+      gravityArgs.detection_version = args.detectionVersion
+    }
+
+    if (args.mergeable != null) {
+      gravityArgs.mergeable = args.mergeable
+    }
+
+    const { body, headers } = await artworkDuplicatePairsLoader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}

--- a/src/schema/v2/artworkDuplicatePair/detectArtworkDuplicatesMutation.ts
+++ b/src/schema/v2/artworkDuplicatePair/detectArtworkDuplicatesMutation.ts
@@ -1,0 +1,105 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+const DetectArtworkDuplicatesSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "DetectArtworkDuplicatesSuccess",
+  isTypeOf: (data) => data._type !== "GravityMutationError",
+  fields: () => ({
+    status: {
+      type: GraphQLString,
+      resolve: ({ status }) => status,
+    },
+    partnerId: {
+      type: GraphQLString,
+      resolve: ({ partner_id }) => partner_id,
+    },
+    detectionVersion: {
+      type: GraphQLString,
+      resolve: ({ detection_version }) => detection_version,
+    },
+  }),
+})
+
+const DetectArtworkDuplicatesFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "DetectArtworkDuplicatesFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const DetectArtworkDuplicatesResponseOrErrorType = new GraphQLUnionType({
+  name: "DetectArtworkDuplicatesResponseOrError",
+  types: [
+    DetectArtworkDuplicatesSuccessType,
+    DetectArtworkDuplicatesFailureType,
+  ],
+})
+
+export const detectArtworkDuplicatesMutation = mutationWithClientMutationId({
+  name: "DetectArtworkDuplicatesMutation",
+  description: "Trigger duplicate detection for a partner's artworks",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner",
+    },
+    detectionVersion: {
+      type: GraphQLString,
+      description: "Optional detection version to use",
+    },
+  },
+  outputFields: {
+    detectArtworkDuplicatesResponseOrError: {
+      type: DetectArtworkDuplicatesResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, detectionVersion },
+    { detectArtworkDuplicatesLoader }
+  ) => {
+    if (!detectArtworkDuplicatesLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const gravityArgs: Record<string, any> = {
+        partner_id: partnerId,
+      }
+
+      if (detectionVersion) {
+        gravityArgs.detection_version = detectionVersion
+      }
+
+      const result = await detectArtworkDuplicatesLoader(gravityArgs)
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  },
+})

--- a/src/schema/v2/artworkDuplicatePair/dismissArtworkDuplicatePairMutation.ts
+++ b/src/schema/v2/artworkDuplicatePair/dismissArtworkDuplicatePairMutation.ts
@@ -1,0 +1,90 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ArtworkDuplicatePairType } from "./artworkDuplicatePairType"
+
+const DismissArtworkDuplicatePairSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "DismissArtworkDuplicatePairSuccess",
+  isTypeOf: (data) => data._type !== "GravityMutationError",
+  fields: () => ({
+    artworkDuplicatePair: {
+      type: ArtworkDuplicatePairType,
+      resolve: (pair) => pair,
+    },
+  }),
+})
+
+const DismissArtworkDuplicatePairFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "DismissArtworkDuplicatePairFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const DismissArtworkDuplicatePairResponseOrErrorType = new GraphQLUnionType({
+  name: "DismissArtworkDuplicatePairResponseOrError",
+  types: [
+    DismissArtworkDuplicatePairSuccessType,
+    DismissArtworkDuplicatePairFailureType,
+  ],
+})
+
+export const dismissArtworkDuplicatePairMutation = mutationWithClientMutationId(
+  {
+    name: "DismissArtworkDuplicatePairMutation",
+    description: "Dismiss an artwork duplicate pair",
+    inputFields: {
+      id: {
+        type: new GraphQLNonNull(GraphQLString),
+        description: "The ID of the artwork duplicate pair",
+      },
+    },
+    outputFields: {
+      artworkDuplicatePairOrError: {
+        type: DismissArtworkDuplicatePairResponseOrErrorType,
+        resolve: (result) => result,
+      },
+    },
+    mutateAndGetPayload: async (
+      { id },
+      { updateArtworkDuplicatePairLoader }
+    ) => {
+      if (!updateArtworkDuplicatePairLoader) {
+        throw new Error("You need to be signed in to perform this action")
+      }
+
+      try {
+        const result = await updateArtworkDuplicatePairLoader(id, {
+          status: "dismissed",
+        })
+        return result
+      } catch (error) {
+        const formattedErr = formatGravityError(error)
+        if (formattedErr) {
+          return { ...formattedErr, _type: "GravityMutationError" }
+        } else {
+          throw error instanceof Error ? error : new Error(String(error))
+        }
+      }
+    },
+  }
+)

--- a/src/schema/v2/artworkDuplicatePair/mergeArtworkDuplicatePairMutation.ts
+++ b/src/schema/v2/artworkDuplicatePair/mergeArtworkDuplicatePairMutation.ts
@@ -1,0 +1,124 @@
+import {
+  GraphQLInputObjectType,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { snakeCaseKeys } from "lib/helpers"
+import { ResolverContext } from "types/graphql"
+import { ArtworkDuplicatePairType } from "./artworkDuplicatePairType"
+
+const ArtworkDuplicateMergeFieldOverridesInput = new GraphQLInputObjectType({
+  name: "ArtworkDuplicateMergeFieldOverridesInput",
+  fields: {
+    title: { type: GraphQLString },
+    date: { type: GraphQLString },
+    width: { type: GraphQLString },
+    height: { type: GraphQLString },
+    depth: { type: GraphQLString },
+    diameter: { type: GraphQLString },
+    metric: { type: GraphQLString },
+    medium: { type: GraphQLString },
+    availability: { type: GraphQLString },
+    priceMinor: { type: GraphQLInt },
+    priceCurrency: { type: GraphQLString },
+    privateNotes: { type: GraphQLString },
+  },
+})
+
+const MergeArtworkDuplicatePairSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "MergeArtworkDuplicatePairSuccess",
+  isTypeOf: (data) => data._type !== "GravityMutationError",
+  fields: () => ({
+    artworkDuplicatePair: {
+      type: ArtworkDuplicatePairType,
+      resolve: (pair) => pair,
+    },
+  }),
+})
+
+const MergeArtworkDuplicatePairFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "MergeArtworkDuplicatePairFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const MergeArtworkDuplicatePairResponseOrErrorType = new GraphQLUnionType({
+  name: "MergeArtworkDuplicatePairResponseOrError",
+  types: [
+    MergeArtworkDuplicatePairSuccessType,
+    MergeArtworkDuplicatePairFailureType,
+  ],
+})
+
+export const mergeArtworkDuplicatePairMutation = mutationWithClientMutationId({
+  name: "MergeArtworkDuplicatePairMutation",
+  description: "Merge an artwork duplicate pair",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork duplicate pair",
+    },
+    primaryArtworkId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork to keep as primary",
+    },
+    fieldOverrides: {
+      type: ArtworkDuplicateMergeFieldOverridesInput,
+      description: "Optional field-level overrides for the merge",
+    },
+  },
+  outputFields: {
+    artworkDuplicatePairOrError: {
+      type: MergeArtworkDuplicatePairResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { id, primaryArtworkId, fieldOverrides },
+    { updateArtworkDuplicatePairLoader }
+  ) => {
+    if (!updateArtworkDuplicatePairLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const gravityArgs: Record<string, any> = {
+        status: "merged",
+        primary_artwork_id: primaryArtworkId,
+      }
+
+      if (fieldOverrides) {
+        gravityArgs.field_overrides = snakeCaseKeys(fieldOverrides)
+      }
+
+      const result = await updateArtworkDuplicatePairLoader(id, gravityArgs)
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  },
+})

--- a/src/schema/v2/artworkDuplicatePair/reopenArtworkDuplicatePairMutation.ts
+++ b/src/schema/v2/artworkDuplicatePair/reopenArtworkDuplicatePairMutation.ts
@@ -1,0 +1,85 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ArtworkDuplicatePairType } from "./artworkDuplicatePairType"
+
+const ReopenArtworkDuplicatePairSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ReopenArtworkDuplicatePairSuccess",
+  isTypeOf: (data) => data._type !== "GravityMutationError",
+  fields: () => ({
+    artworkDuplicatePair: {
+      type: ArtworkDuplicatePairType,
+      resolve: (pair) => pair,
+    },
+  }),
+})
+
+const ReopenArtworkDuplicatePairFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ReopenArtworkDuplicatePairFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ReopenArtworkDuplicatePairResponseOrErrorType = new GraphQLUnionType({
+  name: "ReopenArtworkDuplicatePairResponseOrError",
+  types: [
+    ReopenArtworkDuplicatePairSuccessType,
+    ReopenArtworkDuplicatePairFailureType,
+  ],
+})
+
+export const reopenArtworkDuplicatePairMutation = mutationWithClientMutationId({
+  name: "ReopenArtworkDuplicatePairMutation",
+  description: "Reopen a dismissed artwork duplicate pair",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork duplicate pair",
+    },
+  },
+  outputFields: {
+    artworkDuplicatePairOrError: {
+      type: ReopenArtworkDuplicatePairResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { updateArtworkDuplicatePairLoader }) => {
+    if (!updateArtworkDuplicatePairLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const result = await updateArtworkDuplicatePairLoader(id, {
+        status: "open",
+      })
+      return result
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -265,6 +265,12 @@ import deleteConversationMessageTemplateMutation from "./conversationMessageTemp
 import { discoveryCategoriesConnection } from "./discoveryCategoriesConnection"
 import { discoveryCategoryConnection } from "./discoveryCategoryConnection"
 import { discoveryCategoryArtworksConnection } from "./discoveryCategoryArtworksConnection"
+import { artworkDuplicatePair } from "./artworkDuplicatePair/artworkDuplicatePair"
+import { artworkDuplicatePairsConnection } from "./artworkDuplicatePair/artworkDuplicatePairs"
+import { detectArtworkDuplicatesMutation } from "./artworkDuplicatePair/detectArtworkDuplicatesMutation"
+import { dismissArtworkDuplicatePairMutation } from "./artworkDuplicatePair/dismissArtworkDuplicatePairMutation"
+import { reopenArtworkDuplicatePairMutation } from "./artworkDuplicatePair/reopenArtworkDuplicatePairMutation"
+import { mergeArtworkDuplicatePairMutation } from "./artworkDuplicatePair/mergeArtworkDuplicatePairMutation"
 import { ArtworkResult } from "./artworkResult"
 import { updateMeCollectionsMutation } from "./me/updateCollectionsMutation"
 import { CreateSaleAgreementMutation } from "./SaleAgreements/createSaleAgreementMutation"
@@ -451,6 +457,8 @@ const rootFields = {
   artistSeriesConnection: ArtistSeriesConnection,
   artwork: Artwork,
   artworkAttributionClasses: ArtworkAttributionClasses,
+  artworkDuplicatePair,
+  artworkDuplicatePairsConnection,
   artworkMediums: ArtworkMediums,
   artworkImport: ArtworkImport,
   artworkResult: ArtworkResult,
@@ -684,6 +692,8 @@ export default new GraphQLSchema({
       deleteArtworkImport: DeleteArtworkImportMutation,
       deleteArtworkTemplate: deleteArtworkTemplateMutation,
       deleteConversationMessageTemplate: deleteConversationMessageTemplateMutation,
+      detectArtworkDuplicates: detectArtworkDuplicatesMutation,
+      dismissArtworkDuplicatePair: dismissArtworkDuplicatePairMutation,
       deleteArtworkImage: DeleteArtworkImageMutation,
       reprocessArtworkImage: ReprocessArtworkImageMutation,
       deleteBankAccount: deleteBankAccountMutation,
@@ -736,12 +746,14 @@ export default new GraphQLSchema({
       markNotificationAsRead: markNotificationAsReadMutation,
       markNotificationsAsSeen: markNotificationsAsSeenMutation,
       mergeArtists: mergeArtistsMutation,
+      mergeArtworkDuplicatePair: mergeArtworkDuplicatePairMutation,
       moveArtworksBetweenPartnerLists: moveArtworksBetweenPartnerListsMutation,
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
       publishNavigationDraft: publishNavigationDraftMutation,
       publishViewingRoom: publishViewingRoomMutation,
+      reopenArtworkDuplicatePair: reopenArtworkDuplicatePairMutation,
       removeArtworkFromPartnerList: removeArtworkFromPartnerListMutation,
       removeArtworkFromPartnerShow: removeArtworkFromPartnerShowMutation,
       removeInstallShotFromPartnerShow: removeInstallShotFromPartnerShowMutation,


### PR DESCRIPTION
Fairly boilerplate - adds the type + root fields (used in the UX - list of dupes, detail view for a dupe - mutations to kick off dupe detection, as well as dismissing or merging). Dupes 'r us!