### PR TITLE
feat(hack16): add instagramMedia field to artist

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2722,6 +2722,16 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   ): [ArtistInsight!]!
 
   """
+  Instagram media for display on an artist page.
+  """
+  instagramMedia(
+    """
+    The number of media items to return.
+    """
+    first: Int
+  ): [ArtistInstagramMedia]
+
+  """
   A type-specific ID likely used as a database ID.
   """
   internalID: ID!
@@ -3063,6 +3073,13 @@ type ArtistInsightsCount {
   groupShowCount: Int!
   reviewedCount: Int!
   soloShowCount: Int!
+}
+
+type ArtistInstagramMedia {
+  caption: String
+  image: Image
+  internalID: String
+  permalink: String
 }
 
 type ArtistMeta {

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -54,6 +54,9 @@ export default (opts) => {
     ),
     artistArtworksLoader: gravityLoader((id) => `artist/${id}/artworks`),
     artistCareerHighlightsLoader: gravityLoader("artist_career_highlights"),
+    artistInstagramMediaLoader: gravityLoader(
+      (id) => `artist/${id}/instagram_media`
+    ),
     artistGenesLoader: gravityLoader((id) => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader((id) => `artist/${id}`),
     artistsLoader: gravityLoader("artists", {}, { headers: true }),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -54,10 +54,10 @@ export default (opts) => {
     ),
     artistArtworksLoader: gravityLoader((id) => `artist/${id}/artworks`),
     artistCareerHighlightsLoader: gravityLoader("artist_career_highlights"),
+    artistGenesLoader: gravityLoader((id) => `artist/${id}/genome/genes`),
     artistInstagramMediaLoader: gravityLoader(
       (id) => `artist/${id}/instagram_media`
     ),
-    artistGenesLoader: gravityLoader((id) => `artist/${id}/genome/genes`),
     artistLoader: gravityLoader((id) => `artist/${id}`),
     artistsLoader: gravityLoader("artists", {}, { headers: true }),
     artistsByLetterLoader: gravityLoader(

--- a/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
+++ b/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
@@ -1,0 +1,89 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("artist.instagramMedia", () => {
+  let media
+  let context
+
+  beforeEach(() => {
+    media = [
+      {
+        id: "1",
+        media_type: "IMAGE",
+        media_url: "https://example.com/1.jpg",
+        permalink: "https://instagram.com/p/1",
+        caption: "one",
+      },
+      {
+        id: "2",
+        media_type: "IMAGE",
+        media_url: "https://example.com/2.jpg",
+        permalink: "https://instagram.com/p/2",
+        caption: "two",
+      },
+    ]
+
+    context = {
+      artistLoader: () => Promise.resolve({ id: "artistID", _id: "artistID" }),
+      artistInstagramMediaLoader: () => Promise.resolve(media),
+    }
+  })
+
+  it("returns instagram media with an image, permalink and caption", async () => {
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            internalID
+            permalink
+            caption
+            image {
+              url
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      artist: {
+        instagramMedia: [
+          {
+            internalID: "1",
+            permalink: "https://instagram.com/p/1",
+            caption: "one",
+            image: { url: "https://example.com/1.jpg" },
+          },
+          {
+            internalID: "2",
+            permalink: "https://instagram.com/p/2",
+            caption: "two",
+            image: { url: "https://example.com/2.jpg" },
+          },
+        ],
+      },
+    })
+  })
+
+  it("limits the number of items with `first`", async () => {
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia(first: 1) {
+            internalID
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      artist: {
+        instagramMedia: [{ internalID: "1" }],
+      },
+    })
+  })
+})

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -45,5 +45,4 @@ export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
       ? body.slice(0, Math.max(0, first))
       : body
   },
-  },
 }

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -40,9 +40,10 @@ export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
     },
   },
   resolve: async ({ id }, { first }, { artistInstagramMediaLoader }) => {
-    const body = await artistInstagramMediaLoader(id)
+    const body = (await artistInstagramMediaLoader(id)) || []
     return typeof first === "number"
       ? body.slice(0, Math.max(0, first))
       : body
+  },
   },
 }

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -41,8 +41,8 @@ export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
   },
   resolve: async ({ id }, { first }, { artistInstagramMediaLoader }) => {
     const body = await artistInstagramMediaLoader(id)
-    return typeof first === "number" ? media.slice(0, Math.max(0, first)) : media
-
-    return typeof first === "number" ? media.slice(0, first) : media
+    return typeof first === "number"
+      ? body.slice(0, Math.max(0, first))
+      : body
   },
 }

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -1,0 +1,48 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import Image, { normalizeImageData } from "schema/v2/image"
+
+const ArtistInstagramMediaType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtistInstagramMedia",
+  fields: {
+    internalID: {
+      type: GraphQLString,
+      resolve: ({ id }) => id,
+    },
+    permalink: {
+      type: GraphQLString,
+      resolve: ({ permalink }) => permalink,
+    },
+    caption: {
+      type: GraphQLString,
+      resolve: ({ caption }) => caption,
+    },
+    image: {
+      type: Image.type,
+      resolve: ({ media_url }) => normalizeImageData(media_url),
+    },
+  },
+})
+
+export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
+  type: new GraphQLList(ArtistInstagramMediaType),
+  description: "Instagram media for display on an artist page.",
+  args: {
+    first: {
+      type: GraphQLInt,
+      description: "The number of media items to return.",
+    },
+  },
+  resolve: async ({ id }, { first }, { artistInstagramMediaLoader }) => {
+    const body = await artistInstagramMediaLoader(id)
+    const media = Array.isArray(body) ? body : []
+
+    return typeof first === "number" ? media.slice(0, first) : media
+  },
+}

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -41,7 +41,7 @@ export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
   },
   resolve: async ({ id }, { first }, { artistInstagramMediaLoader }) => {
     const body = await artistInstagramMediaLoader(id)
-    const media = Array.isArray(body) ? body : []
+    return typeof first === "number" ? media.slice(0, Math.max(0, first)) : media
 
     return typeof first === "number" ? media.slice(0, first) : media
   },

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -49,6 +49,7 @@ import ArtistCarousel from "./carousel"
 import { CurrentEvent } from "./current"
 import ArtistHighlights from "./highlights"
 import { ArtistInsights } from "./insights"
+import { InstagramMedia } from "./artistInstagramMedia"
 import Meta from "./meta"
 import { Related } from "./related"
 import {
@@ -826,6 +827,7 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       initials: initials("name"),
       insights: ArtistInsights,
+      instagramMedia: InstagramMedia,
       isConsignable: {
         type: GraphQLBoolean,
         resolve: ({ consignable }) => consignable,


### PR DESCRIPTION
Exposes an artist's Instagram photos on the Artist type for the artist-page Instagram rail. Data is loaded from Gravity's new [GET /api/v1/artist/:id/instagram_media endpoint.](https://github.com/artsy/gravity/pull/20359)
