### PR TITLE
feat(TOP-274): expand partnerOffersConnection accepting userID and offerType args

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3142,9 +3142,15 @@ type Artwork implements Node & Searchable & Sellable {
     before: String
     first: Int
     last: Int
+
+    # Filter by offer type(s). Gravity defaults to bulk offers when omitted.
+    offerType: [PartnerOfferTypeEnum]
     page: Int
     size: Int
     sort: PartnerOfferSorts
+
+    # Only return offers targeting this user (e.g. a personalized offer from a conversation).
+    userID: String
   ): PartnerOfferConnection
 
   # A connection of orders for this artwork from the partner's perspective.
@@ -22140,6 +22146,7 @@ enum PartnerOfferSorts {
 
 enum PartnerOfferSourceEnum {
   ABANDONED_ORDER
+  CONVERSATION
   SAVE
 }
 
@@ -22196,6 +22203,11 @@ enum PartnerOfferToCollectorSorts {
   CREATED_AT_DESC
   END_AT_ASC
   END_AT_DESC
+}
+
+enum PartnerOfferTypeEnum {
+  BULK
+  PERSONALIZED
 }
 
 # A connection to a list of items.

--- a/src/schema/v2/artwork/__tests__/partnerOffersConnection.test.ts
+++ b/src/schema/v2/artwork/__tests__/partnerOffersConnection.test.ts
@@ -1,0 +1,107 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("artwork partnerOffersConnection", () => {
+  let partnerOffersLoader
+  let context
+
+  beforeEach(() => {
+    partnerOffersLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            id: "offer-1",
+            active: true,
+            artwork_id: "artwork-1",
+            available: true,
+            partner_id: "partner-1",
+            price_currency: "USD",
+            discount_percentage: 10,
+            source: "Conversation",
+            created_at: "2024-02-27T19:01:51.461Z",
+            end_at: "2024-03-01T19:01:51.457Z",
+          },
+        ],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    context = {
+      artworkLoader: () =>
+        Promise.resolve({ id: "artwork-1", _id: "artwork-1" }),
+      partnerOffersLoader,
+    }
+  })
+
+  it("passes user_id and offer_type to the loader and returns the personalized offer", async () => {
+    const query = gql`
+      {
+        artwork(id: "artwork-1") {
+          partnerOffersConnection(
+            userID: "user-1"
+            offerType: [PERSONALIZED]
+            first: 10
+          ) {
+            totalCount
+            edges {
+              node {
+                internalID
+                artworkId
+                source
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(partnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artwork_id: "artwork-1",
+        user_id: "user-1",
+        offer_type: ["personalized"],
+      })
+    )
+
+    expect(data).toEqual({
+      artwork: {
+        partnerOffersConnection: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                internalID: "offer-1",
+                artworkId: "artwork-1",
+                source: "CONVERSATION",
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it("omits user_id and offer_type when those args are not given", async () => {
+    const query = gql`
+      {
+        artwork(id: "artwork-1") {
+          partnerOffersConnection(first: 10) {
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(partnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: undefined, offer_type: undefined })
+    )
+  })
+})

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -81,7 +81,7 @@ import { date } from "../fields/date"
 import { InquiryQuestionType } from "../inquiry_question"
 import { LotStandingType } from "../me/lot_standing"
 import { myLocationType } from "../me/myLocation"
-import { PartnerOfferType } from "../partnerOffer"
+import { PartnerOfferType, PartnerOfferTypeEnumType } from "../partnerOffer"
 import FormattedNumber from "../types/formatted_number"
 import { ArtworkCompletenessChecklistItemType } from "./artworkCompletenessChecklistItem"
 import { ArtworkCompletenessTier } from "./artworkCompletenessTier"
@@ -1356,6 +1356,16 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         args: pageable({
           page: { type: GraphQLInt },
           size: { type: GraphQLInt },
+          userID: {
+            type: GraphQLString,
+            description:
+              "Only return offers targeting this user (e.g. a personalized offer from a conversation).",
+          },
+          offerType: {
+            type: new GraphQLList(PartnerOfferTypeEnumType),
+            description:
+              "Filter by offer type(s). Gravity defaults to bulk offers when omitted.",
+          },
           sort: {
             type: new GraphQLEnumType({
               name: "PartnerOfferSorts",
@@ -1392,6 +1402,8 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
             page,
             size,
             artwork_id: artwork.id,
+            user_id: args.userID,
+            offer_type: args.offerType,
             sort: args.sort,
           })
 

--- a/src/schema/v2/partnerOffer.ts
+++ b/src/schema/v2/partnerOffer.ts
@@ -18,6 +18,15 @@ export const PartnerOfferSourceEnumType = new GraphQLEnumType({
   values: {
     SAVE: { value: "Save" },
     ABANDONED_ORDER: { value: "Abandoned Order" },
+    CONVERSATION: { value: "Conversation" },
+  },
+})
+
+export const PartnerOfferTypeEnumType = new GraphQLEnumType({
+  name: "PartnerOfferTypeEnum",
+  values: {
+    BULK: { value: "bulk" },
+    PERSONALIZED: { value: "personalized" },
   },
 })
 


### PR DESCRIPTION
Related to [TOP-274]

Expands the **partnerOffersConnection** wiring it up with the new filtering arguments added in https://github.com/artsy/gravity/pull/20225 and https://github.com/artsy/gravity/pull/20222

cc @artsy/topaz-devs 

[TOP-274]: https://artsyproduct.atlassian.net/browse/TOP-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ