### PR TITLE
chore: TOP-260 - show cancelled imports

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20740,8 +20740,8 @@ type Partner implements Node {
     before: String
     first: Int
 
-    # Include cancelled imports in results. Defaults to false.
-    includeCanceled: Boolean
+    # Include inactive imports in results. Defaults to false.
+    includeInactive: Boolean
     last: Int
 
     # Filter by import source: 'bulk_import' or 'multi_add'. Returns all sources if omitted.

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20739,6 +20739,9 @@ type Partner implements Node {
     after: String
     before: String
     first: Int
+
+    # Include cancelled imports in results. Defaults to false.
+    includeCanceled: Boolean
     last: Int
 
     # Filter by import source: 'bulk_import' or 'multi_add'. Returns all sources if omitted.

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -782,6 +782,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             description:
               "Filter by import source: 'bulk_import' or 'multi_add'. Returns all sources if omitted.",
           },
+          includeCanceled: {
+            type: GraphQLBoolean,
+            description:
+              "Include cancelled imports in results. Defaults to false.",
+          },
         },
         resolve: async ({ id }, args, { artworkImportsLoader }) => {
           if (!artworkImportsLoader) return null
@@ -795,6 +800,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             total_count: true,
             partner_id: id,
             ...(args.source && { source: args.source }),
+            ...(args.includeCanceled && { include_canceled: true }),
           })
 
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -782,10 +782,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             description:
               "Filter by import source: 'bulk_import' or 'multi_add'. Returns all sources if omitted.",
           },
-          includeCanceled: {
+          includeInactive: {
             type: GraphQLBoolean,
             description:
-              "Include cancelled imports in results. Defaults to false.",
+              "Include inactive imports in results. Defaults to false.",
           },
         },
         resolve: async ({ id }, args, { artworkImportsLoader }) => {
@@ -800,7 +800,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             total_count: true,
             partner_id: id,
             ...(args.source && { source: args.source }),
-            ...(args.includeCanceled && { include_canceled: true }),
+            ...(args.includeInactive && { include_inactive: true }),
           })
 
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)


### PR DESCRIPTION
Solves [TOP-260]

Consumes the Gravity changes made in https://github.com/artsy/gravity/pull/20137 to conditionally show cancelled imports. This will be used on the `/list` page for admins to see cancelled imports. This should help with understanding the status of imports and help with debugging.

cc: @artsy/topaz-devs 

[TOP-260]: https://artsyproduct.atlassian.net/browse/TOP-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ