### PR TITLE
feat: add hybrid search args to artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -466,6 +466,15 @@ type Alert {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -516,6 +525,9 @@ type Alert {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -1904,6 +1916,15 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -1954,6 +1975,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -2380,6 +2404,15 @@ type ArtistPartnerEdge {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -2430,6 +2463,9 @@ type ArtistPartnerEdge {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -2557,6 +2593,15 @@ type ArtistSeries implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -2607,6 +2652,9 @@ type ArtistSeries implements Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -3586,6 +3634,15 @@ type ArtworkFilterNode {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -3636,6 +3693,9 @@ type ArtworkFilterNode {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -13520,6 +13580,15 @@ interface EntityWithFilterArtworksConnectionInterface {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -13569,6 +13638,9 @@ interface EntityWithFilterArtworksConnectionInterface {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -13858,6 +13930,15 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -13908,6 +13989,9 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -14412,6 +14496,15 @@ input FilterArtworksInput {
   geneID: String
   geneIDs: [String]
   height: String
+
+  # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+  hybridNeuralK: Int
+
+  # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+  hybridPaginationDepth: Int
+
+  # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+  hybridWeights: [Float!]
   importSources: [String]
   includeAllJSON: Boolean
   includeArtworksByFollowedArtists: Boolean
@@ -14461,6 +14554,9 @@ input FilterArtworksInput {
   sold: Boolean
   sort: String
   tagID: String
+
+  # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+  variant: String
   viewingRoomID: ID
   visibilityLevel: String
   width: String
@@ -14989,6 +15085,15 @@ type Gene implements Node & Searchable {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -15039,6 +15144,9 @@ type Gene implements Node & Searchable {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -17274,6 +17382,15 @@ type MarketingCollection implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -17324,6 +17441,9 @@ type MarketingCollection implements Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -21081,6 +21201,15 @@ type Partner implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -21131,6 +21260,9 @@ type Partner implements Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -21484,6 +21616,15 @@ type PartnerArtist {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -21534,6 +21675,9 @@ type PartnerArtist {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -21694,6 +21838,15 @@ type PartnerArtistEdge {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -21744,6 +21897,9 @@ type PartnerArtistEdge {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -23205,6 +23361,15 @@ type Query {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -23255,6 +23420,9 @@ type Query {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -23619,6 +23787,15 @@ type Query {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -23669,6 +23846,9 @@ type Query {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -26413,6 +26593,15 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -26463,6 +26652,9 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -27029,6 +27221,15 @@ type Tag implements Node {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -27079,6 +27280,9 @@ type Tag implements Node {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -30409,6 +30613,15 @@ type Viewer {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -30459,6 +30672,9 @@ type Viewer {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String
@@ -30697,6 +30913,15 @@ type Viewer {
     geneID: String
     geneIDs: [String]
     height: String
+
+    # Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.
+    hybridNeuralK: Int
+
+    # Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.
+    hybridPaginationDepth: Int
+
+    # Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.
+    hybridWeights: [Float!]
     importSources: [String]
     includeAllJSON: Boolean
     includeArtworksByFollowedArtists: Boolean
@@ -30747,6 +30972,9 @@ type Viewer {
     sold: Boolean
     sort: String
     tagID: String
+
+    # Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.
+    variant: String
     viewingRoomID: ID
     visibilityLevel: String
     width: String

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -943,6 +943,309 @@ describe("artworksConnection", () => {
     })
   })
 
+  describe("filter by variant", () => {
+    const mockFilterArtworksLoader = jest.fn((_args) => {
+      return Promise.resolve({
+        hits: [
+          {
+            id: "kaws-toys",
+          },
+        ],
+        aggregations: {
+          total: {
+            value: 1,
+          },
+        },
+      })
+    })
+
+    const context = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: mockFilterArtworksLoader,
+      },
+    }
+
+    it("passes variant to Gravity when provided", async () => {
+      const query = gql`
+        {
+          artworksConnection(input: { variant: "hybrid", first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "hybrid",
+        })
+      )
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "kaws-toys" } },
+      ])
+    })
+
+    it("does not pass variant to Gravity when omitted", async () => {
+      const query = gql`
+        {
+          artworksConnection(input: { first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          variant: expect.anything(),
+        })
+      )
+    })
+  })
+
+  describe("hybrid search tuning args", () => {
+    const mockFilterArtworksLoader = jest.fn((_args) => {
+      return Promise.resolve({
+        hits: [
+          {
+            id: "kaws-toys",
+          },
+        ],
+        aggregations: {
+          total: {
+            value: 1,
+          },
+        },
+      })
+    })
+
+    const context = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: mockFilterArtworksLoader,
+      },
+    }
+
+    it("passes the hybrid args to Gravity when variant is hybrid", async () => {
+      const query = gql`
+        {
+          artworksConnection(
+            input: {
+              variant: "hybrid"
+              hybridNeuralK: 50
+              hybridWeights: [0.3, 0.7]
+              hybridPaginationDepth: 500
+              first: 10
+            }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "hybrid",
+          hybrid_neural_k: 50,
+          hybrid_weights: [0.3, 0.7],
+          hybrid_pagination_depth: 500,
+        })
+      )
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "kaws-toys" } },
+      ])
+    })
+
+    it("does not pass any hybrid args to Gravity when omitted", async () => {
+      const query = gql`
+        {
+          artworksConnection(input: { variant: "hybrid", first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          hybrid_neural_k: expect.anything(),
+        })
+      )
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          hybrid_weights: expect.anything(),
+        })
+      )
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          hybrid_pagination_depth: expect.anything(),
+        })
+      )
+    })
+
+    it("throws when a hybrid arg is provided without variant: hybrid", async () => {
+      const query = gql`
+        {
+          artworksConnection(input: { hybridNeuralK: 50, first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        '`hybridNeuralK`, `hybridWeights`, and `hybridPaginationDepth` can only be used when `variant` is "hybrid".'
+      )
+    })
+
+    it("throws when a hybrid arg is provided with a non-hybrid variant", async () => {
+      const query = gql`
+        {
+          artworksConnection(
+            input: { variant: "keyword", hybridWeights: [0.5, 0.5], first: 10 }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        '`hybridNeuralK`, `hybridWeights`, and `hybridPaginationDepth` can only be used when `variant` is "hybrid".'
+      )
+    })
+
+    it("throws when hybridNeuralK is out of range", async () => {
+      const tooLow = gql`
+        {
+          artworksConnection(
+            input: { variant: "hybrid", hybridNeuralK: 0, first: 10 }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(tooLow, context)).rejects.toThrow(
+        "`hybridNeuralK` must be between 1 and 200."
+      )
+
+      const tooHigh = gql`
+        {
+          artworksConnection(
+            input: { variant: "hybrid", hybridNeuralK: 201, first: 10 }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(tooHigh, context)).rejects.toThrow(
+        "`hybridNeuralK` must be between 1 and 200."
+      )
+    })
+
+    it("throws when hybridPaginationDepth is out of range", async () => {
+      const tooLow = gql`
+        {
+          artworksConnection(
+            input: { variant: "hybrid", hybridPaginationDepth: 0, first: 10 }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(tooLow, context)).rejects.toThrow(
+        "`hybridPaginationDepth` must be between 1 and 10000."
+      )
+
+      const tooHigh = gql`
+        {
+          artworksConnection(
+            input: {
+              variant: "hybrid"
+              hybridPaginationDepth: 10001
+              first: 10
+            }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(tooHigh, context)).rejects.toThrow(
+        "`hybridPaginationDepth` must be between 1 and 10000."
+      )
+    })
+
+    it("throws when hybridWeights does not contain exactly two floats", async () => {
+      const query = gql`
+        {
+          artworksConnection(
+            input: { variant: "hybrid", hybridWeights: [0.5], first: 10 }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await expect(runQuery(query, context)).rejects.toThrow(
+        "`hybridWeights` must contain exactly two floats."
+      )
+    })
+  })
+
   describe("CMS request filtering", () => {
     describe("simple CMS requests", () => {
       it("uses partnerArtworksAllLoader for simple CMS requests", async () => {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -2,6 +2,7 @@ import {
   GraphQLBoolean,
   GraphQLFieldConfig,
   GraphQLFieldConfigArgumentMap,
+  GraphQLFloat,
   GraphQLID,
   GraphQLInputObjectType,
   GraphQLInt,
@@ -280,6 +281,26 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   viewingRoomID: {
     type: GraphQLID,
   },
+  variant: {
+    type: GraphQLString,
+    description:
+      "Search strategy. 'hybrid' blends semantic (meaning-based) results into the keyword search. Requires a keyword; team-only.",
+  },
+  hybridNeuralK: {
+    type: GraphQLInt,
+    description:
+      "Hybrid only: how many candidates the semantic arm retrieves. Higher = wider semantic net.",
+  },
+  hybridWeights: {
+    type: new GraphQLList(new GraphQLNonNull(GraphQLFloat)),
+    description:
+      "Hybrid only: [lexical, neural] balance when blending scores, e.g. [0.5,0.5] equal, [0.3,0.7] favors semantic.",
+  },
+  hybridPaginationDepth: {
+    type: GraphQLInt,
+    description:
+      "Hybrid only: results each arm contributes to the blend; must be ≥ from + page size. Caps pagination depth.",
+  },
   signed: {
     type: GraphQLBoolean,
     description: "When true, will only return signed artworks.",
@@ -516,6 +537,10 @@ const convertFilterArgs = ({
   showID,
   sizes,
   tagID,
+  variant,
+  hybridNeuralK,
+  hybridWeights,
+  hybridPaginationDepth,
   viewingRoomID,
   visibilityLevel,
   ..._options
@@ -562,6 +587,10 @@ const convertFilterArgs = ({
     sale_id: saleID,
     sizes: sizes,
     tag_id: tagID,
+    variant: variant,
+    hybrid_neural_k: hybridNeuralK,
+    hybrid_weights: hybridWeights,
+    hybrid_pagination_depth: hybridPaginationDepth,
     viewing_room_id: viewingRoomID,
     visibility_level: visibilityLevel,
     ..._options,
@@ -607,6 +636,10 @@ const filterArtworksConnectionTypeFactory = (
       include_all_json,
       visibility_level,
       price_range,
+      variant,
+      hybrid_neural_k,
+      hybrid_weights,
+      hybrid_pagination_depth,
       aggregations: aggregationOptions = [],
     } = options
 
@@ -618,6 +651,36 @@ const filterArtworksConnectionTypeFactory = (
     // inc-223
     if (price_range === "*-1") {
       throw new Error("Invalid input")
+    }
+
+    // Hybrid search tuning args only apply when `variant` is "hybrid".
+    const hybridArgsProvided =
+      hybrid_neural_k != null ||
+      hybrid_weights != null ||
+      hybrid_pagination_depth != null
+
+    if (hybridArgsProvided && variant !== "hybrid") {
+      throw new Error(
+        '`hybridNeuralK`, `hybridWeights`, and `hybridPaginationDepth` can only be used when `variant` is "hybrid".'
+      )
+    }
+
+    if (
+      hybrid_neural_k != null &&
+      (hybrid_neural_k < 1 || hybrid_neural_k > 200)
+    ) {
+      throw new Error("`hybridNeuralK` must be between 1 and 200.")
+    }
+
+    if (
+      hybrid_pagination_depth != null &&
+      (hybrid_pagination_depth < 1 || hybrid_pagination_depth > 10000)
+    ) {
+      throw new Error("`hybridPaginationDepth` must be between 1 and 10000.")
+    }
+
+    if (hybrid_weights != null && hybrid_weights.length !== 2) {
+      throw new Error("`hybridWeights` must contain exactly two floats.")
     }
 
     const requestedPersonalizedAggregation = aggregationOptions.includes(


### PR DESCRIPTION
> [!NOTE]
> Depends on https://github.com/artsy/gravity/pull/20282

Adds a `variant` argument to `artworksConnection`, plus three hybrid-only tuning arguments that are forwarded to Gravity:

- `variant` (`String`) — search strategy; `"hybrid"` blends semantic results into keyword search.
- `hybridNeuralK` (`Int`, 1–200) — how many candidates the semantic arm retrieves.
- `hybridWeights` (`[Float!]`, exactly two) — `[lexical, neural]` score balance.
- `hybridPaginationDepth` (`Int`, 1–10000) — results each arm contributes to the blend.

Last 3 are for experimentation only — once we settle on values they should be configured in Gravity.

The args map to Gravity's `variant`, `hybrid_neural_k`, `hybrid_weights`, and `hybrid_pagination_depth`. When an arg is omitted, nothing extra is sent to Gravity. The three `hybrid*` args only apply when `variant: "hybrid"`.