### PR TITLE
fix: conversation starter: Downstream 404 are being surfaced to users as hard crashes/500s

### DIFF
--- a/src/directives/principalField/__tests__/principalFieldDirectiveExtension.test.ts
+++ b/src/directives/principalField/__tests__/principalFieldDirectiveExtension.test.ts
@@ -1,0 +1,42 @@
+import { graphql, parse } from "graphql"
+import { HTTPError } from "lib/HTTPError"
+import { principalFieldDirectiveExtension } from "../principalFieldDirectiveExtension"
+
+describe("principalFieldDirectiveExtension", () => {
+  it("surfaces the HTTP status code when the @principalField loader rejects with an HTTPError", async () => {
+    const { schema } = require("schema/v2")
+
+    const query = `
+      {
+        viewingRoom(id: "some-deleted-viewing-room") @principalField {
+          internalID
+        }
+      }
+    `
+
+    const result = await graphql({
+      schema,
+      source: query,
+      contextValue: {
+        viewingRoomLoader: () =>
+          Promise.reject(
+            new HTTPError(
+              "Not Found",
+              404,
+              "Viewing Room Not Found: some-deleted-viewing-room"
+            )
+          ),
+      },
+    })
+
+    expect(result.errors).toBeTruthy()
+
+    const extensions = principalFieldDirectiveExtension(parse(query), result)
+
+    expect(extensions).toEqual({
+      principalField: {
+        httpStatusCode: 404,
+      },
+    })
+  })
+})

--- a/src/lib/graphqlErrorHandler.ts
+++ b/src/lib/graphqlErrorHandler.ts
@@ -30,13 +30,15 @@ export const flattenErrors = (error: GraphQLError) => {
     : [error]
 }
 
-// graphql-tools' stitching/delegation layer can re-wrap an already-located
-// GraphQLError in another GraphQLError as it crosses subschema boundaries,
-// nesting `originalError` one level deeper each time. Walk the chain to find
-// the underlying HTTPError instead of assuming it's one level down.
-const deepestOriginalError = (
-  e: Error | GraphQLError
-): Error | GraphQLError => {
+// An error can be wrapped in several nested `GraphQLError`s before it reaches
+// us: `graphql-middleware` (e.g. our @timeout middleware) wraps every resolver,
+// and graphql 16 re-locates the error at each execution layer it crosses,
+// nesting `originalError` one level deeper each time. (This reproduces even for
+// a plain local resolver, so it is not specific to stitching.) Walk the chain
+// to the underlying error instead of assuming it's exactly one level down.
+export const deepestOriginalError = (
+  e?: Error | GraphQLError | null
+): Error | GraphQLError | null | undefined => {
   let current = e
   while (current && (current as GraphQLError).originalError) {
     current = (current as GraphQLError).originalError as Error | GraphQLError
@@ -110,7 +112,7 @@ const reportErrorToSentry = (
   const href = `${baseURL}/graphiql?variables=${encodedVars}&query=${encodedQuery}`
 
   Sentry.captureException(
-    error.originalError || error,
+    deepestOriginalError(error) || error,
     Sentry.Handlers.parseRequest(
       {
         tags: { graphql: "exec_error" },

--- a/src/lib/graphqlErrorHandler.ts
+++ b/src/lib/graphqlErrorHandler.ts
@@ -30,6 +30,20 @@ export const flattenErrors = (error: GraphQLError) => {
     : [error]
 }
 
+// graphql-tools' stitching/delegation layer can re-wrap an already-located
+// GraphQLError in another GraphQLError as it crosses subschema boundaries,
+// nesting `originalError` one level deeper each time. Walk the chain to find
+// the underlying HTTPError instead of assuming it's one level down.
+const deepestOriginalError = (
+  e: Error | GraphQLError
+): Error | GraphQLError => {
+  let current = e
+  while (current && (current as GraphQLError).originalError) {
+    current = (current as GraphQLError).originalError as Error | GraphQLError
+  }
+  return current
+}
+
 export const statusCodeForError = (e) => {
   // Check for server-side errors during stitching downstream.
   // `e.originalError` is of `ServerError` type.
@@ -46,9 +60,11 @@ export const statusCodeForError = (e) => {
   const matchedCode: string | undefined = (matchedStatus || []).slice(-1)[0]
   const alternateStitchedStatusCode = matchedCode && parseInt(matchedCode)
 
+  const deepestError = deepestOriginalError(e)
+
   return (
     stitchedStatusCode ||
-    (e.originalError instanceof HTTPError && e.originalError.statusCode) ||
+    (deepestError instanceof HTTPError && deepestError.statusCode) ||
     alternateStitchedStatusCode
   )
 }


### PR DESCRIPTION
An increase in chatter from #alerts prompted some investigation into what was going on ([ref](https://artsy.slack.com/archives/C0HP61PUJ/p1783782914125449)) PS feel free to take this and run with it


Noticed Force was reporting a high level of `500s`, trending upwards over the past few days and disproportionately affecting `GET /viewing-rooms` and `fairs/shows`

With deeper investigation (I was trying to see if all these `500s` were incident worthy or not 😅 ), it seems like MP / Force were treating `404s` from Gravity differently than the other day.

## Trends over the past 7 days

[Force overall Datadog over past week](https://app.datadoghq.com/apm/entity/service%3Aforce?dependencyMap.showNetworkMetrics=false&env=production&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=true&graphType=flamegraph&groupMapByOperation=null&operationName=express.request&shouldShowLegend=true&spanKind=server&traceQuery=&start=1783178578759&end=1783783378759&paused=false)

<img width="1638" height="755" alt="Screenshot 2026-07-11 at 11 23 42 AM" src="https://github.com/user-attachments/assets/a2532ac4-2ca9-43ad-882d-82b64344c56e" />


Force [Error threshold alert over past week](https://app.datadoghq.com/monitors/6480731?event_id=AwAAAZ9RvkG4UPd71AAAABhBWjlSdnpOU0FBQk81ZjZqQS1YTGpVVE0AAAAkZjE5ZjUxYmUtNDFiOC00ZTg2LThiY2ItNWQyNGIyYTNlZTcwAAAAAA&fromUser=false&link_event_id=8716100039854448603&link_event_ts=1783782851&link_monitor_id=6480731&link_source=monitor_notif&from_ts=1783191186922&start=1783781951000&end=1783783151000&to_ts=1783795986922&live=true)


<img width="1719" height="606" alt="Screenshot 2026-07-11 at 2 53 54 PM" src="https://github.com/user-attachments/assets/9776e8d1-cb7e-4065-b9f3-1ceadb398a00" />


⚠️ Deducing that the increase in 500s is actually some breaking in our existing error handling after the larger graphql upgrade was deployed (see the roll out cadence and error trends) ⚠️ 


### Last week's experience
A few days before the graphql upgrades

Attempting to view a recently deleted or unpublished Viewing Room (`404 from gravity`) is gracefully handled as a `404`

<img width="1796" height="578" alt="Screenshot 2026-07-11 at 2 34 01 PM" src="https://github.com/user-attachments/assets/bbd16abf-7549-4feb-b104-414c93874e2f" />


<img width="1790" height="880" alt="Screenshot 2026-07-11 at 2 26 06 PM" src="https://github.com/user-attachments/assets/2d6896b4-3444-4c7f-b37b-4cb6c6bc9d55" />


### Today's experience
Attempting to view a recently deleted or unpublished Viewing Room (`404 from gravity`) is bubbling up as a `500` crash

<img width="1797" height="888" alt="Screenshot 2026-07-11 at 2 25 42 PM" src="https://github.com/user-attachments/assets/e5213fd2-762e-4928-a8e8-41d074da014e" />

<img width="1796" height="959" alt="Screenshot 2026-07-11 at 2 46 24 PM" src="https://github.com/user-attachments/assets/6efb0dab-937a-4d37-ad8f-e68f8cb99e42" />


## Want to repro on your own?
Find a recently unpublished or deleted record, in the cases I looked at above, most were recently deleted viewing rooms that were still cached and available on LIST pages `/viewing_rooms`

- https://staging.artsy.net/viewing-room/smart-coast-gallery-young-sung-kim-hyperrealistic-oil-on-canvas-81157ce1-3998-43bc-b89c-c4702d585b0b
- https://www.artsy.net/viewing-room/smart-coast-gallery-young-sung-kim-hyperrealistic-oil-on-canvas-81157ce1-3998-43bc-b89c-c4702d585b0b


Note the deleted at time stamp of today:
<img width="2046" height="959" alt="Screenshot 2026-07-11 at 3 06 04 PM" src="https://github.com/user-attachments/assets/760ab900-f7aa-4d26-9d38-d8ec95a7d5ea" />


---

This PR is a quick attempt to get us back into the `404` handling happy path, it does seem to work in local testing!
Probably shouldnt be rushed but just a heads up to on-call folks that #alerts and dashboards are going to be a little noisy! cc @amonkhouse 