### PR TITLE
feat: add staging canary

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -399,7 +399,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "20"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
 spec:
   ingressClassName: external-nginx
   rules:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -399,7 +399,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "10"
+    nginx.ingress.kubernetes.io/canary-weight: "20"
 spec:
   ingressClassName: external-nginx
   rules:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -133,6 +133,143 @@ spec:
         emptyDir: {}
 
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metaphysics-web-canary
+  labels:
+    app: metaphysics
+    layer: application
+    component: web-canary
+    app.kubernetes.io/version: production
+  namespace: default
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 20%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: metaphysics
+      layer: application
+      component: web-canary
+  template:
+    metadata:
+      labels:
+        app: metaphysics
+        layer: application
+        component: web-canary
+        app.kubernetes.io/version: production
+      name: metaphysics-web-canary
+    spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/fortress:production
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load/load.py
+        - kubernetes
+        - production
+        - metaphysics
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+      containers:
+      - name: metaphysics-web-canary
+        env:
+        - name: PORT
+          value: '3000'
+        - name: DD_TRACER_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DD_TRACER_SERVICE_NAME
+          value: metaphysics-canary
+        - name: STATSD_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NODE_OPTIONS
+          value: --max_old_space_size=768
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        - configMapRef:
+            name: metaphysics-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
+        imagePullPolicy: Always
+        ports:
+        - name: mp-http
+          containerPort: 3000
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 768Mi
+          limits:
+            memory: 1.5Gi
+        readinessProbe:
+          httpGet:
+            port: mp-http
+            path: /health
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 10
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: '1'
+      serviceAccountName: metaphysics
+      tolerations:
+        - key: reserved
+          operator: Equal
+          value: spot
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+                - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
+---
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -143,6 +280,26 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: metaphysics-web
+  minReplicas: 10
+  maxReplicas: 35
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 50
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metaphysics-web-canary
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metaphysics-web-canary
   minReplicas: 10
   maxReplicas: 35
   metrics:
@@ -171,6 +328,27 @@ spec:
     app: metaphysics
     layer: application
     component: web
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metaphysics
+    layer: application
+    component: web-canary
+  name: metaphysics-web-canary-internal
+  namespace: default
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+    name: mp-http
+  selector:
+    app: metaphysics
+    layer: application
+    component: web-canary
   type: ClusterIP
 ---
 apiVersion: networking.k8s.io/v1
@@ -210,5 +388,48 @@ spec:
         backend:
           service:
             name: metaphysics-web-internal
+            port:
+              name: mp-http
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metaphysics-2025-canary
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "10"
+spec:
+  ingressClassName: external-nginx
+  rules:
+  - host: metaphysics-production.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
+            port:
+              name: mp-http
+  - host: metaphysics-cdn.artsy.net # routes to Cloudflare worker
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
+            port:
+              name: mp-http
+  - host: metaphysics-production-alt.artsy.net # preserve this legacy worker hostname until traffic fully migrates away
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
             port:
               name: mp-http

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -399,7 +399,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "50"
+    nginx.ingress.kubernetes.io/canary-weight: "100"
 spec:
   ingressClassName: external-nginx
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -53,8 +53,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        - name: DD_TRACER_SERVICE_NAME
-          value: metaphysics-canary
         - name: STATSD_HOST
           valueFrom:
             fieldRef:
@@ -176,6 +174,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: DD_TRACER_SERVICE_NAME
+          value: metaphysics-canary
         - name: STATSD_HOST
           valueFrom:
             fieldRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -53,6 +53,129 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: DD_TRACER_SERVICE_NAME
+          value: metaphysics-canary
+        - name: STATSD_HOST
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NODE_OPTIONS
+          value: --max_old_space_size=768
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        - configMapRef:
+            name: metaphysics-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/metaphysics:staging
+        imagePullPolicy: Always
+        ports:
+        - name: mp-http
+          containerPort: 3000
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            memory: 1Gi
+        readinessProbe:
+          httpGet:
+            port: mp-http
+            path: /health
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 10
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: '1'
+      serviceAccountName: metaphysics
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metaphysics-web-canary
+  namespace: default
+  labels:
+    app: metaphysics
+    layer: application
+    component: web-canary
+    app.kubernetes.io/version: staging
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: metaphysics
+      layer: application
+      component: web-canary
+  template:
+    metadata:
+      labels:
+        app: metaphysics
+        layer: application
+        component: web-canary
+        app.kubernetes.io/version: staging
+      name: metaphysics-web-canary
+    spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/fortress:staging
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load/load.py
+        - kubernetes
+        - staging
+        - metaphysics
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+      containers:
+      - name: metaphysics-web-canary
+        env:
+        - name: PORT
+          value: '3000'
+        - name: DD_TRACER_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: STATSD_HOST
           valueFrom:
             fieldRef:
@@ -138,6 +261,28 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: metaphysics-web-canary
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: metaphysics-web-canary
+  minReplicas: 2
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+
 ---
 apiVersion: v1
 kind: Service
@@ -159,6 +304,29 @@ spec:
     layer: application
     component: web
   type: ClusterIP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: metaphysics
+    layer: application
+    component: web-canary
+  name: metaphysics-web-canary-internal
+  namespace: default
+spec:
+  ports:
+  - port: 3000
+    protocol: TCP
+    name: mp-http
+    targetPort: mp-http
+  selector:
+    app: metaphysics
+    layer: application
+    component: web-canary
+  type: ClusterIP
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -199,3 +367,47 @@ spec:
             name: metaphysics-web-internal
             port:
               name: mp-http
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: metaphysics-2025-canary
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "50"
+spec:
+  ingressClassName: external-nginx
+  rules:
+  - host: metaphysics-staging.artsy.net
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
+            port:
+              name: mp-http
+  - host: metaphysics-cdn-staging.artsy.net # routes to Cloudflare worker
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
+            port:
+              name: mp-http
+  - host: metaphysics-staging-alt.artsy.net # preserve this legacy worker hostname until traffic fully migrates away
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: metaphysics-web-canary-internal
+            port:
+              name: mp-http
+

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -376,7 +376,7 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
     nginx.ingress.kubernetes.io/canary: "true"
-    nginx.ingress.kubernetes.io/canary-weight: "50"
+    nginx.ingress.kubernetes.io/canary-weight: "0"
 spec:
   ingressClassName: external-nginx
   rules:


### PR DESCRIPTION
This PR demonstrates adding a canary deployment in Staging.

- Add canary `Deployment` and override Datadog `DD_TRACER_SERVICE_NAME`
- Add canary `HorizontalPodAutoscaler`
- Add canary `Service`
- Add canary `Ingress`

Deploy the canary via:

```
hokusai staging/production update --skip-checks
```

Check metrics on Datadog:
- [canonical](https://app.datadoghq.com/apm/entity/service%3Ametaphysics?dependencyMap.showNetworkMetrics=false&env=staging&fromUser=false&graphType=service_map&groupMapByOperation=null&operationName=express.request&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&shouldShowLegend=true&spanKind=server&traceQuery=&start=1783004986637&end=1783005886637&paused=false)

- [canary](https://app.datadoghq.com/apm/entity/service%3Ametaphysics-canary?dependencyMap.showNetworkMetrics=false&env=staging&fromUser=false&graphType=service_map&groupMapByOperation=null&operationName=express.request&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&shouldShowLegend=true&spanKind=server&traceQuery=&start=1783004976635&end=1783005876635&paused=false)

[Google cloud logs](https://console.cloud.google.com/logs/query;query=logName%3D%22projects%2Flogging-492917%2Flogs%2Fkubernetes%22%0Alabels.%22k8s.pod.name%22%3D~%22metaphysics-web*%22;summaryFields=labels%252F%2522k8s.pod.name%2522:false:32:beginning;cursorTimestamp=2026-07-02T15:26:11.874903259Z;duration=P1D?project=logging-492917).


## Rollback steps (on Production/Staging)
1. Git checkout `main` (which reverts the changes made in this branch to `production.yml` or `staging.yml` )
2. run `hokusai staging/production update --skip-checks`
3. Manually delete canary Kubernetes objects:
```
kubectl --context staging/production delete ingress metaphysics-2025-canary
kubectl --context staging/production delete service metaphysics-web-canary-internal
kubectl --context staging/production delete hpa metaphysics-web-canary
kubectl --context staging/production delete deployment metaphysics-web-canary
```
