### PR TITLE
feat(recs): add gravity resolver for WTYL

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -11,6 +11,7 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
 const FEATURE_FLAGS_LIST = [
   "onyx_nwfy-artworks-card-test",
   "diamond_artwork-title-experiment",
+  "onyx_artwork-recommendations-gravity",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -102,6 +102,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
+    artworkRecommendationsLoader: gravityLoader("artwork_recommendations"),
     artworkImportLoader: gravityLoader((id) => `artwork_import/${id}`),
     artworkImportMatchImagesLoader: gravityLoader(
       (id) => `artwork_import/${id}/match_images`,

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -1,8 +1,21 @@
 /* eslint-disable promise/always-return */
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
+jest.mock("lib/featureFlags", () => ({
+  isFeatureFlagEnabled: jest.fn(() => false),
+}))
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+
 describe("artworkRecommendations", () => {
+  afterEach(() => {
+    mockIsFeatureFlagEnabled.mockReset()
+    mockIsFeatureFlagEnabled.mockReturnValue(false)
+  })
+
   const query = gql`
     {
       me {
@@ -119,6 +132,149 @@ describe("artworkRecommendations", () => {
 
     expect(vortexGraphqlLoader).toHaveBeenCalled()
     expect(artworksLoader).not.toHaveBeenCalled()
+  })
+
+  describe("when the WTYL Gravity recs flag is on", () => {
+    beforeEach(() => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true)
+    })
+
+    it("fetches IDs from the Gravity REST endpoint with the same response shape", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn(async () => ({
+        artwork_ids: ["608a7417bdfbd1a789ba092a", "308a7416bdfbd1a789ba0911"],
+      }))
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      const {
+        me: { artworkRecommendations },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).toHaveBeenCalledWith({ size: 50 })
+      expect(vortexGraphqlLoader).not.toHaveBeenCalled()
+      expect(artworksLoader).toHaveBeenCalledWith({
+        ids: ["608a7417bdfbd1a789ba092a", "308a7416bdfbd1a789ba0911"],
+      })
+
+      expect(artworkRecommendations).toMatchInlineSnapshot(`
+        {
+          "edges": [
+            {
+              "node": {
+                "internalID": "608a7417bdfbd1a789ba092a",
+                "slug": "gerhard-richter-abendstimmung-evening-calm-2",
+              },
+            },
+            {
+              "node": {
+                "internalID": "308a7416bdfbd1a789ba0911",
+                "slug": "pablo-picasso-deux-femmes-nues-dans-un-arbre-2",
+              },
+            },
+          ],
+          "totalCount": 2,
+        }
+      `)
+    })
+
+    it("treats a Gravity 404 (kill-switch) as an empty connection", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn(async () => {
+        throw new HTTPError("Not Found", 404)
+      })
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      const {
+        me: { artworkRecommendations },
+      } = await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendations).toMatchInlineSnapshot(`
+        {
+          "edges": [],
+          "totalCount": 0,
+        }
+      `)
+
+      expect(vortexGraphqlLoader).not.toHaveBeenCalled()
+      expect(artworksLoader).not.toHaveBeenCalled()
+    })
+
+    it("propagates a non-404 Gravity error instead of silently emptying", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn(async () => {
+        throw new HTTPError("Internal Server Error", 500)
+      })
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      await expect(runAuthenticatedQuery(query, context)).rejects.toThrow(
+        "Internal Server Error"
+      )
+      expect(vortexGraphqlLoader).not.toHaveBeenCalled()
+      expect(artworksLoader).not.toHaveBeenCalled()
+    })
+
+    it("stays on the Vortex path for impersonated/app requests", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn()
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        xImpersonateUserID: "impersonated-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+      }
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexGraphqlLoader).toHaveBeenCalled()
+    })
   })
 })
 

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -1,5 +1,6 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import { CursorPageable, pageable } from "relay-cursor-paging"
@@ -7,41 +8,30 @@ import { artworkConnection } from "schema/v2/artwork"
 import { createPageCursors } from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 
-// This limits the maximum number of artworks we receive from Vortex and is related to how we implement the Connection in this resolver.
+// This limits the maximum number of artworks we receive from the recommendation
+// backend and is related to how we implement the Connection in this resolver.
 const MAX_ARTWORKS = 50
 
-export const ArtworkRecommendations: GraphQLFieldConfig<
-  void,
-  ResolverContext
-> = {
-  description: "A connection of artwork recommendations for the current user.",
-  type: artworkConnection.connectionType,
-  args: pageable({
-    page: { type: GraphQLInt },
-  }),
-  resolve: async (
-    _root,
-    args: CursorPageable,
-    {
-      artworksLoader,
-      authenticatedLoaders: {
-        vortexGraphqlLoader: vortexGraphQLAuthenticatedLoader,
-      },
-      unauthenticatedLoaders: {
-        vortexGraphqlLoader: vortexGraphQLUnauthenticatedLoader,
-      },
-      xImpersonateUserID,
-      userID,
-    }
-  ) => {
-    if (!artworksLoader || !vortexGraphQLAuthenticatedLoader) return
+// WTYL canary: route to the Gravity REST endpoint (live) instead of Vortex
+// GraphQL (legacy daily-batch). Flipped per-user in the Unleash admin UI.
+const GRAVITY_RAIL_FLAG = "onyx_artwork-recommendations-gravity"
 
-    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+const getArtworkIdsFromVortex = async (
+  userId: string | undefined,
+  context: ResolverContext
+): Promise<string[]> => {
+  const {
+    authenticatedLoaders: {
+      vortexGraphqlLoader: vortexGraphQLAuthenticatedLoader,
+    },
+    unauthenticatedLoaders: {
+      vortexGraphqlLoader: vortexGraphQLUnauthenticatedLoader,
+    },
+    xImpersonateUserID,
+  } = context
 
-    const userId = userID || xImpersonateUserID
-    // Fetching artwork IDs from Vortex
-    const query = {
-      query: gql`
+  const query = {
+    query: gql`
         query artworkRecommendationsQuery {
           artworkRecommendations(first: ${MAX_ARTWORKS}, userId: "${userId}") {
             totalCount
@@ -54,31 +44,84 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
           }
         }
       `,
+  }
+
+  const vortexResult = xImpersonateUserID
+    ? await vortexGraphQLUnauthenticatedLoader!(query)()
+    : await vortexGraphQLAuthenticatedLoader!(query)()
+
+  return extractNodes(vortexResult.data?.artworkRecommendations).map(
+    (node: any) => node?.artworkId
+  )
+}
+
+const getArtworkIdsFromGravity = async (
+  context: ResolverContext
+): Promise<string[]> => {
+  const { artworkRecommendationsLoader } = context
+
+  try {
+    const { artwork_ids } = await artworkRecommendationsLoader!({
+      size: MAX_ARTWORKS,
+    })
+
+    return artwork_ids ?? []
+  } catch (err) {
+    if (err.statusCode === 404) {
+      return []
     }
+    throw err
+  }
+}
 
-    const vortexResult = xImpersonateUserID
-      ? await vortexGraphQLUnauthenticatedLoader(query)()
-      : await vortexGraphQLAuthenticatedLoader(query)()
+export const ArtworkRecommendations: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description: "A connection of artwork recommendations for the current user.",
+  type: artworkConnection.connectionType,
+  args: pageable({
+    page: { type: GraphQLInt },
+  }),
+  resolve: async (_root, args: CursorPageable, context) => {
+    const {
+      artworksLoader,
+      artworkRecommendationsLoader,
+      authenticatedLoaders: {
+        vortexGraphqlLoader: vortexGraphQLAuthenticatedLoader,
+      },
+      xImpersonateUserID,
+      userID,
+    } = context
 
-    const artworkRecommendations = extractNodes(
-      vortexResult.data?.artworkRecommendations
-    )
+    if (!artworksLoader || !vortexGraphQLAuthenticatedLoader) return
 
-    const artworkIds = artworkRecommendations.map(
-      (node: any) => node?.artworkId
-    )
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const userId = userID || xImpersonateUserID
+
+    // The Gravity endpoint serves the authenticated `current_user` and has no
+    // `user_id` param, so impersonated/app requests stay on the Vortex path.
+    const useGravity =
+      !!artworkRecommendationsLoader &&
+      !xImpersonateUserID &&
+      isFeatureFlagEnabled(GRAVITY_RAIL_FLAG, { userId })
+
+    // Fetching artwork IDs from the selected recommendation backend.
+    const artworkIds = useGravity
+      ? await getArtworkIdsFromGravity(context)
+      : await getArtworkIdsFromVortex(userId, context)
 
     const pageArtworkIDs = artworkIds?.slice(offset, offset + size)
 
     // Fetching artwork details from Gravity
-
     const artworks = artworkIds?.length
       ? await artworksLoader({
           ids: pageArtworkIDs,
         })
       : []
 
-    const totalCount = artworkRecommendations.length
+    const totalCount = artworkIds.length
 
     const connection = connectionFromArraySlice(artworks, args, {
       arrayLength: totalCount,


### PR DESCRIPTION
### Context

WTYL (`me.artworkRecommendations`) is served today by Vortex GraphQL, a legacy daily-batch pipeline. Gravity now exposes a live equivalent at `GET /api/v1/artwork_recommendations` (gated server-side by
`enable_onyx_artwork_recommendation_endpoint`). 

Ticket: https://artsyproduct.atlassian.net/browse/ONYX-2122

### Changes

- New Unleash flag `onyx_artwork-recommendations-gravity`
- New authenticated Gravity loader `artworkRecommendationsLoader`
- `artworkRecommendations` resolver now picks the backend behind the flag. Both paths reduce to an ordered list of artwork IDs, then share the existing hydration (`artworksLoader`) and connection/pagination/cursor logic — so the
  response is identical on either side of the flag.
- **Flag off** → unchanged Vortex GraphQL path.
- **Flag on** → Gravity REST. A `404` (Gravity-side flag off) is treated as an empty rail — the intended kill-switch, letting Gravity be toggled off for investigation without rolling MP. Any other failure (401/400/5xx/timeout) propagates exactly like a Vortex failure, so real outages still surface.
- Impersonated/app requests stay on Vortex (WTYL is not being used in Braze, [confirmed here](https://artsy.slack.com/archives/C095747U683/p1779789928583219?thread_ts=1779354279.004109&cid=C095747U683)) : the Gravity endpoint has no `user_id`
  param and only serves `current_user`.


### TODO
- [x] Create Feature flag in Unleash
