### PR TITLE
chore: Require html content for Mailchimp Campaigns mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10868,12 +10868,12 @@ type CreateMailchimpCampaignFailure {
 }
 
 input CreateMailchimpCampaignInput {
-  # Artwork IDs to associate with the campaign (mutually exclusive with partnerShowId; used to render content unless htmlContent is provided)
+  # Artwork IDs to associate with the campaign for tracking (mutually exclusive with partnerShowId)
   artworkIds: [String!]
   clientMutationId: String
 
-  # Pre-rendered HTML body for the campaign. When provided, supersedes the formatter's output but does not preclude tracking via artworkIds or partnerShowId
-  htmlContent: String
+  # Pre-rendered HTML body for the campaign
+  htmlContent: String!
 
   # The Mailchimp list/audience ID to send the campaign to
   listId: String!
@@ -10881,7 +10881,7 @@ input CreateMailchimpCampaignInput {
   # The internal ID of the Mailchimp account to use
   mailchimpAccountId: String!
 
-  # Partner show ID to associate with the campaign (mutually exclusive with artworkIds; used to render content unless htmlContent is provided)
+  # Partner show ID to associate with the campaign for tracking (mutually exclusive with artworkIds)
   partnerShowId: String
 
   # The email preview text
@@ -18781,7 +18781,7 @@ type Mutation {
     input: CreateInvoicePaymentInput!
   ): CreateInvoicePaymentPayload
 
-  # Create a Mailchimp campaign draft for a partner
+  # Create a Mailchimp campaign draft for a partner from pre-rendered HTML
   createMailchimpCampaign(
     input: CreateMailchimpCampaignInput!
   ): CreateMailchimpCampaignPayload

--- a/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
+++ b/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
@@ -8,7 +8,7 @@ const mutation = `
       mailchimpAccountId: "mc-account-1"
       subjectLine: "New Artworks from Acme Gallery"
       listId: "list-1"
-      artworkIds: ["artwork-1", "artwork-2"]
+      htmlContent: "<html><body>Partner-authored content</body></html>"
     }) {
       mailchimpCampaignOrError {
         __typename
@@ -39,83 +39,103 @@ const mockGravityResponse = {
 }
 
 describe("createMailchimpCampaign", () => {
-  describe("with artworkIds", () => {
-    let context: Partial<ResolverContext>
+  let context: Partial<ResolverContext>
 
-    beforeEach(() => {
-      context = {
-        createMailchimpCampaignLoader: jest
-          .fn()
-          .mockResolvedValue(mockGravityResponse),
-      }
-    })
+  beforeEach(() => {
+    context = {
+      createMailchimpCampaignLoader: jest
+        .fn()
+        .mockResolvedValue(mockGravityResponse),
+    }
+  })
 
-    it("passes correct args to Gravity", async () => {
-      await runAuthenticatedQuery(mutation, context)
+  it("passes correct args to Gravity", async () => {
+    await runAuthenticatedQuery(mutation, context)
 
-      expect(
-        context.createMailchimpCampaignLoader as jest.Mock
-      ).toHaveBeenCalledWith({
-        mailchimp_account_id: "mc-account-1",
-        subject_line: "New Artworks from Acme Gallery",
-        list_id: "list-1",
-        artwork_ids: ["artwork-1", "artwork-2"],
-        partner_show_id: undefined,
-        html_content: undefined,
-        preview_text: undefined,
-      })
-    })
-
-    it("returns the created campaign on success", async () => {
-      const result = await runAuthenticatedQuery(mutation, context)
-
-      expect(result).toMatchInlineSnapshot(`
-        {
-          "createMailchimpCampaign": {
-            "mailchimpCampaignOrError": {
-              "__typename": "CreateMailchimpCampaignSuccess",
-              "mailchimpCampaign": {
-                "internalID": "campaign-1",
-                "status": "DRAFT",
-                "subjectLine": "New Artworks from Acme Gallery",
-              },
-            },
-          },
-        }
-      `)
+    expect(
+      context.createMailchimpCampaignLoader as jest.Mock
+    ).toHaveBeenCalledWith({
+      mailchimp_account_id: "mc-account-1",
+      subject_line: "New Artworks from Acme Gallery",
+      list_id: "list-1",
+      artwork_ids: undefined,
+      partner_show_id: undefined,
+      html_content: "<html><body>Partner-authored content</body></html>",
+      preview_text: undefined,
     })
   })
 
-  describe("with partnerShowId", () => {
-    const mutationWithShow = `
+  it("returns the created campaign on success", async () => {
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "createMailchimpCampaign": {
+          "mailchimpCampaignOrError": {
+            "__typename": "CreateMailchimpCampaignSuccess",
+            "mailchimpCampaign": {
+              "internalID": "campaign-1",
+              "status": "DRAFT",
+              "subjectLine": "New Artworks from Acme Gallery",
+            },
+          },
+        },
+      }
+    `)
+  })
+
+  describe("with artworkIds for tracking", () => {
+    const mutationWithArtworks = `
       mutation {
         createMailchimpCampaign(input: {
           mailchimpAccountId: "mc-account-1"
-          subjectLine: "Gallery Show"
+          subjectLine: "Custom Campaign"
           listId: "list-1"
-          partnerShowId: "show-1"
+          htmlContent: "<html><body>Partner-authored content</body></html>"
+          artworkIds: ["artwork-1", "artwork-2"]
         }) {
           mailchimpCampaignOrError {
             __typename
-            ... on CreateMailchimpCampaignSuccess {
-              mailchimpCampaign {
-                internalID
-                subjectLine
-                status
-              }
-            }
           }
         }
       }
     `
 
     it("passes correct args to Gravity", async () => {
-      const context: Partial<ResolverContext> = {
-        createMailchimpCampaignLoader: jest
-          .fn()
-          .mockResolvedValue(mockGravityResponse),
-      }
+      await runAuthenticatedQuery(mutationWithArtworks, context)
 
+      expect(
+        context.createMailchimpCampaignLoader as jest.Mock
+      ).toHaveBeenCalledWith({
+        mailchimp_account_id: "mc-account-1",
+        subject_line: "Custom Campaign",
+        list_id: "list-1",
+        artwork_ids: ["artwork-1", "artwork-2"],
+        partner_show_id: undefined,
+        html_content: "<html><body>Partner-authored content</body></html>",
+        preview_text: undefined,
+      })
+    })
+  })
+
+  describe("with partnerShowId for tracking", () => {
+    const mutationWithShow = `
+      mutation {
+        createMailchimpCampaign(input: {
+          mailchimpAccountId: "mc-account-1"
+          subjectLine: "Gallery Show"
+          listId: "list-1"
+          htmlContent: "<html><body>Partner-authored content</body></html>"
+          partnerShowId: "show-1"
+        }) {
+          mailchimpCampaignOrError {
+            __typename
+          }
+        }
+      }
+    `
+
+    it("passes correct args to Gravity", async () => {
       await runAuthenticatedQuery(mutationWithShow, context)
 
       expect(
@@ -126,89 +146,6 @@ describe("createMailchimpCampaign", () => {
         list_id: "list-1",
         artwork_ids: undefined,
         partner_show_id: "show-1",
-        html_content: undefined,
-        preview_text: undefined,
-      })
-    })
-  })
-
-  describe("with htmlContent", () => {
-    const mutationWithHtml = `
-      mutation {
-        createMailchimpCampaign(input: {
-          mailchimpAccountId: "mc-account-1"
-          subjectLine: "Custom Campaign"
-          listId: "list-1"
-          htmlContent: "<html><body>Partner-authored content</body></html>"
-        }) {
-          mailchimpCampaignOrError {
-            __typename
-            ... on CreateMailchimpCampaignSuccess {
-              mailchimpCampaign {
-                internalID
-                subjectLine
-                status
-              }
-            }
-          }
-        }
-      }
-    `
-
-    it("passes correct args to Gravity", async () => {
-      const context: Partial<ResolverContext> = {
-        createMailchimpCampaignLoader: jest
-          .fn()
-          .mockResolvedValue(mockGravityResponse),
-      }
-
-      await runAuthenticatedQuery(mutationWithHtml, context)
-
-      expect(
-        context.createMailchimpCampaignLoader as jest.Mock
-      ).toHaveBeenCalledWith({
-        mailchimp_account_id: "mc-account-1",
-        subject_line: "Custom Campaign",
-        list_id: "list-1",
-        artwork_ids: undefined,
-        partner_show_id: undefined,
-        html_content: "<html><body>Partner-authored content</body></html>",
-        preview_text: undefined,
-      })
-    })
-
-    it("can be combined with artworkIds for tracking", async () => {
-      const mutationWithHtmlAndArtworks = `
-        mutation {
-          createMailchimpCampaign(input: {
-            mailchimpAccountId: "mc-account-1"
-            subjectLine: "Custom Campaign"
-            listId: "list-1"
-            htmlContent: "<html><body>Partner-authored content</body></html>"
-            artworkIds: ["artwork-1", "artwork-2"]
-          }) {
-            mailchimpCampaignOrError {
-              __typename
-            }
-          }
-        }
-      `
-      const context: Partial<ResolverContext> = {
-        createMailchimpCampaignLoader: jest
-          .fn()
-          .mockResolvedValue(mockGravityResponse),
-      }
-
-      await runAuthenticatedQuery(mutationWithHtmlAndArtworks, context)
-
-      expect(
-        context.createMailchimpCampaignLoader as jest.Mock
-      ).toHaveBeenCalledWith({
-        mailchimp_account_id: "mc-account-1",
-        subject_line: "Custom Campaign",
-        list_id: "list-1",
-        artwork_ids: ["artwork-1", "artwork-2"],
-        partner_show_id: undefined,
         html_content: "<html><body>Partner-authored content</body></html>",
         preview_text: undefined,
       })
@@ -222,6 +159,7 @@ describe("createMailchimpCampaign", () => {
           mailchimpAccountId: "mc-account-1"
           subjectLine: "Test"
           listId: "list-1"
+          htmlContent: "<html><body>Partner-authored content</body></html>"
           artworkIds: ["artwork-1"]
           partnerShowId: "show-1"
         }) {
@@ -233,10 +171,6 @@ describe("createMailchimpCampaign", () => {
     `
 
     it("throws when both artworkIds and partnerShowId are provided", async () => {
-      const context: Partial<ResolverContext> = {
-        createMailchimpCampaignLoader: jest.fn(),
-      }
-
       await expect(
         runAuthenticatedQuery(mutationWithBoth, context)
       ).rejects.toThrow(
@@ -256,9 +190,9 @@ describe("createMailchimpCampaign", () => {
       400,
       gravityResponseBody
     )
-    const context: Partial<ResolverContext> = {
-      createMailchimpCampaignLoader: jest.fn().mockRejectedValue(error),
-    }
+    ;(context.createMailchimpCampaignLoader as jest.Mock).mockRejectedValue(
+      error
+    )
 
     const result = await runAuthenticatedQuery(mutation, context)
 

--- a/src/schema/v2/createMailchimpCampaignMutation.ts
+++ b/src/schema/v2/createMailchimpCampaignMutation.ts
@@ -17,7 +17,7 @@ interface Input {
   mailchimpAccountId: string
   artworkIds?: string[]
   partnerShowId?: string
-  htmlContent?: string
+  htmlContent: string
   subjectLine: string
   previewText?: string
   listId: string
@@ -62,26 +62,26 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "CreateMailchimpCampaign",
-  description: "Create a Mailchimp campaign draft for a partner",
+  description:
+    "Create a Mailchimp campaign draft for a partner from pre-rendered HTML",
   inputFields: {
     mailchimpAccountId: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The internal ID of the Mailchimp account to use",
     },
+    htmlContent: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Pre-rendered HTML body for the campaign",
+    },
     artworkIds: {
       type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
       description:
-        "Artwork IDs to associate with the campaign (mutually exclusive with partnerShowId; used to render content unless htmlContent is provided)",
+        "Artwork IDs to associate with the campaign for tracking (mutually exclusive with partnerShowId)",
     },
     partnerShowId: {
       type: GraphQLString,
       description:
-        "Partner show ID to associate with the campaign (mutually exclusive with artworkIds; used to render content unless htmlContent is provided)",
-    },
-    htmlContent: {
-      type: GraphQLString,
-      description:
-        "Pre-rendered HTML body for the campaign. When provided, supersedes the formatter's output but does not preclude tracking via artworkIds or partnerShowId",
+        "Partner show ID to associate with the campaign for tracking (mutually exclusive with artworkIds)",
     },
     subjectLine: {
       type: new GraphQLNonNull(GraphQLString),


### PR DESCRIPTION
This PR resolves [notion card](https://www.notion.so/artsy/Clean-up-the-old-template-approach-from-Gravity-358cab0764a080bf8a3fc1d96f54ff4a)

Relates to https://github.com/artsy/gravity/pull/20149

Now that html content is the only way to define the template for a Mailchimp campaign, our mutation must reflect that by making it required. Also update comments/descriptions to match the new expectations and remove redundant tests.

cc @artsy/amber-devs 