### PR TITLE
chore: Handle image processing data for Brand Kit logo images

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16099,6 +16099,12 @@ type Image {
   ): CroppedImageUrl
   deepZoom: DeepZoom
   geminiToken: String
+  geminiTokenUpdatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
   height: Int
   href: String
   imageURL: String

--- a/src/schema/v2/image/__tests__/imageHelper.test.ts
+++ b/src/schema/v2/image/__tests__/imageHelper.test.ts
@@ -293,4 +293,60 @@ describe("imageHelper", () => {
       expect(hasProcessingFailed(missingImage)).toBe(false)
     })
   })
+
+  describe("with brand-kit-logo template", () => {
+    const brandKitImage = { gemini_template_key: "brand-kit-logo" }
+
+    it("treats a fresh upload (no versions, recent timestamp) as processing", () => {
+      const freshImage = {
+        ...brandKitImage,
+        image_url: null,
+        image_versions: [],
+        gemini_token_updated_at: new Date().toISOString(),
+      }
+
+      expect(isProcessingImage(freshImage)).toBe(true)
+      expect(hasProcessingFailed(freshImage)).toBe(false)
+    })
+
+    it("treats a fully processed logo (only square_brand_kit) as done — not still processing, not failed", () => {
+      const successImage = {
+        ...brandKitImage,
+        image_url: "https://example.com/logo/:version.jpg",
+        image_versions: ["square_brand_kit"],
+        gemini_token_updated_at: new Date().toISOString(),
+      }
+
+      expect(isProcessingImage(successImage)).toBe(false)
+      expect(hasProcessingFailed(successImage)).toBe(false)
+    })
+
+    it("treats a stuck upload (no versions, past grace period) as failed", () => {
+      const oldTime = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+      const failedImage = {
+        ...brandKitImage,
+        image_url: null,
+        image_versions: [],
+        gemini_token_updated_at: oldTime,
+      }
+
+      expect(isProcessingImage(failedImage)).toBe(false)
+      expect(hasProcessingFailed(failedImage)).toBe(true)
+    })
+
+    it("does not require artwork versions to consider a brand-kit logo complete", () => {
+      const image = {
+        ...brandKitImage,
+        image_versions: ["square_brand_kit"],
+      }
+
+      expect(hasMissingImageVersion(image)).toBe(false)
+    })
+
+    it("falls back to artwork expectations when gemini_template_key is absent", () => {
+      const image = { image_versions: ["square_brand_kit"] }
+
+      expect(hasMissingImageVersion(image)).toBe(true)
+    })
+  })
 })

--- a/src/schema/v2/image/imageHelper.ts
+++ b/src/schema/v2/image/imageHelper.ts
@@ -1,19 +1,39 @@
 /**
- * Expected artwork image versions for processing validation.
+ * Expected image versions per Gemini template, used to detect processing state.
  *
- * Generate from Gemini console with:
- * Account.find_by(name: "Gravity").templates.find_by(key: "additional-image").versions.map(&:key).sort
+ * Generate from the Gemini console with:
+ *   Account.find_by(name: "Gravity").templates.find_by(key: "<template-key>").versions.map(&:key).sort
  */
-export const EXPECTED_ARTWORK_IMAGE_VERSIONS = [
-  "large",
-  "larger",
-  "main",
-  "medium",
-  "normalized",
-  "small",
-  "square",
-  "tall",
-]
+export const EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE = {
+  "additional-image": [
+    "large",
+    "larger",
+    "main",
+    "medium",
+    "normalized",
+    "small",
+    "square",
+    "tall",
+  ],
+  "brand-kit-logo": ["square_brand_kit"],
+} as const
+
+// The last version Gemini emits per template — its presence signals processing is complete.
+export const COMPLETION_VERSION_BY_TEMPLATE = {
+  "additional-image": "normalized",
+  "brand-kit-logo": "square_brand_kit",
+} as const
+
+type TemplateKey = keyof typeof EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE
+const DEFAULT_TEMPLATE: TemplateKey = "additional-image"
+
+const isKnownTemplate = (k: unknown): k is TemplateKey =>
+  typeof k === "string" && k in EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE
+
+const getTemplate = (image): TemplateKey =>
+  isKnownTemplate(image.gemini_template_key)
+    ? image.gemini_template_key
+    : DEFAULT_TEMPLATE
 
 // Grace period for image processing (30 minutes in milliseconds)
 export const GRACE_PERIOD_FOR_PROCESSING = 30 * 60 * 1000
@@ -26,9 +46,8 @@ export const hasImageVersion = (image, version: string) => {
 // Helper function to check if any expected image version is missing
 export const hasMissingImageVersion = (image) => {
   if (!image.image_versions) return true
-  return EXPECTED_ARTWORK_IMAGE_VERSIONS.some(
-    (version) => !image.image_versions.includes(version)
-  )
+  const expected = EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE[getTemplate(image)]
+  return expected.some((version) => !image.image_versions.includes(version))
 }
 
 // Check if image is currently processing
@@ -55,6 +74,8 @@ export const hasProcessingFailed = (image) => {
     return false
   }
 
-  // Normalized is the last generated version and indicates that the image is processed
-  return !hasImageVersion(image, "normalized")
+  return !hasImageVersion(
+    image,
+    COMPLETION_VERSION_BY_TEMPLATE[getTemplate(image)]
+  )
 }

--- a/src/schema/v2/image/index.ts
+++ b/src/schema/v2/image/index.ts
@@ -11,6 +11,7 @@ import {
 import { find, first, isArray } from "lodash"
 import { NullableIDField } from "schema/v2/object_identification"
 import { ResolverContext } from "types/graphql"
+import { date } from "../fields/date"
 import { connectionWithCursorInfo } from "../fields/pagination"
 import CroppedUrl from "./cropped"
 import DeepZoom, { isZoomable } from "./deep_zoom"
@@ -69,6 +70,7 @@ export const ImageType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ gemini_token }) => gemini_token,
     },
+    geminiTokenUpdatedAt: date(),
     href: {
       type: GraphQLString,
     },

--- a/src/schema/v2/partner/__tests__/brandKit.test.ts
+++ b/src/schema/v2/partner/__tests__/brandKit.test.ts
@@ -101,4 +101,126 @@ describe("Partner brandKit field", () => {
       },
     })
   })
+
+  describe("logo field", () => {
+    const partnerData = {
+      _id: "partner-internal-id",
+      id: "catty-partner",
+    }
+
+    const logoQuery = gql`
+      {
+        partner(id: "catty-partner") {
+          brandKit {
+            logo {
+              geminiToken
+              geminiTokenUpdatedAt
+              imageURL
+              imageVersions
+              originalWidth
+              originalHeight
+              aspectRatio
+              isProcessing
+              processingFailed
+            }
+          }
+        }
+      }
+    `
+
+    it("returns null when the brand kit has no logo (image: null)", async () => {
+      const context = {
+        partnerLoader: jest.fn().mockResolvedValue(partnerData),
+        brandKitLoader: jest.fn().mockResolvedValue({
+          id: "brand-kit-1",
+          image: null,
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(logoQuery, context)
+      expect(data).toEqual({ partner: { brandKit: { logo: null } } })
+    })
+
+    it("returns null when the image key is absent", async () => {
+      const context = {
+        partnerLoader: jest.fn().mockResolvedValue(partnerData),
+        brandKitLoader: jest.fn().mockResolvedValue({
+          id: "brand-kit-1",
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(logoQuery, context)
+      expect(data).toEqual({ partner: { brandKit: { logo: null } } })
+    })
+
+    it("exposes processing-state fields while Gemini is still working", async () => {
+      const recentTime = new Date(Date.now() - 5 * 60 * 1000).toISOString()
+      const context = {
+        partnerLoader: jest.fn().mockResolvedValue(partnerData),
+        brandKitLoader: jest.fn().mockResolvedValue({
+          id: "brand-kit-1",
+          image: {
+            id: "image-1",
+            gemini_token: "tok-abc",
+            gemini_token_updated_at: recentTime,
+            image_url: null,
+            image_urls: {},
+            image_versions: [],
+            original_width: null,
+            original_height: null,
+            aspect_ratio: null,
+          },
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(logoQuery, context)
+      expect(data.partner.brandKit.logo).toMatchObject({
+        geminiToken: "tok-abc",
+        geminiTokenUpdatedAt: recentTime,
+        imageURL: null,
+        imageVersions: [],
+        originalWidth: null,
+        originalHeight: null,
+        isProcessing: true,
+        processingFailed: false,
+      })
+    })
+
+    it("exposes a fully processed logo with all fields populated", async () => {
+      const recentTime = new Date(Date.now() - 1 * 60 * 1000).toISOString()
+      const context = {
+        partnerLoader: jest.fn().mockResolvedValue(partnerData),
+        brandKitLoader: jest.fn().mockResolvedValue({
+          id: "brand-kit-1",
+          image: {
+            id: "image-1",
+            gemini_token: "tok-xyz",
+            gemini_token_updated_at: recentTime,
+            image_url: "https://d7hftxdivxxvm.cloudfront.net/abc/:version.jpg",
+            image_urls: {
+              square_brand_kit:
+                "https://d7hftxdivxxvm.cloudfront.net/abc/square_brand_kit.jpg",
+            },
+            image_versions: ["square_brand_kit"],
+            original_width: 1200,
+            original_height: 800,
+            aspect_ratio: 1.5,
+          },
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(logoQuery, context)
+      expect(data.partner.brandKit.logo).toMatchObject({
+        geminiToken: "tok-xyz",
+        geminiTokenUpdatedAt: recentTime,
+        imageURL: "https://d7hftxdivxxvm.cloudfront.net/abc/:version.jpg",
+        imageVersions: ["square_brand_kit"],
+        originalWidth: 1200,
+        originalHeight: 800,
+        aspectRatio: 1.5,
+        isProcessing: false,
+        processingFailed: false,
+      })
+    })
+  })
 })

--- a/src/schema/v2/partner/brandKit.ts
+++ b/src/schema/v2/partner/brandKit.ts
@@ -38,7 +38,13 @@ export const BrandKitType = new GraphQLObjectType<any, ResolverContext>({
     },
     logo: {
       type: Image.type,
-      resolve: ({ image }) => normalizeImageData(image),
+      resolve: ({ image }) => {
+        if (!image) return null
+        return {
+          ...normalizeImageData(image, true),
+          gemini_template_key: "brand-kit-logo",
+        }
+      },
     },
     createdAt: date(),
     updatedAt: date(),


### PR DESCRIPTION
Related PRs: 
- https://github.com/artsy/gravity/pull/20128
- https://github.com/artsy/volt/pull/11378

Ensure images queries for brand kit can behave similar to artwork images when it comes to processing data.

This allows us to:
- Fetch the original image for a brand kit logo until the imaging processing is complete
- Query data for the image processing state (in progress / failure) based on processed image results presence and gemini token update timestamp

cc @artsy/amber-devs 