### PR TITLE
chore: add `fields` to syncCatalogToArtwork mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5931,6 +5931,13 @@ type CatalogArtworkDocument {
   ): String
 }
 
+# Fields that can be synced from catalog artwork (OS) to CMS.
+enum CatalogSyncableField {
+  AVAILABILITY
+  MEDIUM
+  PRICE
+}
+
 type CausalityLotState {
   bidCount: Int
   floorSellingPrice: Money
@@ -26746,6 +26753,9 @@ input SyncCatalogToArtworkMutationInput {
   # The ID of the artwork to sync.
   artworkID: String!
   clientMutationId: String
+
+  # Specific fields to sync. Omit to sync all.
+  fields: [CatalogSyncableField]
 }
 
 type SyncCatalogToArtworkMutationPayload {

--- a/src/schema/v2/artwork/__tests__/syncCatalogToArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/syncCatalogToArtworkMutation.test.ts
@@ -87,6 +87,66 @@ describe("SyncCatalogToArtworkMutation", () => {
     })
   })
 
+  describe("with fields parameter", () => {
+    const fieldsQuery = gql`
+      mutation {
+        syncCatalogToArtwork(
+          input: { artworkID: "artwork-123", fields: [PRICE] }
+        ) {
+          artworkOrError {
+            __typename
+            ... on SyncCatalogToArtworkSuccess {
+              syncedFields
+            }
+          }
+        }
+      }
+    `
+
+    it("forwards fields to the loader", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: jest.fn(() =>
+          Promise.resolve({
+            success: true,
+            synced_fields: ["price"],
+            errors: [],
+          })
+        ),
+        artworkLoader: jest.fn(() =>
+          Promise.resolve({ _id: "artwork-123", id: "artwork-slug" })
+        ),
+      }
+
+      await runAuthenticatedQuery(fieldsQuery, context)
+
+      expect(
+        context.syncCatalogToArtworkLoader
+      ).toHaveBeenCalledWith("artwork-123", { fields: ["price"] })
+    })
+
+    it("passes empty params when fields is omitted", async () => {
+      const context = {
+        syncCatalogToArtworkLoader: jest.fn(() =>
+          Promise.resolve({
+            success: true,
+            synced_fields: ["availability", "medium", "price"],
+            errors: [],
+          })
+        ),
+        artworkLoader: jest.fn(() =>
+          Promise.resolve({ _id: "artwork-123", id: "artwork-slug" })
+        ),
+      }
+
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(context.syncCatalogToArtworkLoader).toHaveBeenCalledWith(
+        "artwork-123",
+        {}
+      )
+    })
+  })
+
   describe("on API failure", () => {
     it("returns a mutation error", async () => {
       const context = {

--- a/src/schema/v2/artwork/syncCatalogToArtworkMutation.ts
+++ b/src/schema/v2/artwork/syncCatalogToArtworkMutation.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLEnumType,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -13,8 +14,19 @@ import {
 import { ResolverContext } from "types/graphql"
 import Artwork from "schema/v2/artwork"
 
+const CatalogSyncableFieldEnum = new GraphQLEnumType({
+  name: "CatalogSyncableField",
+  description: "Fields that can be synced from catalog artwork (OS) to CMS.",
+  values: {
+    AVAILABILITY: { value: "availability" },
+    MEDIUM: { value: "medium" },
+    PRICE: { value: "price" },
+  },
+})
+
 interface SyncCatalogToArtworkMutationInputProps {
   artworkID: string
+  fields?: string[]
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -67,6 +79,10 @@ export const syncCatalogToArtworkMutation = mutationWithClientMutationId<
       type: new GraphQLNonNull(GraphQLString),
       description: "The ID of the artwork to sync.",
     },
+    fields: {
+      type: new GraphQLList(CatalogSyncableFieldEnum),
+      description: "Specific fields to sync. Omit to sync all.",
+    },
   },
   outputFields: {
     artworkOrError: {
@@ -77,7 +93,7 @@ export const syncCatalogToArtworkMutation = mutationWithClientMutationId<
     },
   },
   mutateAndGetPayload: async (
-    { artworkID },
+    { artworkID, fields },
     { syncCatalogToArtworkLoader }
   ) => {
     if (!syncCatalogToArtworkLoader) {
@@ -85,7 +101,8 @@ export const syncCatalogToArtworkMutation = mutationWithClientMutationId<
     }
 
     try {
-      const response = await syncCatalogToArtworkLoader(artworkID)
+      const params = fields?.length ? { fields } : {}
+      const response = await syncCatalogToArtworkLoader(artworkID, params)
       return { ...response, artworkID, _type: "SyncCatalogToArtworkSuccess" }
     } catch (error) {
       const formattedErr = formatGravityError(error)


### PR DESCRIPTION
Following from https://github.com/artsy/gravity/pull/20148 - adds support for `fields` on the sync mutation.