### PR TITLE
chore: Favor non-square version for brand kit logo

### DIFF
--- a/src/schema/v2/image/__tests__/imageHelper.test.ts
+++ b/src/schema/v2/image/__tests__/imageHelper.test.ts
@@ -309,11 +309,11 @@ describe("imageHelper", () => {
       expect(hasProcessingFailed(freshImage)).toBe(false)
     })
 
-    it("treats a fully processed logo (only square_brand_kit) as done — not still processing, not failed", () => {
+    it("treats a fully processed logo (only logo_brand_kit) as done — not still processing, not failed", () => {
       const successImage = {
         ...brandKitImage,
         image_url: "https://example.com/logo/:version.jpg",
-        image_versions: ["square_brand_kit"],
+        image_versions: ["logo_brand_kit"],
         gemini_token_updated_at: new Date().toISOString(),
       }
 
@@ -337,14 +337,14 @@ describe("imageHelper", () => {
     it("does not require artwork versions to consider a brand-kit logo complete", () => {
       const image = {
         ...brandKitImage,
-        image_versions: ["square_brand_kit"],
+        image_versions: ["logo_brand_kit"],
       }
 
       expect(hasMissingImageVersion(image)).toBe(false)
     })
 
     it("falls back to artwork expectations when gemini_template_key is absent", () => {
-      const image = { image_versions: ["square_brand_kit"] }
+      const image = { image_versions: ["logo_brand_kit"] }
 
       expect(hasMissingImageVersion(image)).toBe(true)
     })

--- a/src/schema/v2/image/imageHelper.ts
+++ b/src/schema/v2/image/imageHelper.ts
@@ -15,13 +15,13 @@ export const EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE = {
     "square",
     "tall",
   ],
-  "brand-kit-logo": ["square_brand_kit"],
+  "brand-kit-logo": ["logo_brand_kit"],
 } as const
 
 // The last version Gemini emits per template — its presence signals processing is complete.
 export const COMPLETION_VERSION_BY_TEMPLATE = {
   "additional-image": "normalized",
-  "brand-kit-logo": "square_brand_kit",
+  "brand-kit-logo": "logo_brand_kit",
 } as const
 
 type TemplateKey = keyof typeof EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE

--- a/src/schema/v2/partner/__tests__/brandKit.test.ts
+++ b/src/schema/v2/partner/__tests__/brandKit.test.ts
@@ -198,10 +198,10 @@ describe("Partner brandKit field", () => {
             gemini_token_updated_at: recentTime,
             image_url: "https://d7hftxdivxxvm.cloudfront.net/abc/:version.jpg",
             image_urls: {
-              square_brand_kit:
-                "https://d7hftxdivxxvm.cloudfront.net/abc/square_brand_kit.jpg",
+              logo_brand_kit:
+                "https://d7hftxdivxxvm.cloudfront.net/abc/logo_brand_kit.jpg",
             },
-            image_versions: ["square_brand_kit"],
+            image_versions: ["logo_brand_kit"],
             original_width: 1200,
             original_height: 800,
             aspect_ratio: 1.5,
@@ -214,7 +214,7 @@ describe("Partner brandKit field", () => {
         geminiToken: "tok-xyz",
         geminiTokenUpdatedAt: recentTime,
         imageURL: "https://d7hftxdivxxvm.cloudfront.net/abc/:version.jpg",
-        imageVersions: ["square_brand_kit"],
+        imageVersions: ["logo_brand_kit"],
         originalWidth: 1200,
         originalHeight: 800,
         aspectRatio: 1.5,


### PR DESCRIPTION
[notion card](https://app.notion.com/p/artsy/Non-square-Brand-logo-doesn-t-look-good-397cab0764a080dcb566d1fd265b0173)

Favor the new version setup on Gemini for brand kit logo, so we don't force square processing in the result, which don't always look ideal.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 