### PR TITLE
feat: remove unnecessary [U.K.] disambiguation for United Kingdom and introduce new shippingOriginDisplayName field on artwork.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3211,6 +3211,9 @@ type Artwork implements Node & Searchable & Sellable {
 
   # Minimal location information describing from where artwork will be shipped.
   shippingOrigin: String
+
+  # Display name of the shipping origin country or region (e.g., 'United Kingdom', 'European Union'). Returns empty string if shipping origin is not set.
+  shippingOriginDisplayName: String
   shippingWeight: Float
 
   # The unit of measurement for the shipping weight

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3213,7 +3213,7 @@ type Artwork implements Node & Searchable & Sellable {
   shippingOrigin: String
 
   # Display name of the shipping origin country or region (e.g., 'United Kingdom', 'European Union'). Returns empty string if shipping origin is not set.
-  shippingOriginDisplayName: String
+  shippingOriginRegion: String
   shippingWeight: Float
 
   # The unit of measurement for the shipping weight

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3625,6 +3625,64 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#shippingOriginDisplayName", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          shippingOriginDisplayName
+        }
+      }
+    `
+
+    it("returns empty string when shipping_origin is null", () => {
+      artwork.shipping_origin = null
+      artwork.eu_shipping_origin = false
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOriginDisplayName: "",
+          },
+        })
+      })
+    })
+
+    it("returns the country display name when shipping_origin is present", () => {
+      artwork.shipping_origin = ["New York", "NY", "US"]
+      artwork.eu_shipping_origin = false
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOriginDisplayName: "United States",
+          },
+        })
+      })
+    })
+
+    it("returns 'European Union' when eu_shipping_origin is true", () => {
+      artwork.shipping_origin = ["Paris", "FR"]
+      artwork.eu_shipping_origin = true
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOriginDisplayName: "European Union",
+          },
+        })
+      })
+    })
+
+    it("returns the country name when eu_shipping_origin is false", () => {
+      artwork.shipping_origin = ["London", "GB"]
+      artwork.eu_shipping_origin = false
+      return runQuery(query, context).then((data) => {
+        expect(data).toEqual({
+          artwork: {
+            shippingOriginDisplayName: "United Kingdom",
+          },
+        })
+      })
+    })
+  })
+
   describe("#vatRequirementComplete", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -2850,7 +2850,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             shippingInfo:
-              "Domestic: £10 within United Kingdom [U.K.] \nInternational: £210",
+              "Domestic: £10 within United Kingdom \nInternational: £210",
           },
         })
       })
@@ -2892,7 +2892,7 @@ describe("Artwork type", () => {
         expect(data).toEqual({
           artwork: {
             shippingInfo:
-              "Domestic: Free within United Kingdom [U.K.] \nInternational: Free",
+              "Domestic: Free within United Kingdom \nInternational: Free",
           },
         })
       })

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -3625,11 +3625,11 @@ describe("Artwork type", () => {
     })
   })
 
-  describe("#shippingOriginDisplayName", () => {
+  describe("#shippingOriginRegion", () => {
     const query = `
       {
         artwork(id: "richard-prince-untitled-portrait") {
-          shippingOriginDisplayName
+          shippingOriginRegion
         }
       }
     `
@@ -3640,7 +3640,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
-            shippingOriginDisplayName: "",
+            shippingOriginRegion: "",
           },
         })
       })
@@ -3652,7 +3652,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
-            shippingOriginDisplayName: "United States",
+            shippingOriginRegion: "United States",
           },
         })
       })
@@ -3664,7 +3664,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
-            shippingOriginDisplayName: "European Union",
+            shippingOriginRegion: "European Union",
           },
         })
       })
@@ -3676,7 +3676,7 @@ describe("Artwork type", () => {
       return runQuery(query, context).then((data) => {
         expect(data).toEqual({
           artwork: {
-            shippingOriginDisplayName: "United Kingdom",
+            shippingOriginRegion: "United Kingdom",
           },
         })
       })

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -57,7 +57,7 @@ import Image, {
   normalizeImageData,
 } from "schema/v2/image"
 import { setVersion } from "schema/v2/image/normalize"
-import { COUNTRIES, LocationType } from "schema/v2/location"
+import { LocationType } from "schema/v2/location"
 import {
   CollectionsConnectionType,
   CollectionSorts,
@@ -102,6 +102,7 @@ import { TaxInfo } from "./taxInfo"
 import {
   embed,
   getFigures,
+  getShippingOriginDisplayName,
   isEligibleForOnPlatformTransaction,
   isEligibleToCreateAlert,
   isEmbeddedVideo,
@@ -1607,14 +1608,11 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           let domesticLine = ""
           let internationalLine = "Contact gallery"
 
-          const fullCountryName = artwork.shipping_origin
-            ? COUNTRIES[
-                artwork.shipping_origin[artwork.shipping_origin.length - 1]
-              ]
-            : "country"
-          const withingCountry = artwork.eu_shipping_origin
-            ? "European Union"
-            : fullCountryName
+          const withingCountry = getShippingOriginDisplayName(
+            artwork.shipping_origin,
+            artwork.eu_shipping_origin,
+            "country"
+          )
 
           // domestic related
           if (artwork.process_with_artsy_shipping_domestic) {
@@ -1657,6 +1655,17 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           "Minimal location information describing from where artwork will be shipped.",
         resolve: (artwork) => {
           return artwork.shipping_origin && artwork.shipping_origin.join(", ")
+        },
+      },
+      shippingOriginDisplayName: {
+        type: GraphQLString,
+        description:
+          "Display name of the shipping origin country or region (e.g., 'United Kingdom', 'European Union'). Returns empty string if shipping origin is not set.",
+        resolve: (artwork) => {
+          return getShippingOriginDisplayName(
+            artwork.shipping_origin,
+            artwork.eu_shipping_origin
+          )
         },
       },
       submissionId: {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -102,7 +102,7 @@ import { TaxInfo } from "./taxInfo"
 import {
   embed,
   getFigures,
-  getShippingOriginDisplayName,
+  getDomesticShippingRegionName,
   isEligibleForOnPlatformTransaction,
   isEligibleToCreateAlert,
   isEmbeddedVideo,
@@ -1608,7 +1608,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           let domesticLine = ""
           let internationalLine = "Contact gallery"
 
-          const withingCountry = getShippingOriginDisplayName(
+          const shipsWithin = getDomesticShippingRegionName(
             artwork.shipping_origin,
             artwork.eu_shipping_origin,
             "country"
@@ -1618,7 +1618,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           if (artwork.process_with_artsy_shipping_domestic) {
             domesticLine = "Calculated in checkout"
           } else if (artwork.domestic_shipping_fee_cents === 0) {
-            domesticLine = `Free within ${withingCountry}`
+            domesticLine = `Free within ${shipsWithin}`
           } else if (artwork.domestic_shipping_fee_cents > 0) {
             const formattedPrice = amount(
               ({ domestic_shipping_fee_cents }) =>
@@ -1627,7 +1627,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
               precision: 0,
               symbol: symbolFromCurrencyCode(artwork.price_currency),
             })
-            domesticLine = `${formattedPrice} within ${withingCountry}`
+            domesticLine = `${formattedPrice} within ${shipsWithin}`
           }
 
           // international related
@@ -1657,12 +1657,12 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
           return artwork.shipping_origin && artwork.shipping_origin.join(", ")
         },
       },
-      shippingOriginDisplayName: {
+      shippingOriginRegion: {
         type: GraphQLString,
         description:
           "Display name of the shipping origin country or region (e.g., 'United Kingdom', 'European Union'). Returns empty string if shipping origin is not set.",
         resolve: (artwork) => {
-          return getShippingOriginDisplayName(
+          return getDomesticShippingRegionName(
             artwork.shipping_origin,
             artwork.eu_shipping_origin
           )

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -4,6 +4,7 @@ import { Artwork } from "types/runtime/gravity"
 import { parse } from "url"
 import { normalizeImageData } from "../image"
 import mediums from "lib/artworkMediums"
+import { COUNTRIES } from "../location"
 
 export const isTwoDimensional = ({
   width_cm,
@@ -141,4 +142,18 @@ export const isEligibleToCreateAlert = (artwork: {
   if (category == mediums.Other.name) return false
 
   return true
+}
+
+export const getShippingOriginDisplayName = (
+  shippingOrigin: string[] | null,
+  euShippingOrigin: boolean,
+  fallback = ""
+): string => {
+  if (!shippingOrigin) {
+    return fallback
+  }
+
+  const countryName = COUNTRIES[shippingOrigin[shippingOrigin.length - 1]]
+
+  return euShippingOrigin ? "European Union" : countryName
 }

--- a/src/schema/v2/artwork/utilities.ts
+++ b/src/schema/v2/artwork/utilities.ts
@@ -144,7 +144,7 @@ export const isEligibleToCreateAlert = (artwork: {
   return true
 }
 
-export const getShippingOriginDisplayName = (
+export const getDomesticShippingRegionName = (
   shippingOrigin: string[] | null,
   euShippingOrigin: boolean,
   fallback = ""
@@ -155,5 +155,5 @@ export const getShippingOriginDisplayName = (
 
   const countryName = COUNTRIES[shippingOrigin[shippingOrigin.length - 1]]
 
-  return euShippingOrigin ? "European Union" : countryName
+  return euShippingOrigin ? "European Union" : countryName ?? fallback
 }

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -279,7 +279,7 @@ export const COUNTRIES = {
   FO: "Faroe Islands",
   FR: "France",
   GA: "Gabon",
-  GB: "United Kingdom [U.K.]",
+  GB: "United Kingdom",
   GD: "Grenada",
   GE: "Georgia",
   GF: "French Guiana",


### PR DESCRIPTION
Part of looking at shipping info and needing to display country names in limited space for error messaging realizing this additional `[U.K.]` is not really needed and does not add any info. So cleaning it up.

This list to seem also be duplicated in Volt for partner location usage and in Induction for credit card usage but don't think there is any harm in updating just this MP location for now. Can go back and update the other ones or maybe as future refactor to make our repos share one Location mapping file but that is a different story.