### PR TITLE
feat: add artworksByImageConnection field for neural image search

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -31603,6 +31603,26 @@ type Query {
     )
 
   """
+  A connection of artworks matching an uploaded query image, using a pure vector (neural) image search.
+  """
+  artworksByImageConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    """
+    S3 bucket of the uploaded query image.
+    """
+    s3Bucket: String!
+
+    """
+    S3 key of the uploaded query image.
+    """
+    s3Key: String!
+  ): ArtworkConnection
+
+  """
   Artworks Elastic Search results
   """
   artworksConnection(
@@ -41361,6 +41381,26 @@ type Viewer {
     @deprecated(
       reason: "This is only for use in resolving stitched queries, not for first-class client use!"
     )
+
+  """
+  A connection of artworks matching an uploaded query image, using a pure vector (neural) image search.
+  """
+  artworksByImageConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    """
+    S3 bucket of the uploaded query image.
+    """
+    s3Bucket: String!
+
+    """
+    S3 key of the uploaded query image.
+    """
+    s3Key: String!
+  ): ArtworkConnection
 
   """
   Artworks Elastic Search results

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -77,6 +77,11 @@ export default (opts) => {
     >(({ artwork_id, image_id }) => `artwork/${artwork_id}/image/${image_id}`),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
     artworksLoader: gravityLoader("artworks"),
+    artworksByImageLoader: gravityLoader(
+      "filter/artworks_by_image",
+      {},
+      { headers: true }
+    ),
     authenticationStatusLoader: gravityLoader("me", {}, { headers: true }),
     bidderLoader: gravityLoader((id) => `bidder/${id}`),
     collectionArtworksLoader: gravityLoader(

--- a/src/schema/v2/__tests__/artworksByImageConnection.test.ts
+++ b/src/schema/v2/__tests__/artworksByImageConnection.test.ts
@@ -1,0 +1,129 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("artworksByImageConnection", () => {
+  const artworks = [
+    { id: "artwork-1", title: "Artwork 1" },
+    { id: "artwork-2", title: "Artwork 2" },
+  ]
+
+  const mockArtworksByImageLoader = jest.fn(() =>
+    Promise.resolve({
+      body: { hits: artworks },
+      headers: { "x-total-count": "2" },
+    })
+  )
+
+  const context = {
+    artworksByImageLoader: mockArtworksByImageLoader,
+  } as any
+
+  beforeEach(() => {
+    mockArtworksByImageLoader.mockClear()
+  })
+
+  it("passes the snake_cased s3 args to the gravity loader", async () => {
+    const query = gql`
+      {
+        artworksByImageConnection(
+          s3Key: "uploads/query.jpg"
+          s3Bucket: "artsy-media"
+          first: 10
+        ) {
+          totalCount
+          edges {
+            node {
+              slug
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(mockArtworksByImageLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: {
+          s3_key: "uploads/query.jpg",
+          s3_bucket: "artsy-media",
+        },
+        total_count: true,
+        page: 1,
+        size: 10,
+      })
+    )
+  })
+
+  it("returns a connection of artworks", async () => {
+    const query = gql`
+      {
+        artworksByImageConnection(
+          s3Key: "uploads/query.jpg"
+          s3Bucket: "artsy-media"
+          first: 10
+        ) {
+          totalCount
+          edges {
+            node {
+              slug
+            }
+          }
+        }
+      }
+    `
+
+    const { artworksByImageConnection } = await runQuery(query, context)
+
+    expect(artworksByImageConnection.totalCount).toEqual(2)
+    expect(artworksByImageConnection.edges).toEqual([
+      { node: { slug: "artwork-1" } },
+      { node: { slug: "artwork-2" } },
+    ])
+  })
+
+  it("returns an empty connection when there are no hits", async () => {
+    mockArtworksByImageLoader.mockResolvedValueOnce({
+      body: { hits: [] },
+      headers: { "x-total-count": "0" },
+    })
+
+    const query = gql`
+      {
+        artworksByImageConnection(
+          s3Key: "uploads/query.jpg"
+          s3Bucket: "artsy-media"
+          first: 10
+        ) {
+          totalCount
+          edges {
+            node {
+              slug
+            }
+          }
+        }
+      }
+    `
+
+    const { artworksByImageConnection } = await runQuery(query, context)
+
+    expect(artworksByImageConnection.totalCount).toEqual(0)
+    expect(artworksByImageConnection.edges).toEqual([])
+  })
+
+  it("requires both s3Key and s3Bucket", async () => {
+    const query = gql`
+      {
+        artworksByImageConnection(s3Key: "uploads/query.jpg", first: 10) {
+          edges {
+            node {
+              slug
+            }
+          }
+        }
+      }
+    `
+
+    await expect(runQuery(query, context)).rejects.toThrow(/s3Bucket/)
+  })
+})

--- a/src/schema/v2/artworksByImageConnection.ts
+++ b/src/schema/v2/artworksByImageConnection.ts
@@ -1,0 +1,54 @@
+import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { artworkConnection } from "schema/v2/artwork"
+import { paginationResolver } from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+
+export const artworksByImageConnection: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  description:
+    "A connection of artworks matching an uploaded query image, using a pure vector (neural) image search.",
+  type: artworkConnection.connectionType,
+  args: pageable({
+    s3Key: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 key of the uploaded query image.",
+    },
+    s3Bucket: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "S3 bucket of the uploaded query image.",
+    },
+  }),
+  resolve: async (
+    _root,
+    args: { s3Key: string; s3Bucket: string } & CursorPageable,
+    { artworksByImageLoader }
+  ) => {
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const { body, headers } = await artworksByImageLoader({
+      image: {
+        s3_key: args.s3Key,
+        s3_bucket: args.s3Bucket,
+      },
+      page,
+      size,
+      total_count: true,
+    })
+
+    const { hits = [] } = body
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      args,
+      body: hits,
+      offset,
+      page,
+      size,
+      totalCount,
+    })
+  },
+}

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -162,6 +162,7 @@ import { syncCatalogToArtworkMutation } from "./artwork/syncCatalogToArtworkMuta
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { repositionArtworkImagesMutation } from "./artwork/repositionArtworkImagesMutation"
 import { artworksForUser } from "./artworksForUser"
+import { artworksByImageConnection } from "./artworksByImageConnection"
 import { authenticationStatus } from "./authenticationStatus"
 import { BankAccount } from "./bank_account"
 import { bulkUpdateArtworksMetadataMutation } from "./partner/BulkOperation/bulkUpdateArtworksMetadataMutation"
@@ -470,6 +471,7 @@ const rootFields = {
   artworkImport: ArtworkImport,
   artworkResult: ArtworkResult,
   artworks: Artworks,
+  artworksByImageConnection,
   artworksConnection: filterArtworksConnection(),
   artworksForUser,
   auctionResult: AuctionResult,


### PR DESCRIPTION
Assisted-by: Claude:Opus-4.7 [claude-code]

Related to https://github.com/artsy/gravity/pull/20358

Adds a dedicated `artworksByImageConnection` field for neural image search - finding artworks that visually match an uploaded query image via a vector search.

### Usage

```graphql
{
  artworksByImageConnection(
    s3Key: "uploads/query.jpg"
    s3Bucket: "artsy-media-uploads"
    first: 30
  ) {
    totalCount
    edges {
      node {
        slug
      }
    }
  }
}
```