### PR TITLE
feat: Support filtering by offerType in mePartnerOffersConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -17895,6 +17895,9 @@ type Me implements Node {
     before: String
     first: Int
     last: Int
+
+    # Filter by offer type(s). Gravity defaults to all a users partner offers when omitted.
+    offerType: [PartnerOfferTypeEnum]
     page: Int
     size: Int
     sort: PartnerOfferToCollectorSorts

--- a/src/schema/v2/me/__tests__/index.test.ts
+++ b/src/schema/v2/me/__tests__/index.test.ts
@@ -888,6 +888,36 @@ describe("me/index", () => {
         },
       })
     })
+
+    it("filters by offer type when offerType is provided", async () => {
+      const meLoader = () => Promise.resolve({})
+      const mePartnerOffersLoader = jest.fn(() =>
+        Promise.resolve({
+          body: [],
+          headers: { "x-total-count": "0" },
+        })
+      )
+      const query = gql`
+        query {
+          me {
+            partnerOffersConnection(offerType: [PERSONALIZED], first: 10) {
+              totalCount
+            }
+          }
+        }
+      `
+      await runAuthenticatedQuery(query, {
+        meLoader,
+        mePartnerOffersLoader,
+      })
+
+      expect(mePartnerOffersLoader).toHaveBeenCalledWith({
+        page: 1,
+        size: 10,
+        total_count: true,
+        offer_type: ["personalized"],
+      })
+    })
   })
 })
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -44,6 +44,7 @@ import {
 } from "../identityVerification"
 import Image from "../image"
 import { NotificationType } from "../notifications"
+import { PartnerOfferTypeEnumType } from "../partnerOffer"
 import {
   PartnerOfferToCollectorConnectionType,
   PartnerOfferToCollectorSortsType,
@@ -515,6 +516,11 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         artworkID: {
           type: GraphQLString,
         },
+        offerType: {
+          type: new GraphQLList(PartnerOfferTypeEnumType),
+          description:
+            "Filter by offer type(s). Gravity defaults to all a users partner offers when omitted.",
+        },
         page: { type: GraphQLInt },
         size: { type: GraphQLInt },
         sort: { type: PartnerOfferToCollectorSortsType },
@@ -537,6 +543,9 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         }
         if (args.artworkID) {
           gravityArgs["artwork_id"] = args.artworkID
+        }
+        if (args.offerType) {
+          gravityArgs["offer_type"] = args.offerType
         }
 
         const { body, headers } = await mePartnerOffersLoader(gravityArgs)


### PR DESCRIPTION
Allow clients to filter partner offers by `offerType` argument under the `me.partnerOffersConnection` name spacing

Under the hood this hits a separate `GET me/partner_offers` list endpoint in gravity



- Gravity changes: https://github.com/artsy/gravity/pull/20244
- Force changes: https://github.com/artsy/force/pull/17321