### PR TITLE
fix: avoid caching identical posts

### DIFF
--- a/src/lib/loaders/__tests__/api.test.ts
+++ b/src/lib/loaders/__tests__/api.test.ts
@@ -56,6 +56,21 @@ describe("API loaders", () => {
       })
     })
 
+    it("does not coalesce identical calls for non-GET methods", () => {
+      const postLoader = apiLoader(
+        "some/post/no-coalesce/path",
+        {},
+        { method: "POST" }
+      )
+      const callsBefore = api.mock.calls.length
+      return Promise.all([
+        postLoader({ same: "payload" }),
+        postLoader({ same: "payload" }),
+      ]).then(() => {
+        expect(api.mock.calls.length - callsBefore).toEqual(2)
+      })
+    })
+
     it("passes options for the api function on", () => {
       // Needs to be a new path so that it hasn’t been cached in memcache yet
       loader = apiLoader("some/post/path", {}, { method: "POST" })

--- a/src/lib/loaders/api/loader_with_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_with_authentication_factory.ts
@@ -4,7 +4,7 @@ import { verbose, warn } from "lib/loggers"
 import timer from "lib/timer"
 import { pick } from "lodash"
 import { LoaderFactory } from "../index"
-import { DataLoaderKey } from "./index"
+import { APIOptions, DataLoaderKey } from "./index"
 import { loaderInterface } from "./loader_interface"
 
 /**
@@ -27,6 +27,9 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
 ) => {
   return (accessTokenLoader) => {
     const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
+      const method = (pathAPIOptions as APIOptions).method
+      const isMutatingMethod = !!method && method !== "GET"
+
       const loader = new DataLoader<
         DataLoaderKey,
         T | { body: T; headers: any }
@@ -82,7 +85,7 @@ export const apiLoaderWithAuthenticationFactory = <T = any>(
         },
         {
           batch: false,
-          cache: true,
+          cache: !isMutatingMethod,
           cacheKeyFn: (input) => JSON.stringify(input),
         }
       )

--- a/src/lib/loaders/api/loader_without_authentication_factory.ts
+++ b/src/lib/loaders/api/loader_without_authentication_factory.ts
@@ -41,6 +41,9 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
   globalAPIOptions: APIOptions = {}
 ) => {
   const apiLoaderFactory = (path, globalParams = {}, pathAPIOptions = {}) => {
+    const method = (pathAPIOptions as APIOptions).method
+    const isMutatingMethod = !!method && method !== "GET"
+
     const loader = new DataLoader<DataLoaderKey, T | { body: T; headers: any }>(
       (keys) =>
         Promise.all<any>(
@@ -161,7 +164,7 @@ export const apiLoaderWithoutAuthenticationFactory = <T = any>(
         ),
       {
         batch: false,
-        cache: true,
+        cache: !isMutatingMethod,
         cacheKeyFn: (input) => JSON.stringify(input),
       }
     )


### PR DESCRIPTION
Ran into an issue where creating multiple editions with the same inventory count ends up only creating a single edition. Traced this down to a cache in the loaders which I believe shouldn't be necessary for methods other than GET.

Before:

https://github.com/user-attachments/assets/790e0405-69ce-4de9-9702-b1617c75c528


After:

https://github.com/user-attachments/assets/46b14fe6-6808-4a09-8495-5d40d126e8ee

@artsy/amber-devs 