### PR TITLE
fix: handle missing artwork titles

### DIFF
--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -159,6 +159,24 @@ describe("Meta", () => {
         })
       })
 
+      describe("with a null title", () => {
+        const context = {
+          artworkLoader: () =>
+            Promise.resolve({
+              ...artworkData,
+              title: null,
+            }),
+        }
+
+        it("defaults to 'Untitled'", async () => {
+          const data = await runQuery(query, context as any)
+
+          expect(data.artwork.meta.title).toBe(
+            "Untitled (1975) by Hans Hartung - For Sale | Artsy"
+          )
+        })
+      })
+
       describe("with a long title", () => {
         const context = {
           artworkLoader: () =>

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -18,10 +18,13 @@ const isInquireAboutAvailability = (saleMessage) =>
   saleMessage == "Inquire about availability"
 
 const titleWithDate = ({ title, date }) =>
-  join(" ", [title, date ? `(${date})` : undefined])
+  join(" ", [title || "Untitled", date ? `(${date})` : undefined])
 
 const titleWithDateV2 = ({ title, date }) =>
-  join(" ", [truncate(title, TITLE_MAX_LENGTH), date ? `(${date})` : undefined])
+  join(" ", [
+    truncate(title || "Untitled", TITLE_MAX_LENGTH),
+    date ? `(${date})` : undefined,
+  ])
 
 export const artistNames = (artwork) =>
   artwork.cultural_maker || map(artwork.artists, "name").join(", ")


### PR DESCRIPTION
Follow-up to #7721 

As flagged [here](https://artsy.slack.com/archives/C05EEBNEF71/p1782160052365629?thread_ts=1782159119.249549&cid=C05EEBNEF71), a fraction of artworks are missing titles and were therefore showing up with funny looking title tags.

Although these may be improperly catalogued works rather than truly untitled ones, we follow the same logic as the artwork tombstone itself here, and display these with a sensible default title of "Untitled".

### Before

```
null by Michael Patterson-Carver | Artsy
```

### After

```
Untitled by Michael Patterson-Carver | Artsy
```

cc @artsy/diamond-devs 