### PR TITLE
chore: Allow html content to be passed on Mailchimp campaigns creation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10860,9 +10860,12 @@ type CreateMailchimpCampaignFailure {
 }
 
 input CreateMailchimpCampaignInput {
-  # Artwork IDs to include in the campaign (mutually exclusive with partnerShowId)
+  # Artwork IDs to associate with the campaign (mutually exclusive with partnerShowId; used to render content unless htmlContent is provided)
   artworkIds: [String!]
   clientMutationId: String
+
+  # Pre-rendered HTML body for the campaign. When provided, supersedes the formatter's output but does not preclude tracking via artworkIds or partnerShowId
+  htmlContent: String
 
   # The Mailchimp list/audience ID to send the campaign to
   listId: String!
@@ -10870,7 +10873,7 @@ input CreateMailchimpCampaignInput {
   # The internal ID of the Mailchimp account to use
   mailchimpAccountId: String!
 
-  # Partner show ID to create campaign from (mutually exclusive with artworkIds)
+  # Partner show ID to associate with the campaign (mutually exclusive with artworkIds; used to render content unless htmlContent is provided)
   partnerShowId: String
 
   # The email preview text

--- a/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
+++ b/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
@@ -61,6 +61,7 @@ describe("createMailchimpCampaign", () => {
         list_id: "list-1",
         artwork_ids: ["artwork-1", "artwork-2"],
         partner_show_id: undefined,
+        html_content: undefined,
         preview_text: undefined,
       })
     })
@@ -125,6 +126,90 @@ describe("createMailchimpCampaign", () => {
         list_id: "list-1",
         artwork_ids: undefined,
         partner_show_id: "show-1",
+        html_content: undefined,
+        preview_text: undefined,
+      })
+    })
+  })
+
+  describe("with htmlContent", () => {
+    const mutationWithHtml = `
+      mutation {
+        createMailchimpCampaign(input: {
+          mailchimpAccountId: "mc-account-1"
+          subjectLine: "Custom Campaign"
+          listId: "list-1"
+          htmlContent: "<html><body>Partner-authored content</body></html>"
+        }) {
+          mailchimpCampaignOrError {
+            __typename
+            ... on CreateMailchimpCampaignSuccess {
+              mailchimpCampaign {
+                internalID
+                subjectLine
+                status
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("passes correct args to Gravity", async () => {
+      const context: Partial<ResolverContext> = {
+        createMailchimpCampaignLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+
+      await runAuthenticatedQuery(mutationWithHtml, context)
+
+      expect(
+        context.createMailchimpCampaignLoader as jest.Mock
+      ).toHaveBeenCalledWith({
+        mailchimp_account_id: "mc-account-1",
+        subject_line: "Custom Campaign",
+        list_id: "list-1",
+        artwork_ids: undefined,
+        partner_show_id: undefined,
+        html_content: "<html><body>Partner-authored content</body></html>",
+        preview_text: undefined,
+      })
+    })
+
+    it("can be combined with artworkIds for tracking", async () => {
+      const mutationWithHtmlAndArtworks = `
+        mutation {
+          createMailchimpCampaign(input: {
+            mailchimpAccountId: "mc-account-1"
+            subjectLine: "Custom Campaign"
+            listId: "list-1"
+            htmlContent: "<html><body>Partner-authored content</body></html>"
+            artworkIds: ["artwork-1", "artwork-2"]
+          }) {
+            mailchimpCampaignOrError {
+              __typename
+            }
+          }
+        }
+      `
+      const context: Partial<ResolverContext> = {
+        createMailchimpCampaignLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+
+      await runAuthenticatedQuery(mutationWithHtmlAndArtworks, context)
+
+      expect(
+        context.createMailchimpCampaignLoader as jest.Mock
+      ).toHaveBeenCalledWith({
+        mailchimp_account_id: "mc-account-1",
+        subject_line: "Custom Campaign",
+        list_id: "list-1",
+        artwork_ids: ["artwork-1", "artwork-2"],
+        partner_show_id: undefined,
+        html_content: "<html><body>Partner-authored content</body></html>",
         preview_text: undefined,
       })
     })

--- a/src/schema/v2/createMailchimpCampaignMutation.ts
+++ b/src/schema/v2/createMailchimpCampaignMutation.ts
@@ -17,6 +17,7 @@ interface Input {
   mailchimpAccountId: string
   artworkIds?: string[]
   partnerShowId?: string
+  htmlContent?: string
   subjectLine: string
   previewText?: string
   listId: string
@@ -70,12 +71,17 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
     artworkIds: {
       type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
       description:
-        "Artwork IDs to include in the campaign (mutually exclusive with partnerShowId)",
+        "Artwork IDs to associate with the campaign (mutually exclusive with partnerShowId; used to render content unless htmlContent is provided)",
     },
     partnerShowId: {
       type: GraphQLString,
       description:
-        "Partner show ID to create campaign from (mutually exclusive with artworkIds)",
+        "Partner show ID to associate with the campaign (mutually exclusive with artworkIds; used to render content unless htmlContent is provided)",
+    },
+    htmlContent: {
+      type: GraphQLString,
+      description:
+        "Pre-rendered HTML body for the campaign. When provided, supersedes the formatter's output but does not preclude tracking via artworkIds or partnerShowId",
     },
     subjectLine: {
       type: new GraphQLNonNull(GraphQLString),
@@ -102,6 +108,7 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
       mailchimpAccountId,
       artworkIds,
       partnerShowId,
+      htmlContent,
       subjectLine,
       previewText,
       listId,
@@ -123,6 +130,7 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
         mailchimp_account_id: mailchimpAccountId,
         artwork_ids: artworkIds,
         partner_show_id: partnerShowId,
+        html_content: htmlContent,
         subject_line: subjectLine,
         preview_text: previewText,
         list_id: listId,


### PR DESCRIPTION
This PR resolves [this notion card](https://www.notion.so/artsy/Expand-the-GraphQL-mutation-to-handle-the-HTML-content-argument-358cab0764a08019b840ea50ff931733)

Allow the entire html content to be passed to a Mailchimp Campaign. If present, use it as the Mailchimp template

Tested it using the following mutation:

```graphql
mutation createMailChimpCampaignMutation(
  $input: CreateMailchimpCampaignInput!
) {
    createMailchimpCampaign(input: $input) {
      mailchimpCampaignOrError {
        __typename
        ... on CreateMailchimpCampaignSuccess {
          mailchimpCampaign {
            internalID
            subjectLine
            status
          }
        }
        ... on CreateMailchimpCampaignFailure {
          mutationError {
            message
          }
        }
      }
  }
}
```

Query variables:
```json
{
	"input": {
		"mailchimpAccountId": "d6dce5a2-7ac3-40c2-af34-6e4030fc8798",
		"subjectLine": "Lorem",
		"listId": "8028951ac9",
		"htmlContent": "<html><body><h2>Foo Bar</h2><img src='https://d7hftxdivxxvm.cloudfront.net/?height=900&quality=85&resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2Fn7tCXIxvVCUypQf71cyy3A%2Flarger.jpg&width=80'><p><i>Gizmo & Edgar</i></p></body></html>"
	}
}
```

Confirmed the template was rendered on Mailchimp dashboard:

<img width="572" height="570" alt="Screenshot 2026-05-08 at 13 20 47" src="https://github.com/user-attachments/assets/6029cea0-15cb-4bad-ab0f-c2d70e3a567e" />

---

Gravity PR: https://github.com/artsy/gravity/pull/20117

cc @artsy/amber-devs 