### PR TITLE
fix: paintings quick link leads to gene page instead of collection

### DIFF
--- a/src/schema/v2/homeView/sections/QuickLinks.ts
+++ b/src/schema/v2/homeView/sections/QuickLinks.ts
@@ -76,8 +76,8 @@ export const QUICK_LINKS: Array<NavigationPill> = [
   },
   {
     title: "Paintings",
-    href: "/collection/paintings",
-    ownerType: OwnerType.collection,
+    href: "/gene/painting",
+    ownerType: OwnerType.gene,
     icon: "ArtworkIcon",
   },
   {

--- a/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
+++ b/src/schema/v2/homeView/sections/__tests__/QuickLinks.test.ts
@@ -121,9 +121,9 @@ describe("QuickLinks", () => {
             "title": "Statement Pieces",
           },
           {
-            "href": "/collection/paintings",
+            "href": "/gene/painting",
             "icon": "ArtworkIcon",
-            "ownerType": "collection",
+            "ownerType": "gene",
             "title": "Paintings",
           },
           {


### PR DESCRIPTION
Recently we unpublished some collections in favor of genes. One of the quick links was still pointing to an unpublished collection, so I'm replacing it with the corresponding gene now.