### PR TITLE
feat: return catalog edition set data

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -5880,6 +5880,9 @@ type CareerHighlight implements Node {
 type CatalogArtwork {
   artworkId: String
   availability: String
+
+  # Edition sets associated with this catalog artwork.
+  catalogEditionSets: [CatalogEditionSet]
   createdAt(
     format: String
 
@@ -5927,6 +5930,30 @@ type CatalogArtworkDocument {
   internalID: ID!
   publicURL: String!
   title: String
+  updatedAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+}
+
+type CatalogEditionSet {
+  availability: String
+  createdAt(
+    format: String
+
+    # A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    timezone: String
+  ): String
+  editionSetId: String
+
+  # A globally unique ID.
+  id: ID!
+
+  # A type-specific ID likely used as a database ID.
+  internalID: ID!
+  priceListed: Money
   updatedAt(
     format: String
 

--- a/src/schema/v2/artwork/__tests__/catalogArtwork.test.ts
+++ b/src/schema/v2/artwork/__tests__/catalogArtwork.test.ts
@@ -107,6 +107,93 @@ describe("Artwork.catalogArtwork", () => {
     })
   })
 
+  it("returns catalog edition sets with priceListed using the parent currency", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            catalogEditionSets {
+              internalID
+              editionSetId
+              availability
+              priceListed {
+                major
+                minor
+                currencyCode
+                display
+              }
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithCatalogArtwork({
+        id: "catalog-artwork-id",
+        price_currency: "USD",
+        catalog_edition_sets: [
+          {
+            id: "edition-set-1",
+            edition_set_id: "gravity-edition-set-1",
+            price_minor: 150000,
+            availability: "for sale",
+            created_at: "2024-01-15T10:30:00Z",
+            updated_at: "2024-06-20T14:45:00Z",
+          },
+        ],
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: {
+          catalogEditionSets: [
+            {
+              internalID: "edition-set-1",
+              editionSetId: "gravity-edition-set-1",
+              availability: "for sale",
+              priceListed: {
+                major: 1500,
+                minor: 150000,
+                currencyCode: "USD",
+                display: "US$1,500",
+              },
+              createdAt: "2024-01-15T10:30:00Z",
+              updatedAt: "2024-06-20T14:45:00Z",
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it("returns an empty list when catalog_edition_sets is not present", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            catalogEditionSets {
+              internalID
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithCatalogArtwork({
+        id: "catalog-artwork-id",
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: { catalogArtwork: { catalogEditionSets: [] } },
+    })
+  })
+
   it("returns createdAt and updatedAt dates", async () => {
     const query = gql`
       {

--- a/src/schema/v2/catalogArtwork.ts
+++ b/src/schema/v2/catalogArtwork.ts
@@ -9,6 +9,10 @@ import { InternalIDFields } from "./object_identification"
 import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
 import { date } from "./fields/date"
 import { CatalogArtworkDocumentType } from "./catalogArtworkDocument"
+import {
+  CatalogEditionSetGravityResponse,
+  CatalogEditionSetType,
+} from "./catalogEditionSet"
 
 export const CatalogArtworkType = new GraphQLObjectType<any, ResolverContext>({
   name: "CatalogArtwork",
@@ -66,6 +70,17 @@ export const CatalogArtworkType = new GraphQLObjectType<any, ResolverContext>({
         })
         return body
       },
+    },
+    catalogEditionSets: {
+      type: new GraphQLList(CatalogEditionSetType),
+      description: "Edition sets associated with this catalog artwork.",
+      resolve: ({ catalog_edition_sets, price_currency }) =>
+        (catalog_edition_sets ?? []).map(
+          (editionSet: CatalogEditionSetGravityResponse) => ({
+            ...editionSet,
+            price_currency,
+          })
+        ),
     },
   },
 })

--- a/src/schema/v2/catalogEditionSet.ts
+++ b/src/schema/v2/catalogEditionSet.ts
@@ -1,0 +1,47 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "./object_identification"
+import { date } from "./fields/date"
+import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
+
+export interface CatalogEditionSetGravityResponse {
+  id: string
+  edition_set_id: string
+  price_minor: number | null
+  availability: string | null
+  created_at: string
+  updated_at: string
+}
+
+export const CatalogEditionSetType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "CatalogEditionSet",
+  fields: {
+    ...InternalIDFields,
+    editionSetId: {
+      type: GraphQLString,
+      resolve: ({ edition_set_id }) => edition_set_id,
+    },
+    priceListed: {
+      type: Money,
+      resolve: (
+        { price_minor: minor, price_currency: currencyCode },
+        args,
+        context,
+        info
+      ) => {
+        return resolveMinorAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          args,
+          context,
+          info
+        )
+      },
+    },
+    availability: { type: GraphQLString },
+    createdAt: date(),
+    updatedAt: date(),
+  },
+})


### PR DESCRIPTION
Return catalog edition sets so we can feature the data on the Inventory table
Follow up for https://github.com/artsy/gravity/pull/20219

@artsy/amber-devs 