### PR TITLE
chore: remove artsy-mcp repo from schema syncing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
     executor:
       name: node/default
       tag: "22.5"
-    parallelism: 7
+    parallelism: 6
     steps:
       - checkout
       - setup_hokusai

--- a/scripts/push-schema-changes.js
+++ b/scripts/push-schema-changes.js
@@ -88,12 +88,6 @@ async function updateSchemaFile({
  * update .circleci/config.yml `push-schema-changes` job parallelism count to match
  */
 const supportedRepos = {
-  "artsy-mcp": {
-    skipInstall: true,
-    skipRelay: true,
-    skipPrettier: true,
-    destinations: ["apps/artsy-mcp/data/schema.graphql"],
-  },
   eigen: {
     body: `${defaultBody} #nochangelog`,
     skipDeprecatedEngineCheck: true,


### PR DESCRIPTION
I haven't been following the artsy agent stuff, but this job is breaking and I think the fix is to remove the repo?