### PR TITLE
feat: Expose partner_offer_id on LineItems from Exchange

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7183,6 +7183,7 @@ type CommerceLineItem {
   ): String
   listPriceCents: Int!
   order: CommerceOrder!
+  partnerOfferId: String
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
   quantity: Int!
   selectedShippingQuote: CommerceShippingQuote
@@ -16788,6 +16789,7 @@ type LineItem {
   # A type-specific ID likely used as a database ID.
   internalID: ID!
   listPrice: Money
+  partnerOfferId: String
   quantity: Int!
 }
 

--- a/src/data/exchange.graphql
+++ b/src/data/exchange.graphql
@@ -854,6 +854,7 @@ type LineItem {
   listPriceCents: Int!
   order: Order!
   priceCents: Int! @deprecated(reason: "switch to use listPriceCents")
+  partnerOfferId: String
   quantity: Int!
   selectedShippingQuote: ShippingQuote
   shipment: Shipment

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -2377,6 +2377,69 @@ describe("Me", () => {
       })
     })
 
+    describe("lineItems partnerOfferId", () => {
+      it("exposes partnerOfferId on lineItems when present", async () => {
+        const localOrderJson = {
+          ...baseOrderJson,
+          line_items: [
+            {
+              ...baseOrderJson.line_items[0],
+              partner_offer_id: "partner-offer-123",
+            },
+          ],
+        }
+
+        const result = await runAuthenticatedQuery(
+          gql`
+            query {
+              me {
+                order(id: "order-id") {
+                  lineItems {
+                    partnerOfferId
+                  }
+                }
+              }
+            }
+          `,
+          {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+          }
+        )
+
+        expect(result.me.order.lineItems[0].partnerOfferId).toEqual(
+          "partner-offer-123"
+        )
+      })
+
+      it("returns null for partnerOfferId on lineItems when absent", async () => {
+        const localOrderJson = {
+          ...baseOrderJson,
+          line_items: [{ ...baseOrderJson.line_items[0] }],
+        }
+
+        const result = await runAuthenticatedQuery(
+          gql`
+            query {
+              me {
+                order(id: "order-id") {
+                  lineItems {
+                    partnerOfferId
+                  }
+                }
+              }
+            }
+          `,
+          {
+            meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+            meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+          }
+        )
+
+        expect(result.me.order.lineItems[0].partnerOfferId).toBeNull()
+      })
+    })
+
     describe("fulfillmentOptions shippingQuoteId", () => {
       const shippingQuoteIdQuery = gql`
         query {

--- a/src/schema/v2/order/types/OrderType.ts
+++ b/src/schema/v2/order/types/OrderType.ts
@@ -201,6 +201,10 @@ const LineItemType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLNonNull(GraphQLInt),
       resolve: ({ quantity }) => quantity,
     },
+    partnerOfferId: {
+      type: GraphQLString,
+      resolve: ({ partner_offer_id }) => partner_offer_id,
+    },
   }),
 })
 

--- a/src/schema/v2/order/types/exchangeJson.ts
+++ b/src/schema/v2/order/types/exchangeJson.ts
@@ -96,6 +96,7 @@ export interface OrderJSON {
     edition_set_id?: string
     id: string
     list_price_cents: number
+    partner_offer_id?: string
     quantity: number
     shipping_total_cents?: number
     tax_cents?: number


### PR DESCRIPTION
feat: Expose partner_offer_id on LineItems from Exchange


Addressing a portion of: https://artsyproduct.atlassian.net/browse/TOP-322

This will allow us to tie the original partner offer over to the Order in exchange. This is needed for tracking success, the user journey though post purchase of a partner offer from convos


cc @artsy/topaz-devs 