### PR TITLE
feat(TOP-273): wire up new params for createPartnerOffer related endpoint

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -31728,7 +31728,9 @@ input createPartnerOfferMutationInput {
   artwork_id: String!
   clientMutationId: String
   discount_percentage: Int!
+  impulse_conversation_id: String
   note: String
+  user_id: String
 }
 
 type createPartnerOfferMutationPayload {

--- a/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
+++ b/src/schema/v2/__tests__/createPartnerOfferMutation.test.ts
@@ -34,6 +34,34 @@ const mutation = gql`
   }
 `
 
+const mutationWithConversation = gql`
+  mutation {
+    createPartnerOffer(
+      input: {
+        artwork_id: "xyz321"
+        discount_percentage: 10
+        note: "hi!"
+        impulse_conversation_id: "conversation_id"
+        user_id: "user_id"
+      }
+    ) {
+      partnerOfferOrError {
+        __typename
+        ... on createPartnerOfferSuccess {
+          partnerOffer {
+            internalID
+          }
+        }
+        ... on createPartnerOfferFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
 describe("Create a partner offer for users", () => {
   describe("when succesfull", () => {
     const partnerOffer = {
@@ -77,6 +105,40 @@ describe("Create a partner offer for users", () => {
             },
           },
         },
+      })
+    })
+
+    it("passes the optional args to the loader", async () => {
+      const createPartnerOfferLoader = jest.fn().mockResolvedValue(partnerOffer)
+
+      await runAuthenticatedQuery(mutation, {
+        ...context,
+        createPartnerOfferLoader,
+      })
+
+      expect(createPartnerOfferLoader).toHaveBeenCalledWith({
+        artwork_id: "xyz321",
+        discount_percentage: 10,
+        note: "hi!",
+        impulse_conversation_id: undefined,
+        user_id: undefined,
+      })
+    })
+
+    it("passes impulse_conversation_id and user_id together to the loader", async () => {
+      const createPartnerOfferLoader = jest.fn().mockResolvedValue(partnerOffer)
+
+      await runAuthenticatedQuery(mutationWithConversation, {
+        ...context,
+        createPartnerOfferLoader,
+      })
+
+      expect(createPartnerOfferLoader).toHaveBeenCalledWith({
+        artwork_id: "xyz321",
+        discount_percentage: 10,
+        note: "hi!",
+        impulse_conversation_id: "conversation_id",
+        user_id: "user_id",
       })
     })
   })

--- a/src/schema/v2/createPartnerOfferMutation.ts
+++ b/src/schema/v2/createPartnerOfferMutation.ts
@@ -18,6 +18,8 @@ interface Input {
   artwork_id: string
   discount_percentage: number
   note?: string
+  impulse_conversation_id?: string
+  user_id?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -65,6 +67,8 @@ export const createPartnerOfferMutation = mutationWithClientMutationId<
     artwork_id: { type: new GraphQLNonNull(GraphQLString) },
     discount_percentage: { type: new GraphQLNonNull(GraphQLInt) },
     note: { type: GraphQLString },
+    impulse_conversation_id: { type: GraphQLString },
+    user_id: { type: GraphQLString },
   },
   outputFields: {
     partnerOfferOrError: {
@@ -83,6 +87,8 @@ export const createPartnerOfferMutation = mutationWithClientMutationId<
         artwork_id: args.artwork_id,
         discount_percentage: args.discount_percentage,
         note: args.note,
+        impulse_conversation_id: args.impulse_conversation_id,
+        user_id: args.user_id,
       })
     } catch (error) {
       const formattedErr = formatGravityError(error)


### PR DESCRIPTION
Resolves [TOP-273]

Add the new params added in https://github.com/artsy/gravity/pull/20164 to the `createPartnerOffer` mutation.

cc @artsy/topaz-devs 

[TOP-273]: https://artsyproduct.atlassian.net/browse/TOP-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ