### PR TITLE
chore: delete emailFrequency

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17542,9 +17542,6 @@ type Me implements Node {
     @deprecated(
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
-
-  # Frequency of marketing emails.
-  emailFrequency: String @deprecated(reason: "This field is no longer used.")
   followsAndSaves: FollowsAndSaves
   hasCreditCards: Boolean
   hasPassword: Boolean!
@@ -27967,9 +27964,6 @@ input UpdateMyProfileInput {
 
   # The given email of the user.
   email: String
-
-  # Frequency of marketing emails.
-  emailFrequency: String @deprecated(reason: "This field is no longer used.")
 
   # Gender.
   gender: String

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -342,12 +342,6 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
     email: {
       type: GraphQLString,
     },
-    emailFrequency: {
-      description: "Frequency of marketing emails.",
-      deprecationReason: "This field is no longer used.",
-      resolve: ({ email_frequency }) => email_frequency,
-      type: GraphQLString,
-    },
     canRequestEmailConfirmation: {
       type: new GraphQLNonNull(GraphQLBoolean),
       description: "Whether user is allowed to request email confirmation",

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -129,11 +129,6 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
       type: CurrencyPreference,
     },
     email: { description: "The given email of the user.", type: GraphQLString },
-    emailFrequency: {
-      description: "Frequency of marketing emails.",
-      deprecationReason: "This field is no longer used.",
-      type: GraphQLString,
-    },
     gender: { type: GraphQLString, description: "Gender." },
     industry: {
       type: GraphQLString,


### PR DESCRIPTION
This PR deletes the `emailFrequency` field that was marked as deprecated in #7637.

- [Code search](https://github.com/search?q=org%3Aartsy%20emailFrequency&type=code) shows that this is not being used by any clients.
- It was [removed from Eigen ](https://github.com/artsy/eigen/pull/6542)back in 2022, so it is safe to assume that no active user is on a version of the app that is expecting this field to exist.

cc: @artsy/diamond-devs 