### PR TITLE
chore: move duplicate pairs connection under partner

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3435,8 +3435,8 @@ input ArtworkDuplicateMergeFieldOverridesInput {
 }
 
 type ArtworkDuplicatePair {
-  artwork1: Artwork!
-  artwork2: Artwork!
+  artwork1: Artwork
+  artwork2: Artwork
   createdAt(
     format: String
 
@@ -20712,6 +20712,23 @@ type Partner implements Node {
     size: Int
     sort: ArtistAlertsSort
   ): ArtistsWithAlertCountsConnection
+
+  # Artwork duplicate pairs for this partner
+  artworkDuplicatePairsConnection(
+    after: String
+    before: String
+
+    # Filter by detection version
+    detectionVersion: String
+    first: Int
+    last: Int
+
+    # Filter by whether the pair can be merged (neither artwork is both published and listed on Artsy)
+    mergeable: Boolean
+
+    # Filter by pair status
+    status: ArtworkDuplicatePairStatus
+  ): ArtworkDuplicatePairConnection
 
   # A connection of artwork imports from a Partner.
   artworkImportsConnection(

--- a/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairType.ts
+++ b/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairType.ts
@@ -29,13 +29,13 @@ export const ArtworkDuplicatePairType = new GraphQLObjectType<
   fields: () => ({
     ...IDFields,
     artwork1: {
-      type: new GraphQLNonNull(ArtworkType),
+      type: ArtworkType,
       resolve: ({ artwork_1_id }, _args, { artworkLoader }) => {
         return artworkLoader(artwork_1_id)
       },
     },
     artwork2: {
-      type: new GraphQLNonNull(ArtworkType),
+      type: ArtworkType,
       resolve: ({ artwork_2_id }, _args, { artworkLoader }) => {
         return artworkLoader(artwork_2_id)
       },

--- a/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairs.ts
+++ b/src/schema/v2/artworkDuplicatePair/artworkDuplicatePairs.ts
@@ -85,3 +85,65 @@ export const artworkDuplicatePairsConnection: GraphQLFieldConfig<
     })
   },
 }
+
+export const ArtworkDuplicatePairsConnection: GraphQLFieldConfig<
+  any,
+  ResolverContext
+> = {
+  type: ArtworkDuplicatePairConnection,
+  description: "Artwork duplicate pairs for this partner",
+  args: pageable({
+    status: {
+      type: ArtworkDuplicatePairStatusEnum,
+      description: "Filter by pair status",
+    },
+    detectionVersion: {
+      type: GraphQLString,
+      description: "Filter by detection version",
+    },
+    mergeable: {
+      type: GraphQLBoolean,
+      description:
+        "Filter by whether the pair can be merged (neither artwork is both published and listed on Artsy)",
+    },
+  }),
+  resolve: async ({ id }, args, { artworkDuplicatePairsLoader }) => {
+    if (!artworkDuplicatePairsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const gravityArgs: Record<string, any> = {
+      partner_id: id,
+      size,
+      page,
+      total_count: true,
+    }
+
+    if (args.status) {
+      gravityArgs.status = args.status
+    }
+
+    if (args.detectionVersion) {
+      gravityArgs.detection_version = args.detectionVersion
+    }
+
+    if (args.mergeable != null) {
+      gravityArgs.mergeable = args.mergeable
+    }
+
+    const { body, headers } = await artworkDuplicatePairsLoader(gravityArgs)
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -74,6 +74,7 @@ import {
   EXAMPLE_TEMPLATES,
 } from "schema/v2/conversationMessageTemplate/conversationMessageTemplateExample"
 import { ArtworkTemplatesConnection } from "schema/v2/artworkTemplate/artworkTemplatesConnection"
+import { ArtworkDuplicatePairsConnection } from "schema/v2/artworkDuplicatePair/artworkDuplicatePairs"
 import { BrandKitType } from "./brandKit"
 import { bulkUpdateMetadataPreview } from "./BulkOperation/bulkUpdateMetadataPreview"
 
@@ -857,6 +858,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           })
         },
       },
+      artworkDuplicatePairsConnection: ArtworkDuplicatePairsConnection,
       conversationMessageTemplatesConnection: ConversationMessageTemplatesConnection,
       artworkTemplatesConnection: ArtworkTemplatesConnection,
       conversationMessageTemplateExamples: {


### PR DESCRIPTION
Adds the connection for duplicate pairs to be under `partner`, and also makes the artworks nullable, as when a pair has already been merged (or in general an artwork was deleted/cleaned up) - that would no longer resolve.