### PR TITLE
feat: delete edition set from update artwork mutation

### DIFF
--- a/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/updateArtworkMutation.test.ts
@@ -968,6 +968,7 @@ describe("UpdateArtworkMutation", () => {
         updateArtworkLoader,
         updateArtworkEditionSetLoader,
         createArtworkEditionSetLoader,
+        deleteArtworkEditionSetLoader: jest.fn(),
       }
 
       await runAuthenticatedQuery(convertMutation, context)
@@ -1033,6 +1034,7 @@ describe("UpdateArtworkMutation", () => {
         updateArtworkLoader,
         updateArtworkEditionSetLoader,
         createArtworkEditionSetLoader,
+        deleteArtworkEditionSetLoader: jest.fn(),
       }
 
       await runAuthenticatedQuery(updateMutation, context)
@@ -1040,6 +1042,60 @@ describe("UpdateArtworkMutation", () => {
       expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
       expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
         { artworkId: "25", editionSetId: "set-1" },
+        expect.objectContaining({ edition_size: "15" })
+      )
+    })
+
+    it("deletes edition sets when id and delete: true are provided", async () => {
+      const createArtworkEditionSetLoader = jest.fn()
+      const updateArtworkEditionSetLoader = jest.fn()
+      const deleteArtworkEditionSetLoader = jest.fn().mockResolvedValue({})
+      const updateArtworkLoader = jest.fn().mockResolvedValue({
+        id: "25",
+        _id: "25",
+      })
+
+      const deleteMutation = gql`
+        mutation {
+          updateArtwork(
+            input: {
+              id: "25"
+              editionSets: [
+                { id: "set-1", delete: true }
+                { id: "set-2", editionSize: "15" }
+              ]
+            }
+          ) {
+            artworkOrError {
+              __typename
+              ... on updateArtworkSuccess {
+                artwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        updateArtworkLoader,
+        updateArtworkEditionSetLoader,
+        createArtworkEditionSetLoader,
+        deleteArtworkEditionSetLoader,
+      }
+
+      await runAuthenticatedQuery(deleteMutation, context)
+
+      expect(createArtworkEditionSetLoader).not.toHaveBeenCalled()
+      expect(deleteArtworkEditionSetLoader).toHaveBeenCalledTimes(1)
+      expect(deleteArtworkEditionSetLoader).toHaveBeenCalledWith({
+        artworkId: "25",
+        editionSetId: "set-1",
+      })
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledTimes(1)
+      expect(updateArtworkEditionSetLoader).toHaveBeenCalledWith(
+        { artworkId: "25", editionSetId: "set-2" },
         expect.objectContaining({ edition_size: "15" })
       )
     })

--- a/src/schema/v2/artwork/updateArtworkMutation.ts
+++ b/src/schema/v2/artwork/updateArtworkMutation.ts
@@ -340,6 +340,7 @@ export const updateArtworkMutation = mutationWithClientMutationId<
       updateArtworkLoader,
       updateArtworkEditionSetLoader,
       createArtworkEditionSetLoader,
+      deleteArtworkEditionSetLoader,
       addImageToArtworkLoader,
       setDefaultArtworkImageLoader,
     }
@@ -347,7 +348,8 @@ export const updateArtworkMutation = mutationWithClientMutationId<
     if (
       !updateArtworkLoader ||
       !updateArtworkEditionSetLoader ||
-      !createArtworkEditionSetLoader
+      !createArtworkEditionSetLoader ||
+      !deleteArtworkEditionSetLoader
     ) {
       return new Error("You need to be signed in to perform this action")
     }
@@ -431,6 +433,13 @@ export const updateArtworkMutation = mutationWithClientMutationId<
         await Promise.all(
           editionSets.map((editionSet) => {
             if (editionSet.id) {
+              if (editionSet.delete) {
+                return deleteArtworkEditionSetLoader({
+                  artworkId: id,
+                  editionSetId: editionSet.id,
+                })
+              }
+
               return updateArtworkEditionSetLoader(
                 {
                   artworkId: id,


### PR DESCRIPTION
Support deleting edition sets from update artwork mutation so that ArtOS "Edit Edition Set" modal works as expected

@artsy/amber-devs 