### PR TITLE
feat: allow edition sets creation from artwork update

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -27200,6 +27200,9 @@ input UpdateArtworkEditionSetInput {
   # The diameter of the artwork
   diameter: String
 
+  # The unit of measurement for diameter on an edition set
+  diameterMetric: String
+
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
@@ -27216,8 +27219,14 @@ input UpdateArtworkEditionSetInput {
   # The height of the artwork
   height: String
 
-  # The id of the artwork to update.
-  id: String!
+  # The unit of measurement for height/width/depth on an edition set
+  hwdMetric: String
+
+  # The id of the edition set to update. Omit to create a new edition set.
+  id: String
+
+  # The inventory count for an edition set
+  inventoryCount: Int
 
   # The unit of measurement for artwork dimensions
   metric: String
@@ -27238,6 +27247,9 @@ input UpdateArtworkEditionSetInput {
   published: Boolean
   shippingWeight: Float
   shippingWeightMetric: String
+
+  # The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.
+  sizeType: String
   title: String
 
   # The width of the artwork
@@ -27356,6 +27368,9 @@ input UpdateArtworkMutationInput {
   # Whether the artwork is listed on Artsy
   artsyListing: Boolean
 
+  # The attribution class of the artwork
+  attributionClass: ArtworkAttributionClassType
+
   # The availability of the artwork
   availability: String
 
@@ -27382,6 +27397,9 @@ input UpdateArtworkMutationInput {
   # The diameter of the artwork
   diameter: String
 
+  # The unit of measurement for diameter on an edition set
+  diameterMetric: String
+
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
@@ -27401,11 +27419,17 @@ input UpdateArtworkMutationInput {
   # The height of the artwork
   height: String
 
+  # The unit of measurement for height/width/depth on an edition set
+  hwdMetric: String
+
   # The id of the artwork to update.
   id: String!
 
   # A list of S3 locations (bucket and key pairs) for artwork images to be added.
   imageS3Locations: [S3LocationInput!]
+
+  # The inventory count for an edition set
+  inventoryCount: Int
 
   # The inventory ID of the artwork
   inventoryId: String
@@ -27435,6 +27459,9 @@ input UpdateArtworkMutationInput {
   published: Boolean
   shippingWeight: Float
   shippingWeightMetric: String
+
+  # The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.
+  sizeType: String
   title: String
 
   # The width of the artwork

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -27200,9 +27200,6 @@ input UpdateArtworkEditionSetInput {
   # The diameter of the artwork
   diameter: String
 
-  # The unit of measurement for diameter on an edition set
-  diameterMetric: String
-
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
@@ -27219,13 +27216,10 @@ input UpdateArtworkEditionSetInput {
   # The height of the artwork
   height: String
 
-  # The unit of measurement for height/width/depth on an edition set
-  hwdMetric: String
-
   # The id of the edition set to update. Omit to create a new edition set.
   id: String
 
-  # The inventory count for an edition set
+  # The inventory count
   inventoryCount: Int
 
   # The unit of measurement for artwork dimensions
@@ -27248,7 +27242,7 @@ input UpdateArtworkEditionSetInput {
   shippingWeight: Float
   shippingWeightMetric: String
 
-  # The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.
+  # The size type, e.g. "hwd" or "diameter".
   sizeType: String
   title: String
 
@@ -27397,9 +27391,6 @@ input UpdateArtworkMutationInput {
   # The diameter of the artwork
   diameter: String
 
-  # The unit of measurement for diameter on an edition set
-  diameterMetric: String
-
   # Show/Hide the price range of an artwork
   displayPriceRange: Boolean
 
@@ -27419,16 +27410,13 @@ input UpdateArtworkMutationInput {
   # The height of the artwork
   height: String
 
-  # The unit of measurement for height/width/depth on an edition set
-  hwdMetric: String
-
   # The id of the artwork to update.
   id: String!
 
   # A list of S3 locations (bucket and key pairs) for artwork images to be added.
   imageS3Locations: [S3LocationInput!]
 
-  # The inventory count for an edition set
+  # The inventory count
   inventoryCount: Int
 
   # The inventory ID of the artwork
@@ -27460,7 +27448,7 @@ input UpdateArtworkMutationInput {
   shippingWeight: Float
   shippingWeightMetric: String
 
-  # The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.
+  # The size type, e.g. "hwd" or "diameter".
   sizeType: String
   title: String
 

--- a/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
@@ -943,8 +943,7 @@ describe("UpdateArtworkMutation", () => {
                   sizeType: "hwd"
                   height: "10"
                   width: "20"
-                  hwdMetric: "cm"
-                  diameterMetric: "cm"
+                  metric: "cm"
                   priceListed: "1000"
                   priceCurrency: "USD"
                   availability: "for sale"
@@ -983,11 +982,10 @@ describe("UpdateArtworkMutation", () => {
         "25",
         expect.objectContaining({
           edition_size: "10",
-          inventory_count: 5,
+          inventory: { count: 5 },
           height: "10",
           width: "20",
-          hwd_metric: "cm",
-          diameter_metric: "cm",
+          metric: "cm",
           size_type: "hwd",
           price_listed: "1000",
           price_currency: "USD",
@@ -998,7 +996,7 @@ describe("UpdateArtworkMutation", () => {
         "25",
         expect.objectContaining({
           edition_size: "20",
-          inventory_count: 3,
+          inventory: { count: 3 },
         })
       )
     })

--- a/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
@@ -920,4 +920,130 @@ describe("UpdateArtworkMutation", () => {
       expect(loaderArgs.artsy_listing).toBeUndefined()
     })
   })
+
+  describe("editionSets field", () => {
+    it("creates new edition sets when no id is provided", async () => {
+      const createArtworkEditionSetLoader = jest.fn().mockResolvedValue({})
+      const updateArtworkEditionSetLoader = jest.fn()
+      const updateArtworkLoader = jest.fn().mockResolvedValue({
+        id: "25",
+        _id: "25",
+      })
+
+      const convertMutation = gql`
+        mutation {
+          updateArtwork(
+            input: {
+              id: "25"
+              attributionClass: LIMITED_EDITION
+              editionSets: [
+                {
+                  editionSize: "10"
+                  inventoryCount: 5
+                  sizeType: "hwd"
+                  height: "10"
+                  width: "20"
+                  hwdMetric: "cm"
+                  diameterMetric: "cm"
+                  priceListed: "1000"
+                  priceCurrency: "USD"
+                  availability: "for sale"
+                }
+                { editionSize: "20", inventoryCount: 3 }
+              ]
+            }
+          ) {
+            artworkOrError {
+              __typename
+              ... on updateArtworkSuccess {
+                artwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        updateArtworkLoader,
+        updateArtworkEditionSetLoader,
+        createArtworkEditionSetLoader,
+      }
+
+      await runAuthenticatedQuery(convertMutation, context)
+
+      expect(updateArtworkLoader).toHaveBeenCalledWith(
+        "25",
+        expect.objectContaining({ attribution_class: "limited edition" })
+      )
+      expect(updateArtworkEditionSetLoader).not.toHaveBeenCalled()
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledTimes(2)
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        "25",
+        expect.objectContaining({
+          edition_size: "10",
+          inventory_count: 5,
+          height: "10",
+          width: "20",
+          hwd_metric: "cm",
+          diameter_metric: "cm",
+          size_type: "hwd",
+          price_listed: "1000",
+          price_currency: "USD",
+          availability: "for sale",
+        })
+      )
+      expect(createArtworkEditionSetLoader).toHaveBeenCalledWith(
+        "25",
+        expect.objectContaining({
+          edition_size: "20",
+          inventory_count: 3,
+        })
+      )
+    })
+
+    it("updates existing edition sets when id is provided", async () => {
+      const createArtworkEditionSetLoader = jest.fn()
+      const updateArtworkEditionSetLoader = jest.fn().mockResolvedValue({})
+      const updateArtworkLoader = jest.fn().mockResolvedValue({
+        id: "25",
+        _id: "25",
+      })
+
+      const updateMutation = gql`
+        mutation {
+          updateArtwork(
+            input: {
+              id: "25"
+              editionSets: [{ id: "set-1", editionSize: "15" }]
+            }
+          ) {
+            artworkOrError {
+              __typename
+              ... on updateArtworkSuccess {
+                artwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        updateArtworkLoader,
+        updateArtworkEditionSetLoader,
+        createArtworkEditionSetLoader,
+      }
+
+      await runAuthenticatedQuery(updateMutation, context)
+
+      expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        { artworkId: "25", editionSetId: "set-1" },
+        expect.objectContaining({ edition_size: "15" })
+      )
+    })
+  })
 })

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -16,6 +16,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { omit } from "lodash"
 import Artwork from "schema/v2/artwork"
+import { ArtworkAttributionClassEnum } from "schema/v2/me/myCollectionCreateArtworkMutation"
 import { ResolverContext } from "types/graphql"
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -55,6 +56,7 @@ interface UpdateArtworkMutationInputProps {
   artistIds?: string[]
   artsyListing?: boolean
   artistProofs?: string
+  attributionClass?: string
   availability?: string
   certificateOfAuthenticity?: boolean
   coaByGallery?: boolean
@@ -71,6 +73,7 @@ interface UpdateArtworkMutationInputProps {
     UpdateArtworkMutationInputProps,
     | "editionSets"
     | "artistIds"
+    | "attributionClass"
     | "mediumType"
     | "date"
     | "inventoryId"
@@ -84,8 +87,11 @@ interface UpdateArtworkMutationInputProps {
   framedMetric?: string
   framedWidth?: string
   height?: string
+  hwdMetric?: string
+  diameterMetric?: string
   id?: string
   imageS3Locations?: S3LocationInput[]
+  inventoryCount?: number
   inventoryId?: string
   metric?: string
   offer?: boolean
@@ -100,6 +106,7 @@ interface UpdateArtworkMutationInputProps {
   priceMin?: number
   shippingWeight?: number
   shippingWeightMetric?: string
+  sizeType?: string
   title?: string
   width?: string
 }
@@ -170,6 +177,10 @@ const inputFields = {
   artistProofs: {
     type: GraphQLString,
   },
+  attributionClass: {
+    type: ArtworkAttributionClassEnum,
+    description: "The attribution class of the artwork",
+  },
   delete: {
     type: GraphQLBoolean,
   },
@@ -196,6 +207,15 @@ const inputFields = {
     type: GraphQLString,
     description: "The unit of measurement for artwork dimensions",
   },
+  hwdMetric: {
+    type: GraphQLString,
+    description:
+      "The unit of measurement for height/width/depth on an edition set",
+  },
+  diameterMetric: {
+    type: GraphQLString,
+    description: "The unit of measurement for diameter on an edition set",
+  },
   width: {
     type: GraphQLString,
     description: "The width of the artwork",
@@ -217,6 +237,10 @@ const inputFields = {
   },
   framed: {
     type: GraphQLBoolean,
+  },
+  inventoryCount: {
+    type: GraphQLInt,
+    description: "The inventory count for an edition set",
   },
   inventoryId: {
     type: GraphQLString,
@@ -250,6 +274,11 @@ const inputFields = {
   shippingWeight: {
     type: GraphQLFloat,
   },
+  sizeType: {
+    type: GraphQLString,
+    description:
+      'The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.',
+  },
   title: {
     type: GraphQLString,
   },
@@ -272,6 +301,7 @@ const S3LocationInputType = new GraphQLInputObjectType({
 
 const editionSetExcludedFields = [
   "artistIds",
+  "attributionClass",
   "mediumType",
   "date",
   "inventoryId",
@@ -280,7 +310,14 @@ const editionSetExcludedFields = [
 
 const UpdateArtworkEditionSetInput = new GraphQLInputObjectType({
   name: "UpdateArtworkEditionSetInput",
-  fields: omit(inputFields, editionSetExcludedFields),
+  fields: {
+    ...omit(inputFields, editionSetExcludedFields),
+    id: {
+      type: GraphQLString,
+      description:
+        "The id of the edition set to update. Omit to create a new edition set.",
+    },
+  },
 })
 
 export const updateArtworkMutation = mutationWithClientMutationId<
@@ -314,11 +351,16 @@ export const updateArtworkMutation = mutationWithClientMutationId<
     {
       updateArtworkLoader,
       updateArtworkEditionSetLoader,
+      createArtworkEditionSetLoader,
       addImageToArtworkLoader,
       setDefaultArtworkImageLoader,
     }
   ) => {
-    if (!updateArtworkLoader || !updateArtworkEditionSetLoader) {
+    if (
+      !updateArtworkLoader ||
+      !updateArtworkEditionSetLoader ||
+      !createArtworkEditionSetLoader
+    ) {
       return new Error("You need to be signed in to perform this action")
     }
 
@@ -328,6 +370,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         artists: inputArgs.artistIds,
         artsy_listing: inputArgs.artsyListing,
         artist_proofs: inputArgs.artistProofs,
+        attribution_class: inputArgs.attributionClass,
         availability: inputArgs.availability,
         certificate_of_authenticity: inputArgs.certificateOfAuthenticity,
         coa_by_gallery: inputArgs.coaByGallery,
@@ -347,7 +390,10 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         framed_width: inputArgs.framedWidth,
         framed: inputArgs.framed,
         height: inputArgs.height,
+        hwd_metric: inputArgs.hwdMetric,
+        diameter_metric: inputArgs.diameterMetric,
         id: inputArgs.id,
+        inventory_count: inputArgs.inventoryCount,
         inventory_id: inputArgs.inventoryId,
         metric: inputArgs.metric,
         offer: inputArgs.offer,
@@ -362,6 +408,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         price_min: inputArgs.priceMin,
         shipping_weight_metric: inputArgs.shippingWeightMetric,
         shipping_weight: inputArgs.shippingWeight,
+        size_type: inputArgs.sizeType,
         title: inputArgs.title,
         width: inputArgs.width,
       }
@@ -394,15 +441,17 @@ export const updateArtworkMutation = mutationWithClientMutationId<
       if (editionSets?.length > 0) {
         await Promise.all(
           editionSets.map((editionSet) => {
-            const input = getGravityArgs(editionSet)
+            if (editionSet.id) {
+              return updateArtworkEditionSetLoader(
+                {
+                  artworkId: id,
+                  editionSetId: editionSet.id,
+                },
+                getGravityArgs(editionSet)
+              )
+            }
 
-            return updateArtworkEditionSetLoader(
-              {
-                artworkId: id,
-                editionSetId: editionSet.id,
-              },
-              input
-            )
+            return createArtworkEditionSetLoader(id, getGravityArgs(editionSet))
           })
         )
       }

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -87,8 +87,6 @@ interface UpdateArtworkMutationInputProps {
   framedMetric?: string
   framedWidth?: string
   height?: string
-  hwdMetric?: string
-  diameterMetric?: string
   id?: string
   imageS3Locations?: S3LocationInput[]
   inventoryCount?: number
@@ -207,15 +205,6 @@ const inputFields = {
     type: GraphQLString,
     description: "The unit of measurement for artwork dimensions",
   },
-  hwdMetric: {
-    type: GraphQLString,
-    description:
-      "The unit of measurement for height/width/depth on an edition set",
-  },
-  diameterMetric: {
-    type: GraphQLString,
-    description: "The unit of measurement for diameter on an edition set",
-  },
   width: {
     type: GraphQLString,
     description: "The width of the artwork",
@@ -240,7 +229,7 @@ const inputFields = {
   },
   inventoryCount: {
     type: GraphQLInt,
-    description: "The inventory count for an edition set",
+    description: "The inventory count",
   },
   inventoryId: {
     type: GraphQLString,
@@ -276,8 +265,7 @@ const inputFields = {
   },
   sizeType: {
     type: GraphQLString,
-    description:
-      'The size type for an edition set, e.g. "hwd" or "diameter". Defaults to "hwd" on new edition sets when any dimension is provided.',
+    description: 'The size type, e.g. "hwd" or "diameter".',
   },
   title: {
     type: GraphQLString,
@@ -390,10 +378,11 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         framed_width: inputArgs.framedWidth,
         framed: inputArgs.framed,
         height: inputArgs.height,
-        hwd_metric: inputArgs.hwdMetric,
-        diameter_metric: inputArgs.diameterMetric,
         id: inputArgs.id,
-        inventory_count: inputArgs.inventoryCount,
+        inventory:
+          inputArgs.inventoryCount != null
+            ? { count: inputArgs.inventoryCount }
+            : undefined,
         inventory_id: inputArgs.inventoryId,
         metric: inputArgs.metric,
         offer: inputArgs.offer,


### PR DESCRIPTION
Support edition sets creation in the update artwork mutation, which will allow more flexibility for handling artwork data in CatalogOS and future CMS refactors

@artsy/amber-devs 