### PR TITLE
feat: expose shipping quote id in fulfillment options

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14834,6 +14834,7 @@ type FulfillmentDetails {
 type FulfillmentOption {
   amount: Money
   selected: Boolean
+  shippingQuoteId: String
   type: FulfillmentOptionTypeEnum!
 }
 

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -2376,5 +2376,47 @@ describe("Me", () => {
         expect(result.me.order.fulfillmentOptions).toEqual([])
       })
     })
+
+    describe("fulfillmentOptions shippingQuoteId", () => {
+      const shippingQuoteIdQuery = gql`
+        query {
+          me {
+            order(id: "order-id") {
+              fulfillmentOptions {
+                type
+                shippingQuoteId
+              }
+            }
+          }
+        }
+      `
+
+      it("exposes shippingQuoteId when present", async () => {
+        orderJson.fulfillment_options = [
+          {
+            type: "domestic_flat",
+            amount_minor: 2000,
+            selected: true,
+            shipping_quote_id: "quote-abc-123",
+          },
+          { type: "pickup", amount_minor: 0 },
+        ]
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+        }
+
+        const result = await runAuthenticatedQuery(
+          shippingQuoteIdQuery,
+          context
+        )
+
+        expect(result.me.order.fulfillmentOptions).toEqual([
+          { type: "DOMESTIC_FLAT", shippingQuoteId: "quote-abc-123" },
+          { type: "PICKUP", shippingQuoteId: null },
+        ])
+      })
+    })
   })
 })

--- a/src/schema/v2/order/__tests__/setOrderFulfillmentOptionMutation.test.ts
+++ b/src/schema/v2/order/__tests__/setOrderFulfillmentOptionMutation.test.ts
@@ -20,6 +20,7 @@ const mockMutation = (type: string) => `
                 currencyCode
               }
               selected
+              shippingQuoteId
             }
           }
         }
@@ -47,6 +48,7 @@ describe("setOrderFulfillmentOption", () => {
             amount_minor: 2000,
             currency_code: "USD",
             selected: true,
+            shipping_quote_id: "quote-abc-123",
           },
           {
             type: "pickup",
@@ -84,11 +86,13 @@ describe("setOrderFulfillmentOption", () => {
                   currencyCode: "USD",
                 },
                 selected: true,
+                shippingQuoteId: "quote-abc-123",
               },
               {
                 type: "PICKUP",
                 amount: null,
                 selected: null,
+                shippingQuoteId: null,
               },
             ],
           },
@@ -183,6 +187,7 @@ describe("setOrderFulfillmentOption", () => {
                 type: "SHIPPING_TBD",
                 amount: null,
                 selected: null,
+                shippingQuoteId: null,
               },
             ],
           },

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -278,6 +278,10 @@ export const FulfillmentOptionType = new GraphQLObjectType<
       },
     },
     selected: { type: GraphQLBoolean },
+    shippingQuoteId: {
+      type: GraphQLString,
+      resolve: ({ shipping_quote_id }) => shipping_quote_id ?? null,
+    },
   },
 })
 


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-3192

Exchange exposes [shipping quote id](https://github.com/artsy/exchange/blob/e327c38257233d9b691d95f80d36dc83f9ce94e5/app/services/fulfillment_option_service.rb#L357C9-L357C26) in fulfillment options. This exposes it in Metaphysics accordingly.

Note that the exposed shipping quote id will only be used for client-side tracking purposes. The client only passes a type (e.g. `artsy_standard`, `artsy_white_glove`) — not a shipping_quote_id. The server resolves which specific quote to use.