### PR TITLE
feat: expose public location in artwork type

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3160,7 +3160,7 @@ type Artwork implements Node & Searchable & Sellable {
   listingOptions: ArtworkListingOptions
   literature(format: Format): String
 
-  # Represents partner's location
+  # Represents partner's location (authorized users only)
   location: Location
   manufacturer(format: Format): String
   marketPriceInsights: ArtworkPriceInsights
@@ -3237,6 +3237,9 @@ type Artwork implements Node & Searchable & Sellable {
   # Returns true if this work is eligible to be automatically opted into Artsy Domestic Shipping
   processWithArtsyShippingDomestic: Boolean
   provenance(format: Format): String
+
+  # Represents partner's public-facing location (a subset of the full location)
+  publicLocation: Location
 
   # Whether this artwork is published or not
   published: Boolean!

--- a/src/schema/v2/artwork/__tests__/artwork.test.js
+++ b/src/schema/v2/artwork/__tests__/artwork.test.js
@@ -132,6 +132,67 @@ describe("Artwork type", () => {
     })
   })
 
+  describe("#publicLocation", () => {
+    const query = `
+      {
+        artwork(id: "richard-prince-untitled-portrait") {
+          publicLocation {
+            internalID
+            city
+            state
+            country
+            postalCode
+          }
+        }
+      }
+    `
+
+    it("returns the artwork's public location", async () => {
+      artwork = {
+        ...artwork,
+        public_location: {
+          id: "5a1b2c3d4e5f60001234abcd",
+          city: "New York",
+          state: "NY",
+          country: "US",
+          postal_code: "10013",
+        },
+      }
+
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          publicLocation: {
+            internalID: "5a1b2c3d4e5f60001234abcd",
+            city: "New York",
+            state: "NY",
+            country: "US",
+            postalCode: "10013",
+          },
+        },
+      })
+    })
+
+    it("returns null when there is no public location", async () => {
+      context = {
+        artworkLoader: () => Promise.resolve(artwork),
+      }
+
+      const data = await runQuery(query, context)
+
+      expect(data).toEqual({
+        artwork: {
+          publicLocation: null,
+        },
+      })
+    })
+  })
+
   describe("#importSource", () => {
     const query = `
       {

--- a/src/schema/v2/artwork/index.ts
+++ b/src/schema/v2/artwork/index.ts
@@ -1266,7 +1266,13 @@ export const ArtworkType = new GraphQLObjectType<any, ResolverContext>({
       location: {
         type: LocationType,
         resolve: ({ location }) => location,
-        description: "Represents partner's location",
+        description: "Represents partner's location (authorized users only)",
+      },
+      publicLocation: {
+        type: LocationType,
+        resolve: ({ public_location }) => public_location,
+        description:
+          "Represents partner's public-facing location (a subset of the full location)",
       },
       manufacturer: markdown(),
       medium: {


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-3279

This exposes the public location in the artwork type. The data (specifically postal code) will be used to fetch more accurate shipping estimate from Arta widget.