### PR TITLE
chore: add schema + mutation for onboarding (OS)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15136,6 +15136,71 @@ type GravityMutationError {
   type: String
 }
 
+type GuidedTourChecklist {
+  completedCount: Int!
+  items: [GuidedTourChecklistItem!]!
+  totalCount: Int!
+}
+
+type GuidedTourChecklistItem {
+  key: String!
+  showMeHowTour: GuidedTourTour
+  state: GuidedTourChecklistItemState!
+  title: String!
+}
+
+enum GuidedTourChecklistItemState {
+  COMPLETE
+  INCOMPLETE
+}
+
+enum GuidedTourContext {
+  CATALOG_OS
+}
+
+enum GuidedTourEventType {
+  CHECKLIST_ITEM_COMPLETED
+  STEP_VIEWED
+  TOUR_COMPLETED
+  TOUR_DISMISSED
+  TOUR_STARTED
+}
+
+enum GuidedTourState {
+  COMPLETED
+  DISMISSED
+  IN_PROGRESS
+  NOT_STARTED
+}
+
+# A user's guided tour state for a context, server-driven.
+type GuidedTourStateView {
+  # The single step to render now, or null when no required tour is active.
+  activeStep: GuidedTourStep
+  activeTour: GuidedTourTour
+  checklist: GuidedTourChecklist!
+  context: GuidedTourContext!
+}
+
+type GuidedTourStep {
+  anchorKey: String!
+  body: String
+  completesItemKey: String
+  ctaLabel: String
+  index: Int!
+  key: String!
+  placement: String!
+  title: String
+  total: Int!
+}
+
+# An ordered sequence of steps and the user's state in it.
+type GuidedTourTour {
+  key: String!
+  state: GuidedTourState
+  steps: [GuidedTourStep!]!
+}
+
 # A Hero Unit
 type HeroUnit {
   # Main Hero Unit content.
@@ -17599,6 +17664,9 @@ type Me implements Node {
       reason: "emailConfirmed is going to be removed, use isEmailConfirmed instead"
     )
   followsAndSaves: FollowsAndSaves
+
+  # The logged-in user's guided tour state for a given context.
+  guidedTour(context: GuidedTourContext!): GuidedTourStateView
   hasCreditCards: Boolean
   hasPassword: Boolean!
   hasPriceRange: Boolean!
@@ -19242,6 +19310,11 @@ type Mutation {
 
   # Records a user viewing an artwork
   recordArtworkView(input: RecordArtworkViewInput!): RecordArtworkViewPayload
+
+  # Record a guided tour event for the logged-in user and return the refreshed state.
+  recordGuidedTourEvent(
+    input: RecordGuidedTourEventInput!
+  ): RecordGuidedTourEventPayload
 
   # Refresh the access token for a connected Instagram account
   refreshInstagramAccount(
@@ -24595,6 +24668,34 @@ type RecordArtworkViewPayload {
   artworkId: String!
   artwork_id: String! @deprecated(reason: "Use artworkId")
   clientMutationId: String
+}
+
+type RecordGuidedTourEventFailure {
+  mutationError: GravityMutationError!
+}
+
+input RecordGuidedTourEventInput {
+  clientMutationId: String
+  context: GuidedTourContext!
+  itemKey: String
+  reason: String
+  stepPosition: Int
+  tourKey: String
+  type: GuidedTourEventType!
+}
+
+type RecordGuidedTourEventPayload {
+  clientMutationId: String
+  recordGuidedTourEventOrError: RecordGuidedTourEventResponseOrError!
+}
+
+union RecordGuidedTourEventResponseOrError =
+    RecordGuidedTourEventFailure
+  | RecordGuidedTourEventSuccess
+
+type RecordGuidedTourEventSuccess {
+  guidedTour: GuidedTourStateView!
+  me: Me!
 }
 
 type RefreshInstagramAccountFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -979,6 +979,12 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     mePingLoader: gravityLoader("me/ping"),
+    meGuidedTourLoader: gravityLoader("me/guided_tour"),
+    recordGuidedTourEventLoader: gravityLoader(
+      "me/guided_tour/events",
+      {},
+      { method: "POST" }
+    ),
     meTasksLoader: gravityLoader("me/tasks", {}, { headers: true }),
     meDismissTaskLoader: gravityLoader(
       (id) => `me/task/${id}/dismiss`,

--- a/src/schema/v2/me/__tests__/guidedTour.test.ts
+++ b/src/schema/v2/me/__tests__/guidedTour.test.ts
@@ -1,0 +1,207 @@
+/* eslint-disable promise/always-return */
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+const snapshot = {
+  context: "catalog_os",
+  active_tour: {
+    key: "welcome",
+    state: "in_progress",
+    steps: [
+      {
+        key: "welcome.0",
+        anchor_key: "add-artwork-button",
+        placement: "bottom-end",
+        title: "Add your first artwork",
+        body: "Start here.",
+        cta_label: "Next",
+        completes_item_key: "add-first-artwork",
+        index: 0,
+        total: 2,
+      },
+    ],
+  },
+  active_step: {
+    key: "welcome.0",
+    anchor_key: "add-artwork-button",
+    placement: "bottom-end",
+    title: "Add your first artwork",
+    body: "Start here.",
+    cta_label: "Next",
+    completes_item_key: "add-first-artwork",
+    index: 0,
+    total: 2,
+  },
+  checklist: {
+    completed_count: 1,
+    total_count: 2,
+    items: [
+      { key: "check-out-space", title: "Check out", state: "complete" },
+      {
+        key: "add-to-artsy-draft",
+        title: "Add to Artsy",
+        state: "incomplete",
+        show_me_how_tour: {
+          key: "add-to-artsy-draft",
+          state: "not_started",
+          steps: [
+            {
+              key: "add-to-artsy-draft.0",
+              anchor_key: "inventory-row-actions",
+              placement: "left-start",
+              title: "Open the menu",
+              body: "Click the ellipsis.",
+              cta_label: "Got it",
+              index: 0,
+              total: 1,
+            },
+          ],
+        },
+      },
+    ],
+  },
+}
+
+describe("Me guided tour", () => {
+  describe("me.guidedTour", () => {
+    it("returns the server-driven state mapped to the schema", async () => {
+      const query = gql`
+        {
+          me {
+            guidedTour(context: CATALOG_OS) {
+              context
+              activeTour {
+                key
+                state
+                steps {
+                  anchorKey
+                  completesItemKey
+                  index
+                  total
+                }
+              }
+              activeStep {
+                anchorKey
+              }
+              checklist {
+                completedCount
+                totalCount
+                items {
+                  key
+                  state
+                  showMeHowTour {
+                    key
+                  }
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const meGuidedTourLoader = jest.fn().mockResolvedValue(snapshot)
+      const context = {
+        meLoader: jest.fn().mockResolvedValue({}),
+        meGuidedTourLoader,
+      }
+
+      const { me } = await runAuthenticatedQuery(query, context)
+
+      expect(meGuidedTourLoader).toHaveBeenCalledWith({ context: "catalog_os" })
+      expect(me.guidedTour).toEqual({
+        context: "CATALOG_OS",
+        activeTour: {
+          key: "welcome",
+          state: "IN_PROGRESS",
+          steps: [
+            {
+              anchorKey: "add-artwork-button",
+              completesItemKey: "add-first-artwork",
+              index: 0,
+              total: 2,
+            },
+          ],
+        },
+        activeStep: { anchorKey: "add-artwork-button" },
+        checklist: {
+          completedCount: 1,
+          totalCount: 2,
+          items: [
+            { key: "check-out-space", state: "COMPLETE", showMeHowTour: null },
+            {
+              key: "add-to-artsy-draft",
+              state: "INCOMPLETE",
+              showMeHowTour: { key: "add-to-artsy-draft" },
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  describe("recordGuidedTourEvent", () => {
+    const mutation = gql`
+      mutation {
+        recordGuidedTourEvent(
+          input: { context: CATALOG_OS, type: TOUR_STARTED, tourKey: "welcome" }
+        ) {
+          recordGuidedTourEventOrError {
+            ... on RecordGuidedTourEventSuccess {
+              guidedTour {
+                activeTour {
+                  state
+                }
+              }
+            }
+            ... on RecordGuidedTourEventFailure {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("records the event and returns the refreshed state", async () => {
+      const recordGuidedTourEventLoader = jest.fn().mockResolvedValue(snapshot)
+
+      const data = await runAuthenticatedQuery(mutation, {
+        recordGuidedTourEventLoader,
+      })
+
+      expect(recordGuidedTourEventLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: "catalog_os",
+          type: "tour_started",
+          tour_key: "welcome",
+        })
+      )
+      expect(data).toEqual({
+        recordGuidedTourEvent: {
+          recordGuidedTourEventOrError: {
+            guidedTour: { activeTour: { state: "IN_PROGRESS" } },
+          },
+        },
+      })
+    })
+
+    it("returns a mutation error when recording fails", async () => {
+      const recordGuidedTourEventLoader = jest
+        .fn()
+        .mockRejectedValue(new Error("Context Not Found"))
+
+      const data = await runAuthenticatedQuery(mutation, {
+        recordGuidedTourEventLoader,
+      })
+
+      expect(data).toEqual({
+        recordGuidedTourEvent: {
+          recordGuidedTourEventOrError: {
+            mutationError: { message: "Context Not Found" },
+          },
+        },
+      })
+    })
+  })
+})

--- a/src/schema/v2/me/guidedTour/index.ts
+++ b/src/schema/v2/me/guidedTour/index.ts
@@ -1,0 +1,153 @@
+import {
+  GraphQLEnumType,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+
+export const GuidedTourContextEnum = new GraphQLEnumType({
+  name: "GuidedTourContext",
+  values: {
+    CATALOG_OS: { value: "catalog_os" },
+  },
+})
+
+export const GuidedTourTourStateEnum = new GraphQLEnumType({
+  name: "GuidedTourState",
+  values: {
+    NOT_STARTED: { value: "not_started" },
+    IN_PROGRESS: { value: "in_progress" },
+    COMPLETED: { value: "completed" },
+    DISMISSED: { value: "dismissed" },
+  },
+})
+
+export const GuidedTourChecklistItemStateEnum = new GraphQLEnumType({
+  name: "GuidedTourChecklistItemState",
+  values: {
+    COMPLETE: { value: "complete" },
+    INCOMPLETE: { value: "incomplete" },
+  },
+})
+
+export const GuidedTourEventTypeEnum = new GraphQLEnumType({
+  name: "GuidedTourEventType",
+  values: {
+    TOUR_STARTED: { value: "tour_started" },
+    STEP_VIEWED: { value: "step_viewed" },
+    TOUR_COMPLETED: { value: "tour_completed" },
+    TOUR_DISMISSED: { value: "tour_dismissed" },
+    CHECKLIST_ITEM_COMPLETED: { value: "checklist_item_completed" },
+  },
+})
+
+export const GuidedTourStepType = new GraphQLObjectType<any, ResolverContext>({
+  name: "GuidedTourStep",
+  fields: () => ({
+    key: { type: new GraphQLNonNull(GraphQLString) },
+    anchorKey: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ anchor_key }) => anchor_key,
+    },
+    placement: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: GraphQLString },
+    body: { type: GraphQLString },
+    ctaLabel: { type: GraphQLString, resolve: ({ cta_label }) => cta_label },
+    completesItemKey: {
+      type: GraphQLString,
+      resolve: ({ completes_item_key }) => completes_item_key,
+    },
+    index: { type: new GraphQLNonNull(GraphQLInt) },
+    total: { type: new GraphQLNonNull(GraphQLInt) },
+  }),
+})
+
+export const GuidedTourTourType = new GraphQLObjectType<any, ResolverContext>({
+  name: "GuidedTourTour",
+  description: "An ordered sequence of steps and the user's state in it.",
+  fields: () => ({
+    key: { type: new GraphQLNonNull(GraphQLString) },
+    state: { type: GuidedTourTourStateEnum },
+    steps: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GuidedTourStepType))
+      ),
+      resolve: ({ steps }) => steps ?? [],
+    },
+  }),
+})
+
+export const GuidedTourChecklistItemType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "GuidedTourChecklistItem",
+  fields: () => ({
+    key: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    state: { type: new GraphQLNonNull(GuidedTourChecklistItemStateEnum) },
+    showMeHowTour: {
+      type: GuidedTourTourType,
+      resolve: ({ show_me_how_tour }) => show_me_how_tour,
+    },
+  }),
+})
+
+export const GuidedTourChecklistType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "GuidedTourChecklist",
+  fields: () => ({
+    completedCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ completed_count }) => completed_count,
+    },
+    totalCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ total_count }) => total_count,
+    },
+    items: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GuidedTourChecklistItemType))
+      ),
+      resolve: ({ items }) => items ?? [],
+    },
+  }),
+})
+
+export const GuidedTourStateType = new GraphQLObjectType<any, ResolverContext>({
+  name: "GuidedTourStateView",
+  description: "A user's guided tour state for a context, server-driven.",
+  fields: () => ({
+    context: { type: new GraphQLNonNull(GuidedTourContextEnum) },
+    activeTour: {
+      type: GuidedTourTourType,
+      resolve: ({ active_tour }) => active_tour,
+    },
+    activeStep: {
+      type: GuidedTourStepType,
+      description:
+        "The single step to render now, or null when no required tour is active.",
+      resolve: ({ active_step }) => active_step,
+    },
+    checklist: { type: new GraphQLNonNull(GuidedTourChecklistType) },
+  }),
+})
+
+export const GuidedTourField: GraphQLFieldConfig<any, ResolverContext> = {
+  type: GuidedTourStateType,
+  description: "The logged-in user's guided tour state for a given context.",
+  args: {
+    context: { type: new GraphQLNonNull(GuidedTourContextEnum) },
+  },
+  resolve: (_root, { context }, { meGuidedTourLoader }) => {
+    if (!meGuidedTourLoader) return null
+
+    return meGuidedTourLoader({ context })
+  },
+}

--- a/src/schema/v2/me/guidedTour/recordGuidedTourEventMutation.ts
+++ b/src/schema/v2/me/guidedTour/recordGuidedTourEventMutation.ts
@@ -1,0 +1,102 @@
+import {
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  GravityMutationErrorType,
+  formatGravityError,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { meType } from "../index"
+import {
+  GuidedTourContextEnum,
+  GuidedTourEventTypeEnum,
+  GuidedTourStateType,
+} from "./index"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RecordGuidedTourEventSuccess",
+  isTypeOf: (data) => data._type === "success",
+  fields: () => ({
+    guidedTour: {
+      type: new GraphQLNonNull(GuidedTourStateType),
+      resolve: (result) => result.snapshot,
+    },
+    me: {
+      type: new GraphQLNonNull(meType),
+      resolve: (_root, _args, { meLoader }) => meLoader?.(),
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "RecordGuidedTourEventFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: new GraphQLNonNull(GravityMutationErrorType),
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "RecordGuidedTourEventResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) =>
+    data._type === "GravityMutationError" ? FailureType : SuccessType,
+})
+
+export const recordGuidedTourEventMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "RecordGuidedTourEvent",
+  description:
+    "Record a guided tour event for the logged-in user and return the refreshed state.",
+  inputFields: {
+    context: { type: new GraphQLNonNull(GuidedTourContextEnum) },
+    type: { type: new GraphQLNonNull(GuidedTourEventTypeEnum) },
+    tourKey: { type: GraphQLString },
+    stepPosition: { type: GraphQLInt },
+    itemKey: { type: GraphQLString },
+    reason: { type: GraphQLString },
+  },
+  outputFields: {
+    recordGuidedTourEventOrError: {
+      type: new GraphQLNonNull(ResponseOrErrorType),
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (input, { recordGuidedTourEventLoader }) => {
+    if (!recordGuidedTourEventLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const snapshot = await recordGuidedTourEventLoader({
+        context: input.context,
+        type: input.type,
+        tour_key: input.tourKey,
+        step_position: input.stepPosition,
+        item_key: input.itemKey,
+        reason: input.reason,
+      })
+
+      return { _type: "success", snapshot }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      }
+
+      return { message: error.message, _type: "GravityMutationError" }
+    }
+  },
+})

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -35,6 +35,7 @@ import {
   resolveAlertFromJSON,
 } from "../Alerts"
 import { MeCollectorProfile } from "../CollectorProfile/collectorProfile"
+import { GuidedTourField } from "./guidedTour"
 import { artworkConnection } from "../artwork"
 import { emptyConnection, paginationResolver } from "../fields/pagination"
 import {
@@ -500,6 +501,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         return meNotificationLoader(id)
       },
     },
+    guidedTour: GuidedTourField,
     initials: initials("name"),
     order: MeOrder,
     ordersConnection: MeOrdersConnection,

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -204,6 +204,7 @@ import { confirmPasswordMutation } from "./me/confirmPasswordMutation"
 import { createImageMutation } from "./me/createImageMutation"
 import { transferMyCollectionMutation } from "./me/transferMyCollectionMutation"
 import { recordArtworkViewMutation } from "./me/recordArtworkViewMutation"
+import { recordGuidedTourEventMutation } from "./me/guidedTour/recordGuidedTourEventMutation"
 import { markNotificationsAsSeenMutation } from "./me/markNotificationsAsSeenMutation"
 import { requestPriceEstimateMutation } from "./me/requestPriceEstimate"
 import { requestConditionReportMutation } from "./me/requestConditionReportMutation"
@@ -767,6 +768,7 @@ export default new GraphQLSchema({
       repositionPartnerArtistArtworks: repositionPartnerArtistArtworksMutation,
       repositionPartnerLocations: repositionPartnerLocationsMutation,
       recordArtworkView: recordArtworkViewMutation,
+      recordGuidedTourEvent: recordGuidedTourEventMutation,
       requestCredentialsForAssetUpload: CreateAssetRequestLoader,
       requestConditionReport: requestConditionReportMutation,
       requestPriceEstimate: requestPriceEstimateMutation,


### PR DESCRIPTION
# Catalog OS onboarding - Metaphysics

Fairly boilerplate representation of the guided tour snapshot for a user, as well as the record a guided tour event mutation - based on the modeling in https://github.com/artsy/gravity/pull/20234.

## The shape

A read field and a write mutation:

```graphql
me {
  guidedTour(context: CATALOG_OS) {
    activeTour { key state steps { key anchorKey placement title body ctaLabel completesItemKey index total } }
    activeStep { anchorKey placement title body ctaLabel completesItemKey index total }
    checklist {
      completedCount
      totalCount
      items { key title state showMeHowTour { key steps { anchorKey ... } } }
    }
  }
}
```

```graphql
recordGuidedTourEvent(input: {
  context: CATALOG_OS
  type: TOUR_STARTED        # | STEP_VIEWED | TOUR_COMPLETED | TOUR_DISMISSED | CHECKLIST_ITEM_COMPLETED
  tourKey: "welcome"        # plus stepPosition / itemKey / reason depending on the event
}) {
  recordGuidedTourEventOrError {
    ... on RecordGuidedTourEventSuccess { guidedTour { ...the refreshed snapshot } }
    ... on RecordGuidedTourEventFailure { mutationError { message } }
  }
}
```

## Up next

The Volt PR that queries `me { guidedTour(context: CATALOG_OS) }`, renders the initial welcome tour + resume where left off, then switches to the `Getting Started` checklist and can take the user on sub-tours for those checklist items, and fires `recordGuidedTourEvent` at appropriate times.
