### PR TITLE
feat(recs): enable gravity backed wtyl only for future versions

### DIFF
--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -151,6 +151,7 @@ describe("artworkRecommendations", () => {
         artworkRecommendationsLoader,
         meLoader: () => Promise.resolve({}),
         userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.11.0",
         authenticatedLoaders: {
           vortexGraphqlLoader,
         },
@@ -202,6 +203,7 @@ describe("artworkRecommendations", () => {
         artworkRecommendationsLoader,
         meLoader: () => Promise.resolve({}),
         userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.11.0",
         authenticatedLoaders: {
           vortexGraphqlLoader,
         },
@@ -237,6 +239,7 @@ describe("artworkRecommendations", () => {
         artworkRecommendationsLoader,
         meLoader: () => Promise.resolve({}),
         userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.11.0",
         authenticatedLoaders: {
           vortexGraphqlLoader,
         },
@@ -250,6 +253,55 @@ describe("artworkRecommendations", () => {
       )
       expect(vortexGraphqlLoader).not.toHaveBeenCalled()
       expect(artworksLoader).not.toHaveBeenCalled()
+    })
+
+    it("stays on the Vortex path for non-eigen clients (e.g. web)", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn()
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexGraphqlLoader).toHaveBeenCalled()
+    })
+
+    it("stays on the Vortex path for eigen versions below 9.11.0", async () => {
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn()
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.10.0",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexGraphqlLoader).toHaveBeenCalled()
     })
 
     it("stays on the Vortex path for impersonated/app requests", async () => {

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -3,6 +3,7 @@ import { connectionFromArraySlice } from "graphql-relay"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
+import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
 import { CursorPageable, pageable } from "relay-cursor-paging"
 import { artworkConnection } from "schema/v2/artwork"
 import { createPageCursors } from "schema/v2/fields/pagination"
@@ -15,6 +16,19 @@ const MAX_ARTWORKS = 50
 // WTYL canary: route to the Gravity REST endpoint (live) instead of Vortex
 // GraphQL (legacy daily-batch). Flipped per-user in the Unleash admin UI.
 const GRAVITY_RAIL_FLAG = "onyx_artwork-recommendations-gravity"
+
+// Gravity-backed rail ships in eigen 9.11.0+. Checked before the flag so older
+// eigen builds (and non-eigen clients like web) never enter the rollout bucket.
+const MINIMUM_EIGEN_VERSION = { major: 9, minor: 11, patch: 0 }
+
+const isEligibleClient = (context: ResolverContext): boolean => {
+  const actualEigenVersion = getEigenVersionNumber(context.userAgent as string)
+
+  return (
+    !!actualEigenVersion &&
+    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION)
+  )
+}
 
 const getArtworkIdsFromVortex = async (
   userId: string | undefined,
@@ -105,6 +119,7 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
     const useGravity =
       !!artworkRecommendationsLoader &&
       !xImpersonateUserID &&
+      isEligibleClient(context) &&
       isFeatureFlagEnabled(GRAVITY_RAIL_FLAG, { userId })
 
     // Fetching artwork IDs from the selected recommendation backend.


### PR DESCRIPTION
Gates the Gravity backed "We Think You'll Love" rail behind a minimum eigen version (9.11.0) in addition to the existing `onyx_artwork-recommendations-gravity` flag. 

The version check runs before the flag, so clients older than 9.11.0 and non-eigen clients like web stay on the Vortex backend and never enter the rollout bucket. This keeps the canary rollout measured against eligible new-version eigen users only.
