### PR TITLE
chore: deprecate emailFrequency

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17544,7 +17544,7 @@ type Me implements Node {
     )
 
   # Frequency of marketing emails.
-  emailFrequency: String
+  emailFrequency: String @deprecated(reason: "This field is no longer used.")
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
   hasPassword: Boolean!
@@ -27969,7 +27969,7 @@ input UpdateMyProfileInput {
   email: String
 
   # Frequency of marketing emails.
-  emailFrequency: String
+  emailFrequency: String @deprecated(reason: "This field is no longer used.")
 
   # Gender.
   gender: String

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -344,6 +344,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     },
     emailFrequency: {
       description: "Frequency of marketing emails.",
+      deprecationReason: "This field is no longer used.",
       resolve: ({ email_frequency }) => email_frequency,
       type: GraphQLString,
     },

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -131,6 +131,7 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
     email: { description: "The given email of the user.", type: GraphQLString },
     emailFrequency: {
       description: "Frequency of marketing emails.",
+      deprecationReason: "This field is no longer used.",
       type: GraphQLString,
     },
     gender: { type: GraphQLString, description: "Gender." },


### PR DESCRIPTION
- This PR adds a `@deprecated` annotation to the `emailFrequency` field and input field in the Metaphysics schema because it is [no longer being used](https://github.com/search?q=org%3Aartsy+emailfrequency&type=code) by clients or our Braze integration.
- This is an artifact from our "frequency-based" Braze implementation of yesteryear that was not removed after we migrated to the "interest-based" Braze implementation.
- This is the first (overly cautious) step of two to remove this field from the schema.

cc: @artsy/diamond-devs 