### PR TITLE
chore: sync mp and eigen wtyl feature flags

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -12,6 +12,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_nwfy-artworks-card-test",
   "diamond_artwork-title-experiment",
   "onyx_artwork-recommendations-gravity",
+  "onyx_artwork-recommendations-refresh-eigen",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -1,19 +1,26 @@
 /* eslint-disable promise/always-return */
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { HTTPError } from "lib/HTTPError"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 jest.mock("lib/featureFlags", () => ({
   isFeatureFlagEnabled: jest.fn(() => false),
+  getExperimentVariant: jest.fn(() => ({ enabled: false, name: "control" })),
 }))
 
 const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
 
 describe("artworkRecommendations", () => {
   afterEach(() => {
     mockIsFeatureFlagEnabled.mockReset()
     mockIsFeatureFlagEnabled.mockReturnValue(false)
+    mockGetExperimentVariant.mockReset()
+    mockGetExperimentVariant.mockReturnValue({
+      enabled: false,
+      name: "control",
+    })
   })
 
   const query = gql`
@@ -137,6 +144,11 @@ describe("artworkRecommendations", () => {
   describe("when the WTYL Gravity recs flag is on", () => {
     beforeEach(() => {
       mockIsFeatureFlagEnabled.mockReturnValue(true)
+      // Eligible clients are bucketed into the refresh experiment by default.
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: true,
+        name: "experiment",
+      })
     })
 
     it("fetches IDs from the Gravity REST endpoint with the same response shape", async () => {
@@ -265,6 +277,66 @@ describe("artworkRecommendations", () => {
         artworkRecommendationsLoader,
         meLoader: () => Promise.resolve({}),
         userID: "gravity-user-id",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexGraphqlLoader).toHaveBeenCalled()
+    })
+
+    it("stays on the Vortex path when not bucketed into the refresh experiment", async () => {
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: false,
+        name: "control",
+      })
+
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn()
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.11.0",
+        authenticatedLoaders: {
+          vortexGraphqlLoader,
+        },
+        unauthenticatedLoaders: {
+          vortexGraphqlLoader: null,
+        },
+      }
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexGraphqlLoader).toHaveBeenCalled()
+    })
+
+    it("stays on the Vortex path when the experiment variant is a non-experiment name", async () => {
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: true,
+        name: "control",
+      })
+
+      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+      const artworkRecommendationsLoader = jest.fn()
+      const artworksLoader = jest.fn(async () => artworksResponse)
+
+      const context: any = {
+        artworksLoader,
+        artworkRecommendationsLoader,
+        meLoader: () => Promise.resolve({}),
+        userID: "gravity-user-id",
+        userAgent: "Artsy-Mobile/9.11.0",
         authenticatedLoaders: {
           vortexGraphqlLoader,
         },

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -147,7 +147,7 @@ describe("artworkRecommendations", () => {
       // Eligible clients are bucketed into the refresh experiment by default.
       mockGetExperimentVariant.mockReturnValue({
         enabled: true,
-        name: "experiment",
+        name: "variant",
       })
     })
 
@@ -321,7 +321,7 @@ describe("artworkRecommendations", () => {
       expect(vortexGraphqlLoader).toHaveBeenCalled()
     })
 
-    it("stays on the Vortex path when the experiment variant is a non-experiment name", async () => {
+    it("stays on the Vortex path for the control variant", async () => {
       mockGetExperimentVariant.mockReturnValue({
         enabled: true,
         name: "control",

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -21,8 +21,10 @@ const GRAVITY_RAIL_FLAG = "onyx_artwork-recommendations-gravity"
 // eigen builds (and non-eigen clients like web) never enter the rollout bucket.
 const MINIMUM_EIGEN_VERSION = { major: 9, minor: 11, patch: 0 }
 
-// Eigen refresh experiment: clients bucketed into the "experiment" variant are
-// eligible regardless of version, so the rollout can target the experiment cohort.
+// Eigen refresh experiment: the front-end flag that controls the rollout split
+// and unlocks experiment tracking in eigen. Only clients bucketed into the
+// "variant" cohort (vs "control") get the Gravity rail, matching eigen's check
+// in useEnableLiveHomeRecommendations.
 const REFRESH_EIGEN_FLAG = "onyx_artwork-recommendations-refresh-eigen"
 
 const isInRefreshExperiment = (context: ResolverContext): boolean => {
@@ -30,7 +32,7 @@ const isInRefreshExperiment = (context: ResolverContext): boolean => {
     userId: context.userID,
   })
 
-  return !!variant && variant.enabled && variant.name === "experiment"
+  return !!variant && variant.enabled && variant.name === "variant"
 }
 
 const isEligibleClient = (context: ResolverContext): boolean => {

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -1,6 +1,6 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
@@ -21,11 +21,24 @@ const GRAVITY_RAIL_FLAG = "onyx_artwork-recommendations-gravity"
 // eigen builds (and non-eigen clients like web) never enter the rollout bucket.
 const MINIMUM_EIGEN_VERSION = { major: 9, minor: 11, patch: 0 }
 
+// Eigen refresh experiment: clients bucketed into the "experiment" variant are
+// eligible regardless of version, so the rollout can target the experiment cohort.
+const REFRESH_EIGEN_FLAG = "onyx_artwork-recommendations-refresh-eigen"
+
+const isInRefreshExperiment = (context: ResolverContext): boolean => {
+  const variant = getExperimentVariant(REFRESH_EIGEN_FLAG, {
+    userId: context.userID,
+  })
+
+  return !!variant && variant.enabled && variant.name === "experiment"
+}
+
 const isEligibleClient = (context: ResolverContext): boolean => {
   const actualEigenVersion = getEigenVersionNumber(context.userAgent as string)
 
   return (
     !!actualEigenVersion &&
+    isInRefreshExperiment(context) &&
     isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION)
   )
 }


### PR DESCRIPTION
This PR adds an additional guard to make sure update of the WTYL rail on pull to refresh is only available for the users that get the experiment variant 

- Gates the WTYL Gravity recommendations rail on the front-end Eigen experiment variant, so only the experiment cohort hits the new back end, including on pull-to-refresh.
- Routes to Gravity only when: eigen client `>= 9.11.0` **and** in the `"variant"` (experiment) cohort of `onyx_artwork-recommendations-refresh-eigen` **and** the back-end Gravity flag is on.
