### PR TITLE
chore: always return decimal point for line breakdowns as it helps avoid unnecessary flicker in UIs

### DIFF
--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -967,9 +967,9 @@ describe("Me", () => {
             __typename: "SubtotalLine",
             displayName: "Price",
             amount: {
-              display: "US$5,000",
+              display: "US$5,000.00",
               currencySymbol: "$",
-              amount: "5,000",
+              amount: "5,000.00",
             },
           },
           {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -1030,7 +1030,7 @@ describe("Me", () => {
             {
               __typename: "SubtotalLine",
               displayName: "Price",
-              amount: { amount: "7,500" },
+              amount: { amount: "7,500.00" },
             },
             { __typename: "ShippingLine" },
             { __typename: "TaxLine" },
@@ -1058,7 +1058,7 @@ describe("Me", () => {
             {
               __typename: "SubtotalLine",
               displayName: "Price",
-              amount: { amount: "6,000" },
+              amount: { amount: "6,000.00" },
             },
             { __typename: "ShippingLine" },
             { __typename: "TaxLine" },
@@ -1087,7 +1087,7 @@ describe("Me", () => {
             {
               __typename: "SubtotalLine",
               displayName: "Gallery offer",
-              amount: { amount: "5,000" },
+              amount: { amount: "5,000.00" },
             },
             { __typename: "ShippingLine" },
             { __typename: "TaxLine" },
@@ -1116,7 +1116,7 @@ describe("Me", () => {
             {
               __typename: "SubtotalLine",
               displayName: "Price",
-              amount: { amount: "5,000" },
+              amount: { amount: "5,000.00" },
             },
             { __typename: "ShippingLine" },
             { __typename: "TaxLine" },
@@ -1180,7 +1180,7 @@ describe("Me", () => {
               displayName: "Pickup",
               amountFallbackText: null,
               amount: {
-                amount: "0",
+                amount: "0.00",
               },
             },
             {
@@ -1188,7 +1188,7 @@ describe("Me", () => {
               displayName: "Tax",
               amountFallbackText: null,
               amount: {
-                amount: "400",
+                amount: "400.00",
               },
             },
             {
@@ -1224,7 +1224,7 @@ describe("Me", () => {
               displayName: "Free shipping",
               amountFallbackText: null,
               amount: {
-                amount: "0",
+                amount: "0.00",
               },
             },
             {
@@ -1232,7 +1232,7 @@ describe("Me", () => {
               displayName: "Tax",
               amountFallbackText: null,
               amount: {
-                amount: "400",
+                amount: "400.00",
               },
             },
             {
@@ -1268,7 +1268,7 @@ describe("Me", () => {
               displayName: "Free shipping",
               amountFallbackText: null,
               amount: {
-                amount: "0",
+                amount: "0.00",
               },
             },
             {
@@ -1276,7 +1276,7 @@ describe("Me", () => {
               displayName: "Tax",
               amountFallbackText: null,
               amount: {
-                amount: "400",
+                amount: "400.00",
               },
             },
             {
@@ -1607,11 +1607,11 @@ describe("Me", () => {
 
           const result = await runAuthenticatedQuery(query, context)
 
-          // Items amount should not have decimals (only non-null amount, no cents)
+          // Items amount should always have decimals
           expect(result.me.order.pricingBreakdownLines[0]).toEqual({
             __typename: "SubtotalLine",
             displayName: "Price",
-            amount: { amount: "5,000" },
+            amount: { amount: "5,000.00" },
           })
 
           // Other lines should have null amounts

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -1494,7 +1494,7 @@ describe("Me", () => {
           ])
         })
 
-        it("shows no decimals when all amounts are whole dollars", async () => {
+        it("shows decimals even when all amounts are whole dollars", async () => {
           orderJson.items_total_cents = 500000
           orderJson.shipping_total_cents = 10000
           orderJson.tax_total_cents = 40000
@@ -1515,27 +1515,27 @@ describe("Me", () => {
 
           const result = await runAuthenticatedQuery(query, context)
 
-          // No amounts should have decimals since all are whole dollars
+          // All amounts should have decimals always
           expect(result.me.order.pricingBreakdownLines).toEqual([
             {
               __typename: "SubtotalLine",
               displayName: "Price",
-              amount: { amount: "5,000" },
+              amount: { amount: "5,000.00" },
             },
             {
               __typename: "ShippingLine",
               displayName: "Flat rate shipping",
-              amount: { amount: "100" },
+              amount: { amount: "100.00" },
             },
             {
               __typename: "TaxLine",
               displayName: "Tax",
-              amount: { amount: "400" },
+              amount: { amount: "400.00" },
             },
             {
               __typename: "TotalLine",
               displayName: "Total",
-              amount: { amount: "5,500" },
+              amount: { amount: "5,500.00" },
             },
           ])
         })

--- a/src/schema/v2/order/types/PricingBreakdownLines.ts
+++ b/src/schema/v2/order/types/PricingBreakdownLines.ts
@@ -8,7 +8,6 @@ import {
 import {
   Money,
   resolveMinorAndCurrencyFieldsToMoney,
-  deriveCurrencyFormatFromAmounts,
 } from "schema/v2/fields/money"
 import { OrderJSON, FulfillmentOptionJson } from "./exchangeJson"
 import { OfferJSON } from "./OfferType"
@@ -135,25 +134,13 @@ export const resolveOrderPricingBreakdownLines = (
     selected_fulfillment_option: selectedFulfillmentOption,
   } = order
 
-  const amounts = [
-    itemsTotalCents,
-    shippingTotalCents,
-    taxTotalCents,
-    buyerTotalCents,
-  ]
-
-  const { format, exact } = deriveCurrencyFormatFromAmounts(
-    currencyCode,
-    amounts
-  )
-
   const resolveMoney = (amount: number) => {
     return resolveMinorAndCurrencyFieldsToMoney(
       {
         minor: amount,
         currencyCode,
-        format,
-        exact,
+        format: "0,0.00",
+        exact: true,
       },
       args,
       context,
@@ -263,25 +250,13 @@ export const resolveOfferPricingBreakdownLines = (
     _selectedFulfillmentOptionType,
   } = offer
 
-  const amounts = [
-    amountCents,
-    shippingTotalCents,
-    taxTotalCents,
-    buyerTotalCents,
-  ]
-
-  const { format, exact } = deriveCurrencyFormatFromAmounts(
-    currencyCode,
-    amounts
-  )
-
   const resolveMoney = (amount: number) => {
     return resolveMinorAndCurrencyFieldsToMoney(
       {
         minor: amount,
         currencyCode,
-        format,
-        exact,
+        format: "0,0.00",
+        exact: true,
       },
       args,
       context,


### PR DESCRIPTION
address https://artsyproduct.atlassian.net/browse/EMI-3249

We also have this logic applied when we determine `fulfillmentOptions` but think it's ok to keep it there? Though maybe not needed either? Not sure. I guess we can do this part and test to see if it would be more clear if all shipping options came with decimals as well?