### PR TITLE
chore: add canary deployment workflow and docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2.1
 
+# Set `canary_build: true` when triggering a pipeline to build a canary image
+# from any branch without touching the moving :staging / :production tags.
+# Trigger via the CircleCI API:
+#   curl -X POST -u <CIRCLE_TOKEN>: \
+#     -H 'Content-Type: application/json' \
+#     -d '{"branch":"<your-branch>","parameters":{"canary_build":true}}' \
+#     https://circleci.com/api/v2/project/gh/artsy/metaphysics/pipeline
+parameters:
+  canary_build:
+    type: boolean
+    default: false
+
 orbs:
   hokusai: artsy/hokusai@volatile
   horizon: artsy/release@volatile
@@ -123,9 +135,55 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn-berry
       - run: yarn deploy-cloudflare-workers
+  canary-image-push:
+    # Builds the canary image from the current commit and pushes it to ECR
+    # tagged with the commit SHA only. Verifies that the moving :staging tag
+    # is not overwritten — if it is, the job fails loudly so the operator can
+    # roll the tag back before any pod restart pulls the new image.
+    executor:
+      name: node/default
+      tag: "22.5"
+    steps:
+      - checkout
+      - setup_hokusai
+      - run:
+          name: Build & push canary image (SHA tag only)
+          command: |
+            set -euo pipefail
+            SHA=$(git rev-parse HEAD)
+            echo "==> canary build for $SHA"
+
+            BEFORE=$(aws ecr describe-images --repository-name metaphysics --region us-east-1 \
+              --image-ids imageTag=staging \
+              --query 'imageDetails[0].imageDigest' --output text)
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "None" ]; then
+              echo "could not resolve :staging digest" >&2
+              exit 1
+            fi
+            echo "    :staging currently points at $BEFORE"
+
+            # Flag name varies by hokusai version. Try both.
+            if ! hokusai registry push --tag "$SHA" --skip-latest 2>/dev/null; then
+              hokusai registry push --tag "$SHA" --no-update-latest
+            fi
+
+            AFTER=$(aws ecr describe-images --repository-name metaphysics --region us-east-1 \
+              --image-ids imageTag=staging \
+              --query 'imageDetails[0].imageDigest' --output text)
+            if [ "$AFTER" != "$BEFORE" ]; then
+              echo "FATAL: :staging digest moved during canary push" >&2
+              echo "  before: $BEFORE" >&2
+              echo "  after:  $AFTER" >&2
+              echo "Roll the :staging tag back to $BEFORE before any pod restart." >&2
+              exit 1
+            fi
+            echo "    :staging unchanged ✓"
+            echo "canary image ready: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:$SHA"
 
 workflows:
   default:
+    when:
+      not: << pipeline.parameters.canary_build >>
     jobs:
       - test:
           <<: *not_staging_or_release
@@ -179,3 +237,18 @@ workflows:
           context: cloudflare
           requires:
             - hokusai/deploy-production
+
+  canary:
+    # Triggered by setting the canary_build pipeline parameter. Runs on any
+    # branch (no branch filter) so feature branches can build a SHA-tagged
+    # image without merging to main. Does NOT deploy — operator wires the
+    # SHA into hokusai/<env>.yml in a separate canary YAML PR.
+    when: << pipeline.parameters.canary_build >>
+    jobs:
+      - test
+      - type-check
+      - canary-image-push:
+          context: hokusai
+          requires:
+            - test
+            - type-check

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ If any of these queries fail, it's probable that you misconfigured your
 - [Adding a GraphQL micro-service to Metaphysics](docs/adding_a_new_graphql_microservice.md)
 - [Adding a rest micro-service to Metaphysics](docs/adding_a_new_rest_microservice.md)
 - [Debugging with VS Code](docs/debugging_with_vscode.md)
+- [Canary deployments](docs/canary-deployments.md)
 - [GraphQL Schema Design][]
 
 [graphql schema design]: https://github.com/artsy/README/blob/main/playbooks/graphql-schema-design.md

--- a/docs/canary-deployments.md
+++ b/docs/canary-deployments.md
@@ -1,0 +1,123 @@
+# Canary deployment
+
+A canary is a second Kubernetes Deployment running a different image alongside
+the canonical `metaphysics-web` Deployment. Both are selected by the same
+Service, so traffic is split round-robin in proportion to the replica count.
+Use it to observe a risky change against real traffic before rolling it out
+everywhere.
+
+The canonical Artsy procedure lives in
+[`artsy/README/playbooks/hokusai.md`](https://github.com/artsy/README/blob/master/playbooks/hokusai.md#creating-a-canary-deployment).
+This page is a metaphysics-specific summary.
+
+## When to use a canary
+
+- A baseline change you can't easily feature-flag (Yoga upgrades, large
+  stitching refactors, dependency bumps that touch every request).
+- A change you want to compare against canonical in Datadog / Sentry (error
+  rate, p99, memory) before exposing 100% of traffic to it.
+
+## Prerequisites
+
+- `hokusai`, `kubectl`, and `aws ecr` configured for the cluster you're targeting.
+- The canary branch pushed. Note the commit SHA — that's the image tag you'll
+  use everywhere below (`...metaphysics:<sha>`).
+
+## 1. Build & push the canary image
+
+Push only the immutable SHA tag. Never overwrite the moving `:staging` /
+`:production` tags — canonical deployments pull them and `imagePullPolicy: Always`, so updating them silently rolls your change to 100% of that env on
+the next pod restart.
+
+### Option A (recommended) — trigger the `canary` workflow in CircleCI
+
+The `canary` workflow runs `test`, `type-check`, then `canary-image-push`
+(captures `:staging`'s digest, pushes with `--skip-latest`, fails loudly if
+the moving tag is altered).
+
+```sh
+curl -X POST -u "$CIRCLE_TOKEN:" \
+  -H 'Content-Type: application/json' \
+  -d '{"branch":"<your-branch>","parameters":{"canary_build":true}}' \
+  https://circleci.com/api/v2/project/gh/artsy/metaphysics/pipeline
+```
+
+### Option B — locally with `scripts/canary-image.sh`
+
+```sh
+./scripts/canary-image.sh <sha>            # staging (default)
+./scripts/canary-image.sh <sha> production
+```
+
+Same digest-capture + verify behavior as the CI job.
+
+## 2. Add the canary Deployment to the Hokusai spec
+
+Open this as a **separate PR from the change you're canarying**, branched off
+`main`. Don't merge the change PR until rollout is done — that would deploy to
+100% of canonical staging via `hokusai/deploy-staging` and make the canary
+pointless.
+
+Edit `hokusai/staging.yml` (or `hokusai/production.yml`). Copy the existing
+`metaphysics-web` Deployment block and tweak:
+
+- Append `-canary` to every `name` / label value that contains the deployment
+  name. **Keep** the `app: metaphysics` Service selector so traffic splits.
+- `spec.replicas: 1` — roughly `1 / (1 + N)` traffic share. No separate HPA.
+- `container.image` → the **SHA-tagged** image. Never `:staging` /
+  `:production`.
+- Prepend Datadog overrides under `container.env`:
+  ```yaml
+  - name: DD_TRACER_SERVICE_NAME
+    value: metaphysics-canary
+  - name: DD_VERSION
+    value: <sha>
+  ```
+
+Example diff: [artsy/metaphysics#1619](https://github.com/artsy/metaphysics/pull/1619/files).
+
+## 3. Apply
+
+```sh
+hokusai staging update     # or: hokusai production update
+```
+
+## 4. Monitor
+
+- **Datadog:** filter `service:metaphysics-canary` vs `service:metaphysics`.
+  Compare error rate, p50/p95/p99 latency, memory.
+- **Sentry:** filter `release:<sha>` for new signatures.
+- **Logs:** `kubectl --context [staging|production] logs -l app.kubernetes.io/version=canary -f`.
+
+## 5. Roll forward or back
+
+**Roll back:** revert the canary YAML PR, then
+`kubectl --context [staging|production] delete deployment metaphysics-web-canary`
+(`hokusai update` does not garbage-collect). Fix the branch, rebuild image
+(step 1), repeat from step 2.
+
+**Roll forward:** merge the change PR (canonical staging deploys on merge to
+`main`; production on the next release tag). Then open a cleanup PR removing
+both canary blocks and run `kubectl delete deployment metaphysics-web-canary`
+in both contexts.
+
+## Suggested order
+
+1. Build & push image (step 1).
+2. Staging canary YAML PR → soak ~24h.
+3. Production canary YAML PR → soak ~24h.
+4. Merge the change PR.
+5. Cleanup PR + `kubectl delete` in both envs.
+
+The image build, canary YAML, change PR, and cleanup are **separate workflows**
+— bundling defeats the canary.
+
+## Caveats
+
+- **The canary serves real traffic.** Mutations and external API calls run
+  for the share of users that hits it.
+- **Schema-changing canaries are risky.** Persistent caches (CDN, Force's
+  query-id cache) don't distinguish canary vs canonical responses; expect
+  cache poisoning if the schema shape differs.
+- **Don't relax the `only_main` filter on the default `hokusai/push` job** —
+  that path updates `:staging`. Use the `canary` workflow instead.

--- a/scripts/canary-image.sh
+++ b/scripts/canary-image.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Build & push a canary image for a given commit SHA, with a hard guarantee
+# that the moving :staging / :production tags are not touched.
+#
+# Usage:
+#   ./scripts/canary-image.sh <sha> [env]
+#
+# Where:
+#   <sha>  is the commit SHA to tag the image with (full or short)
+#   [env]  is staging (default) or production. Determines which moving tag
+#          we verify hasn't been overwritten.
+#
+# Behavior:
+#   1. Captures the current digest of :<env>
+#   2. Logs into ECR
+#   3. Pushes the image with the SHA tag and --skip-latest
+#   4. Re-captures the digest of :<env> and aborts with non-zero exit if
+#      anything moved.
+
+set -euo pipefail
+
+SHA="${1:-}"
+ENV="${2:-staging}"
+REPO="metaphysics"
+REGION="us-east-1"
+
+if [[ -z "$SHA" ]]; then
+  echo "usage: $0 <sha> [env]" >&2
+  exit 2
+fi
+
+if [[ "$ENV" != "staging" && "$ENV" != "production" ]]; then
+  echo "env must be 'staging' or 'production' (got: $ENV)" >&2
+  exit 2
+fi
+
+echo "==> capturing current :$ENV digest"
+BEFORE=$(aws ecr describe-images \
+  --repository-name "$REPO" --region "$REGION" \
+  --image-ids "imageTag=$ENV" \
+  --query 'imageDetails[0].imageDigest' \
+  --output text 2>/dev/null || true)
+
+if [[ -z "$BEFORE" || "$BEFORE" == "None" ]]; then
+  echo "could not resolve :$ENV digest — check aws creds / region / repo" >&2
+  exit 1
+fi
+echo "    :$ENV currently points at $BEFORE"
+
+echo "==> hokusai registry login"
+hokusai registry login
+
+echo "==> pushing $REPO:$SHA (skip-latest)"
+# Flag name varies by hokusai version. Try --skip-latest first; fall back if
+# the flag is rejected.
+if ! hokusai registry push --tag "$SHA" --skip-latest 2>/dev/null; then
+  echo "    --skip-latest not accepted; trying --no-update-latest"
+  hokusai registry push --tag "$SHA" --no-update-latest
+fi
+
+echo "==> verifying :$ENV digest unchanged"
+AFTER=$(aws ecr describe-images \
+  --repository-name "$REPO" --region "$REGION" \
+  --image-ids "imageTag=$ENV" \
+  --query 'imageDetails[0].imageDigest' \
+  --output text 2>/dev/null || true)
+
+if [[ "$AFTER" != "$BEFORE" ]]; then
+  echo "" >&2
+  echo "FATAL: :$ENV moved during push." >&2
+  echo "  before: $BEFORE" >&2
+  echo "  after:  $AFTER" >&2
+  echo "" >&2
+  echo "Roll the moving tag back to $BEFORE *before* any pod restart pulls" >&2
+  echo "the new image, e.g.:" >&2
+  echo "  MANIFEST=\$(aws ecr batch-get-image --repository-name $REPO \\" >&2
+  echo "    --image-ids imageDigest=$BEFORE --region $REGION \\" >&2
+  echo "    --query 'images[0].imageManifest' --output text)" >&2
+  echo "  aws ecr put-image --repository-name $REPO --region $REGION \\" >&2
+  echo "    --image-tag $ENV --image-manifest \"\$MANIFEST\"" >&2
+  exit 1
+fi
+
+echo "    :$ENV unchanged ✓"
+echo ""
+echo "ready: 585031190124.dkr.ecr.us-east-1.amazonaws.com/$REPO:$SHA"


### PR DESCRIPTION
Setting up a canary for the Yoga PR (#7619) surfaced a few rough edges worth fixing in the repo itself rather than leaving as folklore:

- No way to build a SHA-tagged image from a feature branch. The default `hokusai/push` is gated to `main`, and it pushes both the SHA tag and the moving `:staging` tag. Since staging pulls `:staging` with `imagePullPolicy: Always`, letting it run from a non-main branch would silently roll that branch's image to 100% of staging on the next pod restart.
- No playbook for any of this — every canary in the past has been someone reverse-engineering it from `artsy/README/playbooks/hokusai.md` and a stale Slack thread.

Adds:

- A `canary` workflow in CircleCI, gated on a `canary_build` pipeline parameter. Runs from any branch, pushes the SHA tag only (`--skip-latest`), and verifies `:staging`'s digest is unchanged before/after — fails loudly if anything moved. Trigger via the CircleCI API (curl example in the docs).
- `scripts/canary-image.sh` for the same flow from a laptop, with the same digest-capture + verify behavior.
- `docs/canary-deployments.md`, linked from the README. Walks through image build → canary YAML PR → soak → rollforward / rollback, and explicitly calls out the moving-tag trap.

The default workflow is gated on `not canary_build`, so normal PRs and merges to `main` are unaffected.