### PR TITLE
feat: update artwork title tag experiment

### DIFF
--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -141,19 +141,6 @@ describe("Meta", () => {
       )
     })
 
-    test("variant-b shortens availability and removes year", async () => {
-      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-        enabled: true,
-        name: "variant-b",
-      } as any)
-
-      const data = await runQuery(query, context as any)
-
-      expect(data.artwork.meta.title).toBe(
-        "Hans Hartung | P. 25-1975-H-8 | For Sale | Artsy"
-      )
-    })
-
     describe("with a long title", () => {
       beforeEach(() => {
         artworkData.title =
@@ -183,19 +170,6 @@ describe("Meta", () => {
 
         expect(data.artwork.meta.title).toBe(
           "Hans Hartung | This title is very very very very very very very ver… (1975) | For Sale | Artsy"
-        )
-      })
-
-      test("variant-b truncates title", async () => {
-        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-          enabled: true,
-          name: "variant-b",
-        } as any)
-
-        const data = await runQuery(query, context as any)
-
-        expect(data.artwork.meta.title).toBe(
-          "Hans Hartung | This title is very very very very very very very ver… | For Sale | Artsy"
         )
       })
     })

--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -128,49 +128,54 @@ describe("Meta", () => {
       )
     })
 
-    test("variant-a shortens availability", async () => {
-      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-        enabled: true,
-        name: "variant-a",
-      } as any)
-
-      const data = await runQuery(query, context as any)
-
-      expect(data.artwork.meta.title).toBe(
-        "Hans Hartung | P. 25-1975-H-8 (1975) | For Sale | Artsy"
-      )
-    })
-
-    describe("with a long title", () => {
+    describe("variant-a", () => {
       beforeEach(() => {
-        artworkData.title =
-          "This title is very very very very very very very very very long"
-      })
-
-      test("control displays full title", async () => {
-        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-          enabled: true,
-          name: "control",
-        } as any)
-
-        const data = await runQuery(query, context as any)
-
-        expect(data.artwork.meta.title).toBe(
-          "Hans Hartung | This title is very very very very very very very very very long (1975) | Available for Sale | Artsy"
-        )
-      })
-
-      test("variant-a truncates title", async () => {
         jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
           enabled: true,
           name: "variant-a",
         } as any)
+      })
 
+      it("changes order and shortens availability", async () => {
         const data = await runQuery(query, context as any)
 
         expect(data.artwork.meta.title).toBe(
-          "Hans Hartung | This title is very very very very very very very ver… (1975) | For Sale | Artsy"
+          "P. 25-1975-H-8 (1975) by Hans Hartung - For Sale | Artsy"
         )
+      })
+
+      describe("with a non for-sale work", () => {
+        const context = {
+          artworkLoader: () =>
+            Promise.resolve({ ...artworkData, forsale: false }),
+        }
+
+        it("omits availability", async () => {
+          const data = await runQuery(query, context as any)
+
+          expect(data.artwork.meta.title).toBe(
+            "P. 25-1975-H-8 (1975) by Hans Hartung | Artsy"
+          )
+        })
+      })
+
+      describe("with a long title", () => {
+        const context = {
+          artworkLoader: () =>
+            Promise.resolve({
+              ...artworkData,
+              title:
+                "This title is very very very very very very very very very long",
+            }),
+        }
+
+        it("truncates title", async () => {
+          const data = await runQuery(query, context as any)
+
+          expect(data.artwork.meta.title).toBe(
+            "This title is very very very very very very very ver… (1975) by Hans Hartung - For Sale | Artsy"
+          )
+        })
       })
     })
   })

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -118,7 +118,6 @@ export default Meta
  * ```
  * control   ➡︎ Mevlana Lipp | Cups (2021) | Available for Sale | Artsy
  * variant-a ➡︎ Mevlana Lipp | Cups (2021) | For Sale | Artsy
- * variant-b ➡︎ Mevlana Lipp | Cups | For Sale | Artsy
  * ```
  */
 function generateTitle(artwork, variant) {
@@ -127,13 +126,6 @@ function generateTitle(artwork, variant) {
       return join(" | ", [
         artistNames(artwork),
         titleWithDateV2(artwork),
-        forSaleIndicationV2(artwork),
-        "Artsy",
-      ])
-    case "variant-b":
-      return join(" | ", [
-        artistNames(artwork),
-        truncate(artwork.title, TITLE_MAX_LENGTH), // omits date
         forSaleIndicationV2(artwork),
         "Artsy",
       ])

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -34,7 +34,7 @@ const forSaleIndication = (artwork) =>
 const forSaleIndicationV2 = (artwork) =>
   artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
     ? "For Sale"
-    : "Art & Prints"
+    : undefined
 
 const dimensions = (artwork) => artwork.dimensions[artwork.metric]
 
@@ -117,16 +117,17 @@ export default Meta
  *
  * ```
  * control   ➡︎ Mevlana Lipp | Cups (2021) | Available for Sale | Artsy
- * variant-a ➡︎ Mevlana Lipp | Cups (2021) | For Sale | Artsy
+ * variant-a ➡︎ Cups (2021) by Mevlana Lipp - For Sale | Artsy
  * ```
  */
 function generateTitle(artwork, variant) {
   switch (variant) {
     case "variant-a":
       return join(" | ", [
-        artistNames(artwork),
-        titleWithDateV2(artwork),
-        forSaleIndicationV2(artwork),
+        join(" - ", [
+          join(" by ", [titleWithDateV2(artwork), artistNames(artwork)]),
+          forSaleIndicationV2(artwork),
+        ]),
         "Artsy",
       ])
     default:


### PR DESCRIPTION
This PR closes [Artwork Title Test #1](https://app.notion.com/p/artsy/Artwork-Title-Tag-Test-1-FS-Remove-Available-Year-NFS-add-Art-Prints-336cab0764a081709078c67baf25a35e) and immediately replaces it with [Artwork Title Test #2](https://app.notion.com/p/artsy/Artwork-Title-Tag-Test-2-Swap-ordering-of-artwork-title-and-artist-name-364cab0764a08075aa32c30d7878e462)


To recap the effect of these tests on for-sale works:

|version|title format|
|---|---|
|original version|`Mevlana Lipp \| Cups (2021) \| Available for Sale \| Artsy`|
|Test #⁣1, before this PR|`Mevlana Lipp \| Cups (2021) \| For Sale \| Artsy`|
|Test #⁣2, after this PR|`Cups (2021) by Mevlana Lipp - For Sale \| Artsy`|

A non for-sale work appears similarly, but without any indication of availability, i.e. no "For Sale" copy.

cc @artsy/diamond-devs 