### PR TITLE
chore: Allow empty artworks for Instagram post slides args

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -10855,7 +10855,7 @@ input CreateInstagramPostInput {
   # The internal ID of the Instagram account to post from
   instagramAccountId: String!
 
-  # Slides for the Instagram post. Each slide references an artwork and a custom image. The order determines the carousel position.
+  # Slides for the Instagram post. Each slide requires an s3Key and an optional artworkId for custom image-only slides. The order determines the carousel position.
   slides: [InstagramPostSlideInput!]!
 }
 
@@ -16506,10 +16506,10 @@ type InstagramPostEdge {
 
 # A slide in an Instagram carousel post. The order of slides in the array determines their position in the carousel.
 input InstagramPostSlideInput {
-  # The ID of the artwork for this slide
-  artworkId: String!
+  # The ID of the artwork for this slide (optional for custom image-only slides)
+  artworkId: String
 
-  # S3 object key for this slide's custom image
+  # S3 object key for this slide's image (required)
   s3Key: String!
 }
 

--- a/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
+++ b/src/schema/v2/__tests__/createInstagramPostMutation.test.ts
@@ -153,6 +153,49 @@ describe("createInstagramPost", () => {
     })
   })
 
+  describe("with custom image-only slides (no artworkId)", () => {
+    const mutationWithoutArtworkId = `
+      mutation {
+        createInstagramPost(input: {
+          instagramAccountId: "ig-account-1"
+          slides: [{ s3Key: "partner-1/custom/uuid.png" }]
+        }) {
+          instagramPostOrError {
+            __typename
+            ... on CreateInstagramPostSuccess {
+              instagramPost {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    it("omits artworkId if empty", async () => {
+      const context: Partial<ResolverContext> = {
+        createInstagramPostLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+
+      await runAuthenticatedQuery(mutationWithoutArtworkId, context)
+
+      expect(
+        context.createInstagramPostLoader as jest.Mock
+      ).toHaveBeenCalledWith({
+        instagram_account_id: "ig-account-1",
+        slides: [
+          {
+            s3_key: "partner-1/custom/uuid.png",
+          },
+        ],
+        caption: undefined,
+        collaborators: undefined,
+      })
+    })
+  })
+
   it("throws when slides is empty", async () => {
     const mutationWithEmptySlides = `
       mutation {

--- a/src/schema/v2/createInstagramPostMutation.ts
+++ b/src/schema/v2/createInstagramPostMutation.ts
@@ -15,7 +15,7 @@ import { ResolverContext } from "types/graphql"
 import { InstagramPostType } from "./instagramPost"
 
 interface SlideInput {
-  artworkId: string
+  artworkId?: string | null
   s3Key: string
 }
 
@@ -32,12 +32,13 @@ const InstagramPostSlideInput = new GraphQLInputObjectType({
     "A slide in an Instagram carousel post. The order of slides in the array determines their position in the carousel.",
   fields: {
     artworkId: {
-      type: new GraphQLNonNull(GraphQLString),
-      description: "The ID of the artwork for this slide",
+      type: GraphQLString,
+      description:
+        "The ID of the artwork for this slide (optional for custom image-only slides)",
     },
     s3Key: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "S3 object key for this slide's custom image",
+      description: "S3 object key for this slide's image (required)",
     },
   },
 })
@@ -93,7 +94,7 @@ export const createInstagramPostMutation = mutationWithClientMutationId<
         new GraphQLList(new GraphQLNonNull(InstagramPostSlideInput))
       ),
       description:
-        "Slides for the Instagram post. Each slide references an artwork and a custom image. The order determines the carousel position.",
+        "Slides for the Instagram post. Each slide requires an s3Key and an optional artworkId for custom image-only slides. The order determines the carousel position.",
     },
     caption: {
       type: GraphQLString,
@@ -127,7 +128,7 @@ export const createInstagramPostMutation = mutationWithClientMutationId<
       return await createInstagramPostLoader({
         instagram_account_id: instagramAccountId,
         slides: slides.map((slide) => ({
-          artwork_id: slide.artworkId,
+          ...(slide.artworkId && { artwork_id: slide.artworkId }),
           s3_key: slide.s3Key,
         })),
         caption,


### PR DESCRIPTION
Follow-up on https://github.com/artsy/gravity/pull/20226

We changed that requirement on the back-end to allow empty values for artwork ids. However, `artworkId` is still required for each slide in the mutation, forcing the client to pass an emtpy string.

Changes here allow it to be empty as well.

_Assisted-by: Claude Sonnet 4.6 [claude code]_

cc @artsy/amber-devs 