### PR TITLE
fix(auction-result): 404s when missing associated artist

### DIFF
--- a/src/schema/v2/__tests__/auction_result.test.ts
+++ b/src/schema/v2/__tests__/auction_result.test.ts
@@ -3,6 +3,7 @@ import { runQuery } from "schema/v2/test/utils"
 
 const mockAuctionResult = {
   id: "foo-bar",
+  artist_id: "andy-warhol",
   sale_date_text: "10-12-2020",
   sale_title: "sale-title",
   title: "title",
@@ -319,6 +320,40 @@ describe("AuctionResult type", () => {
       return runQuery(query, context).then((data) => {
         expect(data.auctionResult.artist.name).toEqual("Andy Warhol")
       })
+    })
+  })
+
+  describe("when the underlying row has no artist", () => {
+    it("throws a 404 instead of returning an orphan node", async () => {
+      const auctionResult = {
+        ...mockAuctionResult,
+        artist_id: undefined,
+      }
+
+      const artistLoader = jest.fn()
+
+      const context = {
+        auctionLotLoader: jest.fn(() => Promise.resolve(auctionResult)),
+        artistLoader,
+      }
+
+      const query = `
+        {
+          auctionResult(id: "103") {
+            internalID
+            artist {
+              name
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        `Auction result "103" not found`
+      )
+
+      // We should never make the doomed `GET /artist/undefined` call.
+      expect(artistLoader).not.toHaveBeenCalled()
     })
   })
 

--- a/src/schema/v2/auction_result.ts
+++ b/src/schema/v2/auction_result.ts
@@ -33,6 +33,7 @@ import { InternalIDFields, NodeInterface } from "./object_identification"
 // Taken from https://github.com/RubyMoney/money/blob/master/config/currency_iso.json
 import { YearRange } from "./types/yearRange"
 import { GraphQLError } from "graphql"
+import { HTTPError } from "lib/HTTPError"
 
 export const AuctionResultSortEnum = new GraphQLEnumType({
   name: "AuctionResultSorts",
@@ -100,6 +101,11 @@ const AuctionResultType = new GraphQLObjectType<any, ResolverContext>({
         // In case we get artist already resolved from the main connection
         if (res.artist) {
           return res.artist
+        }
+
+        // Avoid a guaranteed `GET /artist/undefined` 404 against Gravity.
+        if (!res.artist_id) {
+          return null
         }
 
         const artist = await artistLoader(res.artist_id)
@@ -406,11 +412,21 @@ export const AuctionResult: GraphQLFieldConfig<void, ResolverContext> = {
       type: new GraphQLNonNull(GraphQLString),
     },
   },
-  resolve: (_root, { id }, { auctionLotLoader }) => {
+  resolve: async (_root, { id }, { auctionLotLoader }) => {
     if (!auctionLotLoader) {
       return null
     }
-    return auctionLotLoader(id)
+
+    const auctionResult = await auctionLotLoader(id)
+
+    // Auction-result rows without an associated artist are not usable as
+    // standalone entities on Artsy (every consumer renders them artist-first),
+    // so treat them as not-found rather than returning an orphan node.
+    if (!auctionResult?.artist_id) {
+      throw new HTTPError(`Auction result "${id}" not found`, 404)
+    }
+
+    return auctionResult
   },
 }
 


### PR DESCRIPTION
Apparently [some auction results get orphaned](https://app.notion.com/p/artsy/Auction-results-pages-cluttering-index-should-be-removed-343cab0764a08071a141ed87ee5e6244?source=copy_link) and wind up in Google's index, but have empty content. These should just 404.

<img width="1680" height="1024" alt="image" src="https://github.com/user-attachments/assets/4d272104-1556-4a96-9278-5d0389f86197" />

cc @artsy/diamond-devs 