### PR TITLE
chore: add schema and mutation for syncing OS artworks to canonical

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19335,6 +19335,11 @@ type Mutation {
   # Submit an order
   submitOrder(input: submitOrderInput!): submitOrderPayload
 
+  # Syncs catalog artwork (OS) values to the CMS artwork, applying mapping rules for medium, availability, and price.
+  syncCatalogToArtwork(
+    input: SyncCatalogToArtworkMutationInput!
+  ): SyncCatalogToArtworkMutationPayload
+
   # Transfers My Collection artworks from one user to another.
   transferMyCollection(
     input: TransferMyCollectionInput!
@@ -20866,6 +20871,9 @@ type Partner implements Node {
   displayFullPartnerPage: Boolean
   displayWorksSection: Boolean
   distinguishRepresentedArtists: Boolean
+
+  # Whether auto-sync of variable fields to marketplaces is enabled. Defaults to false.
+  distributionSyncEnabled: Boolean
 
   # Return partner documents if current user has CMS access.
   documentsConnection(
@@ -26726,6 +26734,32 @@ type SuggestedAddressFields {
   lines: [String]
 }
 
+type SyncCatalogToArtworkFailure {
+  mutationError: GravityMutationError
+}
+
+input SyncCatalogToArtworkMutationInput {
+  # The ID of the artwork to sync.
+  artworkID: String!
+  clientMutationId: String
+}
+
+type SyncCatalogToArtworkMutationPayload {
+  # On success: the synced artwork and any partial errors. On error: the error that occurred.
+  artworkOrError: SyncCatalogToArtworkResponseOrError
+  clientMutationId: String
+}
+
+union SyncCatalogToArtworkResponseOrError =
+    SyncCatalogToArtworkFailure
+  | SyncCatalogToArtworkSuccess
+
+type SyncCatalogToArtworkSuccess {
+  artwork: Artwork
+  syncErrors: [String]
+  syncedFields: [String]
+}
+
 type System {
   # Deprecated Algolia fields, temporarily kept for legacy compatibility
   algolia: Algolia @deprecated(reason: "Algolia search is no longer supported")
@@ -28355,6 +28389,9 @@ input UpdatePartnerFlagsMutationInput {
   # The default weight metric system to use for artworks. If null, the flag will be unset.
   artworksDefaultWeightMetric: String
   clientMutationId: String
+
+  # Whether auto-sync of variable fields to marketplaces is enabled. If null, the flag will be unset.
+  distributionSyncEnabled: Boolean
 
   # Whether the partner has accepted the GDPR DPA. The server will record the acceptance timestamp.
   gdprDpaAccepted: Boolean

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -381,6 +381,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    syncCatalogToArtworkLoader: gravityLoader(
+      (id) => `catalog_artwork/${id}/sync_to_artwork`,
+      {},
+      { method: "POST" }
+    ),
     createCreditCardLoader: gravityLoader(
       "me/credit_cards",
       {},

--- a/src/schema/v2/artwork/__tests__/syncCatalogToArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/syncCatalogToArtworkMutation.test.ts
@@ -1,0 +1,128 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("SyncCatalogToArtworkMutation", () => {
+  const mutation = gql`
+    mutation {
+      syncCatalogToArtwork(input: { artworkID: "artwork-123" }) {
+        artworkOrError {
+          __typename
+          ... on SyncCatalogToArtworkSuccess {
+            artwork {
+              internalID
+            }
+            syncedFields
+            syncErrors
+          }
+          ... on SyncCatalogToArtworkFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  describe("on success", () => {
+    it("returns artwork, synced fields, and errors", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: jest.fn(() =>
+          Promise.resolve({
+            success: true,
+            synced_fields: ["availability", "medium", "price"],
+            errors: [],
+          })
+        ),
+        artworkLoader: jest.fn(() =>
+          Promise.resolve({ _id: "artwork-123", id: "artwork-slug" })
+        ),
+      }
+
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(context.artworkLoader).toHaveBeenCalledWith("artwork-123")
+      expect(result).toEqual({
+        syncCatalogToArtwork: {
+          artworkOrError: {
+            __typename: "SyncCatalogToArtworkSuccess",
+            artwork: {
+              internalID: "artwork-123",
+            },
+            syncedFields: ["availability", "medium", "price"],
+            syncErrors: [],
+          },
+        },
+      })
+    })
+
+    it("returns partial sync errors", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: jest.fn(() =>
+          Promise.resolve({
+            success: false,
+            synced_fields: ["price"],
+            errors: ["Availability 'on hold' is not syncable"],
+          })
+        ),
+        artworkLoader: jest.fn(() =>
+          Promise.resolve({ _id: "artwork-123", id: "artwork-slug" })
+        ),
+      }
+
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toEqual({
+        syncCatalogToArtwork: {
+          artworkOrError: {
+            __typename: "SyncCatalogToArtworkSuccess",
+            artwork: {
+              internalID: "artwork-123",
+            },
+            syncedFields: ["price"],
+            syncErrors: ["Availability 'on hold' is not syncable"],
+          },
+        },
+      })
+    })
+  })
+
+  describe("on API failure", () => {
+    it("returns a mutation error", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: jest.fn(() =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/catalog_artwork/artwork-123/sync_to_artwork - {"type":"error","message":"Artwork not found"}`
+            )
+          )
+        ),
+      }
+
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toEqual({
+        syncCatalogToArtwork: {
+          artworkOrError: {
+            __typename: "SyncCatalogToArtworkFailure",
+            mutationError: {
+              message: "Artwork not found",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when unauthenticated", () => {
+    it("returns an error", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: undefined,
+      }
+
+      await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+        "You need to be signed in to perform this action"
+      )
+    })
+  })
+})

--- a/src/schema/v2/artwork/syncCatalogToArtworkMutation.ts
+++ b/src/schema/v2/artwork/syncCatalogToArtworkMutation.ts
@@ -1,0 +1,99 @@
+import {
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import Artwork from "schema/v2/artwork"
+
+interface SyncCatalogToArtworkMutationInputProps {
+  artworkID: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "SyncCatalogToArtworkSuccess",
+  isTypeOf: (data) => data._type === "SyncCatalogToArtworkSuccess",
+  fields: () => ({
+    artwork: {
+      type: Artwork.type,
+      resolve: (result, _args, { artworkLoader }) => {
+        return artworkLoader(result.artworkID)
+      },
+    },
+    syncedFields: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ synced_fields }) => synced_fields,
+    },
+    syncErrors: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ errors }) => errors,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "SyncCatalogToArtworkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "SyncCatalogToArtworkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const syncCatalogToArtworkMutation = mutationWithClientMutationId<
+  SyncCatalogToArtworkMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "SyncCatalogToArtworkMutation",
+  description:
+    "Syncs catalog artwork (OS) values to the CMS artwork, applying mapping rules for medium, availability, and price.",
+  inputFields: {
+    artworkID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork to sync.",
+    },
+  },
+  outputFields: {
+    artworkOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the synced artwork and any partial errors. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkID },
+    { syncCatalogToArtworkLoader }
+  ) => {
+    if (!syncCatalogToArtworkLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await syncCatalogToArtworkLoader(artworkID)
+      return { ...response, artworkID, _type: "SyncCatalogToArtworkSuccess" }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
+++ b/src/schema/v2/partner/__tests__/updatePartnerFlagsMutation.test.ts
@@ -14,6 +14,7 @@ describe("UpdatePartnerFlagsMutation", () => {
             artworksDefaultPartnerLocationId: "location-1"
             artworksDefaultWeightMetric: "kg"
             gdprDpaAccepted: true
+            distributionSyncEnabled: true
           }
         ) {
           partnerOrError {
@@ -44,6 +45,7 @@ describe("UpdatePartnerFlagsMutation", () => {
             artworks_default_partner_location_id: "location-1",
             artworks_default_weight_metric: "kg",
             gdpr_dpa_accepted: true,
+            catalog_distribution_sync_enabled: true,
           })
           return Promise.resolve({
             _id: "partner-id",

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1355,6 +1355,18 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLString,
         resolve: ({ name }) => name.trim(),
       },
+      distributionSyncEnabled: {
+        type: GraphQLBoolean,
+        description:
+          "Whether auto-sync of variable fields to marketplaces is enabled. Defaults to false.",
+        resolve: async ({ _id }, _args, { partnerAllLoader }) => {
+          if (!partnerAllLoader) return false
+          const partner = await partnerAllLoader(_id)
+          return (
+            partner.partner_flags?.catalog_distribution_sync_enabled === true
+          )
+        },
+      },
       distinguishRepresentedArtists: {
         type: GraphQLBoolean,
         resolve: ({ distinguish_represented_artists }) =>

--- a/src/schema/v2/partner/updatePartnerFlagsMutation.ts
+++ b/src/schema/v2/partner/updatePartnerFlagsMutation.ts
@@ -21,6 +21,7 @@ interface UpdatePartnerFlagsMutationInputProps {
   artworksDefaultPartnerLocationId?: string | null
   artworksDefaultWeightMetric?: string | null
   gdprDpaAccepted?: boolean | null
+  distributionSyncEnabled?: boolean | null
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -92,6 +93,11 @@ export const updatePartnerFlagsMutation = mutationWithClientMutationId<
       description:
         "Whether the partner has accepted the GDPR DPA. The server will record the acceptance timestamp.",
     },
+    distributionSyncEnabled: {
+      type: GraphQLBoolean,
+      description:
+        "Whether auto-sync of variable fields to marketplaces is enabled. If null, the flag will be unset.",
+    },
   },
   outputFields: {
     partnerOrError: {
@@ -110,6 +116,7 @@ export const updatePartnerFlagsMutation = mutationWithClientMutationId<
       artworksDefaultPartnerLocationId,
       artworksDefaultWeightMetric,
       gdprDpaAccepted,
+      distributionSyncEnabled,
     },
     { updatePartnerFlagsLoader }
   ) => {
@@ -148,6 +155,10 @@ export const updatePartnerFlagsMutation = mutationWithClientMutationId<
 
       if (gdprDpaAccepted !== undefined) {
         flags["gdpr_dpa_accepted"] = gdprDpaAccepted
+      }
+
+      if (distributionSyncEnabled !== undefined) {
+        flags["catalog_distribution_sync_enabled"] = distributionSyncEnabled
       }
 
       const response = await updatePartnerFlagsLoader(id, { flags })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -157,6 +157,7 @@ import { deleteArtistMutation } from "./artist/deleteArtistMutation"
 import { createArtworkMutation } from "./artwork/createArtworkMutation"
 import { deleteArtworkMutation } from "./artwork/deleteArtworkMutation"
 import { updateCatalogArtworkMutation } from "./artwork/updateCatalogArtworkMutation"
+import { syncCatalogToArtworkMutation } from "./artwork/syncCatalogToArtworkMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { repositionArtworkImagesMutation } from "./artwork/repositionArtworkImagesMutation"
 import { artworksForUser } from "./artworksForUser"
@@ -778,6 +779,7 @@ export default new GraphQLSchema({
       startIdentityVerification: startIdentityVerificationMutation,
       submitInquiryRequestMutation,
       submitOrder: submitOrderMutation,
+      syncCatalogToArtwork: syncCatalogToArtworkMutation,
       transferMyCollection: transferMyCollectionMutation,
       triggerCampaign: triggerCampaignMutation,
       unlinkAuthentication: unlinkAuthenticationMutation,


### PR DESCRIPTION
Adds `distributionSyncEnabled: Boolean` field on Partner.
Adds `distributionSyncEnabled: Boolean` input field to the `updatePartnerFlags` mutation.
Adds on-demand `syncCatalogToArtwork` mutation.

Based on https://github.com/artsy/gravity/pull/20135.