### PR TITLE
feat(TOP-297): add partnerOffersConnection to the Conversation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -9947,6 +9947,19 @@ type Conversation implements Node {
     states: [CommerceOrderStateEnum!]
   ): CommerceOrderConnectionWithTotalCount
 
+  # Partner offers for this conversation's artwork, scoped to the user who initiated the conversation (from_id).
+  partnerOffersConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    # Filter by offer type(s). Gravity defaults to bulk offers when omitted.
+    offerType: [PartnerOfferTypeEnum]
+    page: Int
+    size: Int
+  ): PartnerOfferConnection
+
   # A connection of orders for artworks in this conversation from the partner's perspective.
   partnerOrdersConnection(
     after: String

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -81,7 +81,10 @@ import { date } from "../fields/date"
 import { InquiryQuestionType } from "../inquiry_question"
 import { LotStandingType } from "../me/lot_standing"
 import { myLocationType } from "../me/myLocation"
-import { PartnerOfferType, PartnerOfferTypeEnumType } from "../partnerOffer"
+import {
+  PartnerOfferConnectionType,
+  PartnerOfferTypeEnumType,
+} from "../partnerOffer"
 import FormattedNumber from "../types/formatted_number"
 import { ArtworkCompletenessChecklistItemType } from "./artworkCompletenessChecklistItem"
 import { ArtworkCompletenessTier } from "./artworkCompletenessTier"
@@ -1350,9 +1353,7 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       partnerOffersConnection: {
-        type: connectionWithCursorInfo({
-          nodeType: PartnerOfferType,
-        }).connectionType,
+        type: PartnerOfferConnectionType,
         args: pageable({
           page: { type: GraphQLInt },
           size: { type: GraphQLInt },

--- a/src/schema/v2/conversation/__tests__/conversationPartnerOffersConnection.test.ts
+++ b/src/schema/v2/conversation/__tests__/conversationPartnerOffersConnection.test.ts
@@ -1,0 +1,185 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("conversation partnerOffersConnection", () => {
+  let partnerOffersLoader
+  let context
+
+  beforeEach(() => {
+    partnerOffersLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            id: "offer-1",
+            active: true,
+            artwork_id: "artwork-1",
+            available: true,
+            partner_id: "partner-id",
+            price_currency: "USD",
+            discount_percentage: 10,
+            source: "Conversation",
+            created_at: "2024-02-27T19:01:51.461Z",
+            end_at: "2024-03-01T19:01:51.457Z",
+          },
+        ],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    context = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          from_type: "User",
+          to_id: "partner-id",
+          to_type: "Partner",
+          items: [
+            {
+              item_type: "Artwork",
+              item_id: "artwork-1",
+              properties: {
+                id: "artwork-1",
+                _id: "artwork-1",
+              },
+            },
+          ],
+        }),
+      partnerOffersLoader,
+    }
+  })
+
+  it("scopes offers to the conversation's artwork and from_id, and passes offerType", async () => {
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          partnerOffersConnection(first: 10, offerType: [PERSONALIZED]) {
+            totalCount
+            edges {
+              node {
+                internalID
+                artworkId
+                source
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(partnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artwork_id: "artwork-1",
+        user_id: "buyer-1",
+        offer_type: ["personalized"],
+      })
+    )
+
+    expect(data).toEqual({
+      conversation: {
+        partnerOffersConnection: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                internalID: "offer-1",
+                artworkId: "artwork-1",
+                source: "CONVERSATION",
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it("omits offer_type when the arg is not given", async () => {
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          partnerOffersConnection(first: 10) {
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(partnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artwork_id: "artwork-1",
+        user_id: "buyer-1",
+        offer_type: undefined,
+      })
+    )
+  })
+
+  it("returns null when the conversation has no artwork item", async () => {
+    const contextWithNoArtwork = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          items: [],
+        }),
+      partnerOffersLoader,
+    }
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          partnerOffersConnection(first: 10) {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, contextWithNoArtwork)
+
+    expect(data).toEqual({
+      conversation: {
+        partnerOffersConnection: null,
+      },
+    })
+    expect(partnerOffersLoader).not.toHaveBeenCalled()
+  })
+
+  it("throws when partnerOffersLoader is unavailable (signed out)", async () => {
+    const contextWithoutLoader = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          items: [
+            {
+              item_type: "Artwork",
+              item_id: "artwork-1",
+              properties: { id: "artwork-1", _id: "artwork-1" },
+            },
+          ],
+        }),
+    }
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          partnerOffersConnection(first: 10) {
+            totalCount
+          }
+        }
+      }
+    `
+
+    await expect(runQuery(query, contextWithoutLoader)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+})

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -37,6 +37,10 @@ import {
 } from "../fields/pagination"
 import { CollectorResume } from "./collectorResume"
 import { UserInterestConnection } from "../userInterests"
+import {
+  PartnerOfferConnectionType,
+  PartnerOfferTypeEnumType,
+} from "../partnerOffer"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -300,6 +304,52 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
             name: conversation.from_name,
             email: conversation.from_email,
           }
+        },
+      },
+      partnerOffersConnection: {
+        description:
+          "Partner offers for this conversation's artwork, scoped to the user who initiated the conversation (from_id).",
+        type: PartnerOfferConnectionType,
+        args: pageable({
+          page: { type: GraphQLInt },
+          size: { type: GraphQLInt },
+          offerType: {
+            type: new GraphQLList(PartnerOfferTypeEnumType),
+            description:
+              "Filter by offer type(s). Gravity defaults to bulk offers when omitted.",
+          },
+        }),
+        resolve: async ({ from_id, items }, args, { partnerOffersLoader }) => {
+          if (!partnerOffersLoader)
+            throw new Error("You need to be signed in to perform this action")
+
+          // Assume a conversation only has one item
+          const artwork = items?.find((item) => item.item_type === "Artwork")
+          if (!artwork) return null
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await partnerOffersLoader({
+            total_count: true,
+            page,
+            size,
+            artwork_id: artwork.properties.id,
+            user_id: from_id,
+            offer_type: args.offerType,
+          })
+
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            args,
+            body,
+            offset,
+            page,
+            size,
+            totalCount,
+          })
         },
       },
       collectorResume: {


### PR DESCRIPTION
In the same way that we can query `collectorOrdersConnection` in a convo, we need to allow the `partnerOffersConnection`, this PR is related to [TOP-297] and enables us to do it.

cc @artsy/topaz-devs 

[TOP-297]: https://artsyproduct.atlassian.net/browse/TOP-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ