### PR TITLE
chore: Expose strategy details on feature flag query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19059,7 +19059,7 @@ type FeatureFlagEnvironments {
 type FeatureFlagSegment {
   constraints: [FeatureFlagConstraint]
   description: String
-  id: Int
+  internalID: Int
   name: String
 }
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19031,9 +19031,37 @@ type FeatureFlag {
   variants: [FeatureFlagVariantType]
 }
 
+type FeatureFlagConstraint {
+  caseInsensitive: Boolean
+  contextName: String
+  inverted: Boolean
+  operator: String
+  value: String
+  values: [String]
+}
+
 type FeatureFlagEnvironments {
   enabled: Boolean!
   name: String!
+  strategies: [FeatureFlagStrategy]
+}
+
+type FeatureFlagSegment {
+  constraints: [FeatureFlagConstraint]
+  description: String
+  id: Int
+  name: String
+}
+
+type FeatureFlagStrategy {
+  constraints: [FeatureFlagConstraint]
+  name: String
+  parameters: JSON
+
+  """
+  Constraints applied to this strategy via a reusable, named Unleash segment (as opposed to inline constraints)
+  """
+  segments: [FeatureFlagSegment]
 }
 
 input FeatureFlagStrategyInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19036,6 +19036,16 @@ type FeatureFlagConstraint {
   contextName: String
   inverted: Boolean
   operator: String
+
+  """
+  The Partners referenced by this constraint's values, resolved when contextName is `partnerId`
+  """
+  partnerConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): PartnerConnection
   value: String
   values: [String]
 }

--- a/src/lib/loaders/loaders_with_authentication/unleash.ts
+++ b/src/lib/loaders/loaders_with_authentication/unleash.ts
@@ -91,5 +91,6 @@ export const unleashLoaders = (accessToken, opts) => {
     ),
     adminProjectsLoader: unleashLoader("projects"),
     adminProjectLoader: unleashLoader((id) => `projects/${id}`),
+    adminSegmentsLoader: unleashLoader("segments"),
   }
 }

--- a/src/schema/v2/featureFlags/admin/__tests__/featureFlags.test.ts
+++ b/src/schema/v2/featureFlags/admin/__tests__/featureFlags.test.ts
@@ -149,3 +149,96 @@ describe("FeatureFlagConstraint.partnerConnection", () => {
     })
   })
 })
+
+describe("FeatureFlagStrategy.segments", () => {
+  let context
+
+  const featureFlagWithSegments = (segmentIDs) => ({
+    name: "my-flag",
+    description: null,
+    type: "RELEASE",
+    stale: false,
+    impressionData: false,
+    createdAt: "2024-01-01",
+    lastSeenAt: null,
+    project: "default",
+    variants: [],
+    environments: [
+      {
+        name: "production",
+        enabled: true,
+        strategies: [
+          {
+            name: "flexibleRollout",
+            parameters: {},
+            segments: segmentIDs,
+            constraints: [],
+          },
+        ],
+      },
+    ],
+  })
+
+  const query = gql`
+    {
+      admin {
+        featureFlag(id: "my-flag") {
+          environments {
+            strategies {
+              segments {
+                internalID
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  beforeEach(() => {
+    context = {
+      adminSegmentsLoader: () =>
+        Promise.resolve({
+          segments: [
+            { id: 1, name: "Segment One", description: null, constraints: [] },
+            { id: 2, name: "Segment Two", description: null, constraints: [] },
+          ],
+        }),
+    }
+  })
+
+  it("returns only the segments referenced by the strategy's segment ids", async () => {
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(featureFlagWithSegments([2]))
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].segments
+    ).toEqual([{ internalID: 2, name: "Segment Two" }])
+  })
+
+  it("returns an empty list when the strategy has no segment ids", async () => {
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(featureFlagWithSegments([]))
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].segments
+    ).toEqual([])
+  })
+
+  it("returns an empty list when adminSegmentsLoader is unavailable", async () => {
+    delete context.adminSegmentsLoader
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(featureFlagWithSegments([1]))
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].segments
+    ).toEqual([])
+  })
+})

--- a/src/schema/v2/featureFlags/admin/__tests__/featureFlags.test.ts
+++ b/src/schema/v2/featureFlags/admin/__tests__/featureFlags.test.ts
@@ -1,0 +1,151 @@
+import { runQueryOrThrow } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+const { schema } = require("schema/v2")
+
+const runQuery = (query, context) =>
+  runQueryOrThrow({
+    schema,
+    source: query,
+    rootValue: {},
+    contextValue: context,
+  })
+
+describe("FeatureFlagConstraint.partnerConnection", () => {
+  let context
+
+  const featureFlagWithConstraint = (constraint) => ({
+    name: "my-flag",
+    description: null,
+    type: "RELEASE",
+    stale: false,
+    impressionData: false,
+    createdAt: "2024-01-01",
+    lastSeenAt: null,
+    project: "default",
+    variants: [],
+    environments: [
+      {
+        name: "production",
+        enabled: true,
+        strategies: [
+          {
+            name: "flexibleRollout",
+            parameters: {},
+            segments: [],
+            constraints: [constraint],
+          },
+        ],
+      },
+    ],
+  })
+
+  const query = gql`
+    {
+      admin {
+        featureFlag(id: "my-flag") {
+          environments {
+            strategies {
+              constraints {
+                contextName
+                partnerConnection(first: 5) {
+                  totalCount
+                  edges {
+                    node {
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const constraint = ({ contextName, values, ...rest }) =>
+    ({
+      contextName,
+      values,
+      operator: "IN",
+      inverted: false,
+      caseInsensitive: false,
+      ...rest,
+    } as any)
+
+  beforeEach(() => {
+    context = {
+      partnersLoader: (options) =>
+        Promise.resolve({
+          body: options.id.map((id) => ({ id, name: `Partner ${id}` })),
+          headers: {
+            "x-total-count": String(options.id.length),
+          },
+        }),
+    }
+  })
+
+  it("resolves partners referenced by a partnerId constraint", async () => {
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(
+        featureFlagWithConstraint(
+          constraint({
+            contextName: "partnerId",
+            values: ["partner-one", "partner-two"],
+          })
+        )
+      )
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].constraints[0]
+    ).toEqual({
+      contextName: "partnerId",
+      partnerConnection: {
+        totalCount: 2,
+        edges: [
+          { node: { name: "Partner partner-one" } },
+          { node: { name: "Partner partner-two" } },
+        ],
+      },
+    })
+  })
+
+  it("returns null when contextName is not partnerId", async () => {
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(
+        featureFlagWithConstraint(
+          constraint({ contextName: "userId", values: ["user-one"] })
+        )
+      )
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].constraints[0]
+    ).toEqual({
+      contextName: "userId",
+      partnerConnection: null,
+    })
+  })
+
+  it("returns null when there are no values", async () => {
+    context.adminFeatureFlagLoader = () =>
+      Promise.resolve(
+        featureFlagWithConstraint(
+          constraint({ contextName: "partnerId", values: [] })
+        )
+      )
+
+    const data = await runQuery(query, context)
+
+    expect(
+      data.admin.featureFlag.environments[0].strategies[0].constraints[0]
+    ).toEqual({
+      contextName: "partnerId",
+      partnerConnection: null,
+    })
+  })
+})

--- a/src/schema/v2/featureFlags/admin/featureFlags.ts
+++ b/src/schema/v2/featureFlags/admin/featureFlags.ts
@@ -74,11 +74,12 @@ const FeatureFlagConstraintType = new GraphQLObjectType<any, ResolverContext>({
   },
 })
 
-const FeatureFlagSegmentType = new GraphQLObjectType({
+const FeatureFlagSegmentType = new GraphQLObjectType<any, ResolverContext>({
   name: "FeatureFlagSegment",
   fields: {
-    id: {
+    internalID: {
       type: GraphQLInt,
+      resolve: ({ id }) => id,
     },
     name: {
       type: GraphQLString,
@@ -117,7 +118,7 @@ const FeatureFlagStrategyType = new GraphQLObjectType<any, ResolverContext>({
           return []
         }
 
-        const { segments } = await adminSegmentsLoader()
+        const { segments = [] } = await adminSegmentsLoader()
 
         return segments.filter((segment) => segmentIDs.includes(segment.id))
       },

--- a/src/schema/v2/featureFlags/admin/featureFlags.ts
+++ b/src/schema/v2/featureFlags/admin/featureFlags.ts
@@ -10,12 +10,16 @@ import {
 } from "graphql"
 import GraphQLJSON from "graphql-type-json"
 import { merge, sortBy } from "lodash"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
 import { ResolverContext } from "types/graphql"
 import { date } from "../../fields/date"
 import { base64 } from "lib/base64"
 import { GlobalIDField } from "../../object_identification"
+import { paginationResolver } from "../../fields/pagination"
+import { PartnerConnectionType } from "../../partner/partners"
 
-const FeatureFlagConstraintType = new GraphQLObjectType({
+const FeatureFlagConstraintType = new GraphQLObjectType<any, ResolverContext>({
   name: "FeatureFlagConstraint",
   fields: {
     contextName: {
@@ -35,6 +39,37 @@ const FeatureFlagConstraintType = new GraphQLObjectType({
     },
     caseInsensitive: {
       type: GraphQLBoolean,
+    },
+    partnerConnection: {
+      description:
+        "The Partners referenced by this constraint's values, resolved when contextName is `partnerId`",
+      type: PartnerConnectionType,
+      args: pageable({}),
+      resolve: async ({ contextName, values }, args, { partnersLoader }) => {
+        if (contextName !== "partnerId" || !values?.length) {
+          return null
+        }
+
+        const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+        const { body, headers } = await partnersLoader({
+          id: values,
+          page,
+          size,
+          total_count: true,
+        })
+
+        const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+        return paginationResolver({
+          totalCount,
+          offset,
+          page,
+          size,
+          body,
+          args,
+        })
+      },
     },
   },
 })

--- a/src/schema/v2/featureFlags/admin/featureFlags.ts
+++ b/src/schema/v2/featureFlags/admin/featureFlags.ts
@@ -8,11 +8,87 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
+import GraphQLJSON from "graphql-type-json"
 import { merge, sortBy } from "lodash"
 import { ResolverContext } from "types/graphql"
 import { date } from "../../fields/date"
 import { base64 } from "lib/base64"
 import { GlobalIDField } from "../../object_identification"
+
+const FeatureFlagConstraintType = new GraphQLObjectType({
+  name: "FeatureFlagConstraint",
+  fields: {
+    contextName: {
+      type: GraphQLString,
+    },
+    operator: {
+      type: GraphQLString,
+    },
+    values: {
+      type: new GraphQLList(GraphQLString),
+    },
+    value: {
+      type: GraphQLString,
+    },
+    inverted: {
+      type: GraphQLBoolean,
+    },
+    caseInsensitive: {
+      type: GraphQLBoolean,
+    },
+  },
+})
+
+const FeatureFlagSegmentType = new GraphQLObjectType({
+  name: "FeatureFlagSegment",
+  fields: {
+    id: {
+      type: GraphQLInt,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    description: {
+      type: GraphQLString,
+    },
+    constraints: {
+      type: new GraphQLList(FeatureFlagConstraintType),
+    },
+  },
+})
+
+const FeatureFlagStrategyType = new GraphQLObjectType<any, ResolverContext>({
+  name: "FeatureFlagStrategy",
+  fields: {
+    name: {
+      type: GraphQLString,
+    },
+    constraints: {
+      type: new GraphQLList(FeatureFlagConstraintType),
+    },
+    parameters: {
+      type: GraphQLJSON,
+    },
+    segments: {
+      description:
+        "Constraints applied to this strategy via a reusable, named Unleash segment (as opposed to inline constraints)",
+      type: new GraphQLList(FeatureFlagSegmentType),
+      resolve: async (
+        { segments: segmentIDs },
+        _args,
+        { adminSegmentsLoader }
+      ) => {
+        if (!adminSegmentsLoader || !segmentIDs?.length) {
+          return []
+        }
+
+        const { segments } = await adminSegmentsLoader()
+
+        return segments.filter((segment) => segmentIDs.includes(segment.id))
+      },
+    },
+  },
+})
 
 /**
  * An admin representation of an Unleash feature flag, used by Forque
@@ -37,6 +113,9 @@ export const AdminFeatureFlagType = new GraphQLObjectType<any, ResolverContext>(
               },
               enabled: {
                 type: new GraphQLNonNull(GraphQLBoolean),
+              },
+              strategies: {
+                type: new GraphQLList(FeatureFlagStrategyType),
               },
             },
           })

--- a/src/schema/v2/partner/partners.ts
+++ b/src/schema/v2/partner/partners.ts
@@ -21,6 +21,10 @@ import { ResolverContext } from "types/graphql"
 
 const DISTANCE_FALLBACK_SORT = "-created_at"
 
+export const PartnerConnectionType = connectionWithCursorInfo({
+  nodeType: PartnerType,
+}).connectionType
+
 export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLList(Partner.type),
   description: "A list of Partners",
@@ -190,7 +194,7 @@ export const Partners: GraphQLFieldConfig<void, ResolverContext> = {
 }
 
 export const PartnersConnection: GraphQLFieldConfig<void, ResolverContext> = {
-  type: connectionWithCursorInfo({ nodeType: PartnerType }).connectionType,
+  type: PartnerConnectionType,
   description: "A list of Partners",
   args: pageable({
     ids: {


### PR DESCRIPTION
When querying for Unleash feature flag, expose details on environments and strategies so we can surface info on enrolled parterns/users to admins.

In case of partners cohorts, also include details on partners under `partnerConnection`.

Forque PR: https://github.com/artsy/forque/pull/2122

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 