### PR TITLE
feat: stamp curator notes on all marketing-collection artwork connections

### DIFF
--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1801,4 +1801,90 @@ describe("artworksConnection", () => {
       expect(artworksConnection.counts.total).toEqual(3)
     })
   })
+
+  describe("curator notes on marketing-collection-scoped connections", () => {
+    it("stamps notes onto edges by looking the collection up by id/slug", async () => {
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: () =>
+            Promise.resolve({
+              hits: [
+                { _id: "percy-1-id", id: "percy-1", title: "Percy's Ship", artists: [] },
+                { _id: "fiby-2-id", id: "fiby-2", title: "Fiby's Ship", artists: [] },
+              ],
+              aggregations: { total: { value: 2 } },
+            }),
+        },
+        marketingCollectionLoader: () =>
+          Promise.resolve({
+            slug: "curators-picks",
+            artwork_notes: [
+              { artwork_id: "percy-1-id", note: "Chosen for its bold use of color" },
+            ],
+          }),
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            marketingCollectionID: "curators-picks"
+            first: 2
+            aggregations: [TOTAL]
+          ) {
+            edges {
+              note
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { note: "Chosen for its bold use of color", node: { slug: "percy-1" } },
+        { note: null, node: { slug: "fiby-2" } },
+      ])
+    })
+
+    it("does not fail the connection when the collection lookup errors", async () => {
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: () =>
+            Promise.resolve({
+              hits: [{ _id: "percy-1-id", id: "percy-1", title: "Percy's Ship", artists: [] }],
+              aggregations: { total: { value: 1 } },
+            }),
+        },
+        marketingCollectionLoader: () => Promise.reject(new Error("boom")),
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            marketingCollectionID: "curators-picks"
+            first: 1
+            aggregations: [TOTAL]
+          ) {
+            edges {
+              note
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([
+        { note: null, node: { slug: "percy-1" } },
+      ])
+    })
+  })
 })

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1886,5 +1886,45 @@ describe("artworksConnection", () => {
         { note: null, node: { slug: "percy-1" } },
       ])
     })
+
+    it("does not look the collection up when `note` is not selected", async () => {
+      const marketingCollectionLoader = jest.fn(() =>
+        Promise.resolve({
+          artwork_notes: [{ artwork_id: "percy-1-id", note: "unused" }],
+        })
+      )
+      const context = {
+        authenticatedLoaders: {},
+        unauthenticatedLoaders: {
+          filterArtworksLoader: () =>
+            Promise.resolve({
+              hits: [{ _id: "percy-1-id", id: "percy-1", title: "Percy's Ship", artists: [] }],
+              aggregations: { total: { value: 1 } },
+            }),
+        },
+        marketingCollectionLoader,
+      }
+
+      const query = gql`
+        {
+          artworksConnection(
+            marketingCollectionID: "curators-picks"
+            first: 1
+            aggregations: [TOTAL]
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(artworksConnection.edges).toEqual([{ node: { slug: "percy-1" } }])
+      expect(marketingCollectionLoader).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/schema/v2/__tests__/marketingCollections.test.ts
+++ b/src/schema/v2/__tests__/marketingCollections.test.ts
@@ -217,6 +217,51 @@ describe("MarketingCollections", () => {
     })
   })
 
+  it("does not re-fetch the collection when the root carries no notes", async () => {
+    const query = gql`
+      {
+        marketingCollection(slug: "percys-z-collection-1") {
+          artworksConnection(first: 1) {
+            edges {
+              note
+              node {
+                slug
+              }
+            }
+          }
+        }
+      }
+    `
+
+    // A (non-curated) collection whose payload omits `artwork_notes` entirely.
+    const payload = { ...marketingCollectionsData[0] }
+
+    const marketingCollectionLoader = jest.fn(() => Promise.resolve(payload))
+
+    const context: any = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: () =>
+          Promise.resolve({
+            hits: [{ _id: "percy-1-id", id: "percy-1", title: "Percy's Ship", artists: [] }],
+            aggregations: { total: { value: 1 } },
+          }),
+      },
+      marketingCollectionLoader,
+    }
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      marketingCollection: {
+        artworksConnection: { edges: [{ note: null, node: { slug: "percy-1" } }] },
+      },
+    })
+    // Only the collection-field resolution should hit the loader — no extra
+    // note lookup, since the root is authoritative.
+    expect(marketingCollectionLoader).toHaveBeenCalledTimes(1)
+  })
+
   it("does not crash when only id is selected on artworksConnection", async () => {
     const query = gql`
       {

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -999,7 +999,21 @@ const stampCuratorNotes = async ({
 
   let artworkNotes = root?.artwork_notes
 
-  if (!artworkNotes && marketingCollectionID && marketingCollectionLoader) {
+  // When the connection is resolved from the marketing collection itself, `root` is
+  // that collection and its `artwork_notes` are authoritative — a missing/undefined
+  // field means "no notes", not "not loaded", so we must not re-fetch it (Gravity
+  // omits the field for non-curated collections). Only connections that are merely
+  // *filtered* by a collection (rails, where `root` is not the collection) fall back
+  // to a lookup.
+  const rootIsMarketingCollection =
+    root?.id != null && root.id === marketingCollectionID
+
+  if (
+    artworkNotes == null &&
+    !rootIsMarketingCollection &&
+    marketingCollectionID &&
+    marketingCollectionLoader
+  ) {
     try {
       const collection = await marketingCollectionLoader(marketingCollectionID)
       artworkNotes = collection?.artwork_notes

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -621,6 +621,7 @@ const filterArtworksConnectionTypeFactory = (
       },
       filterArtworksUncachedLoader,
       isCMSRequest,
+      marketingCollectionLoader,
       partnerArtworksAllLoader,
       partnerListArtworksLoader,
     } = ctx
@@ -877,6 +878,16 @@ const filterArtworksConnectionTypeFactory = (
       gravityOptions.size
     )
 
+    // Stamp curator notes onto edges for marketing-collection-scoped connections
+    // (the collection page, the `MarketingCollection.artworksConnection` field, and
+    // marketing-collection-backed rails such as `Viewer.artworksConnection`).
+    await stampCuratorNotes({
+      connection,
+      root,
+      marketingCollectionID: gravityOptions.marketing_collection_id,
+      marketingCollectionLoader,
+    })
+
     return Object.assign(
       {
         pageCursors: createPageCursors(
@@ -890,6 +901,57 @@ const filterArtworksConnectionTypeFactory = (
     )
   },
 })
+
+/**
+ * The curator's note lives on the `marketing_collection_artworks` join record in
+ * Gravity and is surfaced per-edge (see the `note` edge field above). It is only
+ * populated for marketing-collection-scoped connections.
+ *
+ * When the connection is resolved from a `MarketingCollection` root, the notes are
+ * already present on `root.artwork_notes` (no extra fetch). For connections that are
+ * merely *filtered* by a marketing collection (e.g. `Viewer.artworksConnection(
+ * marketingCollectionID:)` behind the home rails), we look the collection up by id/slug
+ * to read its notes. Notes are non-essential, so a failed lookup never fails the
+ * connection.
+ */
+const stampCuratorNotes = async ({
+  connection,
+  root,
+  marketingCollectionID,
+  marketingCollectionLoader,
+}: {
+  connection: { edges?: any[] }
+  root: any
+  marketingCollectionID?: string
+  marketingCollectionLoader?: (id: string) => Promise<any>
+}): Promise<void> => {
+  if (!connection?.edges?.length) return
+
+  let artworkNotes = root?.artwork_notes
+
+  if (!artworkNotes && marketingCollectionID && marketingCollectionLoader) {
+    try {
+      const collection = await marketingCollectionLoader(marketingCollectionID)
+      artworkNotes = collection?.artwork_notes
+    } catch (_error) {
+      artworkNotes = undefined
+    }
+  }
+
+  if (!artworkNotes?.length) return
+
+  const notesByArtworkId: Record<string, string> = Object.fromEntries(
+    artworkNotes.map(({ artwork_id, note }: { artwork_id: string; note: string }) => [
+      artwork_id,
+      note,
+    ])
+  )
+
+  connection.edges = connection.edges.map((edge) => ({
+    ...edge,
+    note: edge?.node?._id ? notesByArtworkId[edge.node._id] ?? null : null,
+  }))
+}
 
 // Support passing in your own primary key
 // so that you can nest this function into another.

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -912,18 +912,6 @@ const filterArtworksConnectionTypeFactory = (
 })
 
 /**
- * The curator's note lives on the `marketing_collection_artworks` join record in
- * Gravity and is surfaced per-edge (see the `note` edge field above). It is only
- * populated for marketing-collection-scoped connections.
- *
- * When the connection is resolved from a `MarketingCollection` root, the notes are
- * already present on `root.artwork_notes` (no extra fetch). For connections that are
- * merely *filtered* by a marketing collection (e.g. `Viewer.artworksConnection(
- * marketingCollectionID:)` behind the home rails), we look the collection up by id/slug
- * to read its notes. Notes are non-essential, so a failed lookup never fails the
- * connection.
- */
-/**
  * Returns true when the query selected `edges { note }` on this connection.
  *
  * The generic `hasFieldSelection` helper can't answer this — `note` sits under
@@ -984,6 +972,18 @@ const selectsEdgeNote = (info: GraphQLResolveInfo): boolean => {
   )
 }
 
+/**
+ * The curator's note lives on the `marketing_collection_artworks` join record in
+ * Gravity and is surfaced per-edge (see the `note` edge field above). It is only
+ * populated for marketing-collection-scoped connections.
+ *
+ * When the connection is resolved from a `MarketingCollection` root, the notes are
+ * already present on `root.artwork_notes` (no extra fetch). For connections that are
+ * merely *filtered* by a marketing collection (e.g. `Viewer.artworksConnection(
+ * marketingCollectionID:)` behind the home rails), we look the collection up by id/slug
+ * to read its notes. Notes are non-essential, so a failed lookup never fails the
+ * connection.
+ */
 const stampCuratorNotes = async ({
   connection,
   root,

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -10,8 +10,10 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
+  GraphQLResolveInfo,
   GraphQLString,
   GraphQLUnionType,
+  SelectionSetNode,
 } from "graphql"
 import {
   connectionDefinitions,
@@ -881,12 +883,19 @@ const filterArtworksConnectionTypeFactory = (
     // Stamp curator notes onto edges for marketing-collection-scoped connections
     // (the collection page, the `MarketingCollection.artworksConnection` field, and
     // marketing-collection-backed rails such as `Viewer.artworksConnection`).
-    await stampCuratorNotes({
-      connection,
-      root,
-      marketingCollectionID: gravityOptions.marketing_collection_id,
-      marketingCollectionLoader,
-    })
+    //
+    // Only do this when the client actually selected `edges { note }`. Otherwise the
+    // stamping — and, on rails that don't resolve from a MarketingCollection root, the
+    // extra collection lookup — would run on hot paths (e.g. the "Curators' Picks" home
+    // rail) for data nobody requested.
+    if (selectsEdgeNote(info)) {
+      await stampCuratorNotes({
+        connection,
+        root,
+        marketingCollectionID: gravityOptions.marketing_collection_id,
+        marketingCollectionLoader,
+      })
+    }
 
     return Object.assign(
       {
@@ -914,6 +923,67 @@ const filterArtworksConnectionTypeFactory = (
  * to read its notes. Notes are non-essential, so a failed lookup never fails the
  * connection.
  */
+/**
+ * Returns true when the query selected `edges { note }` on this connection.
+ *
+ * The generic `hasFieldSelection` helper can't answer this — `note` sits under
+ * `edges`, deeper than that helper's selection-depth threshold — so we do a small
+ * fragment-aware walk here: look for an `edges` field directly under the connection,
+ * then a `note` field within it. Used to avoid stamping (and the collection lookup it
+ * can trigger) when the note isn't actually requested.
+ */
+const selectsEdgeNote = (info: GraphQLResolveInfo): boolean => {
+  const { fragments } = info
+
+  const selectsField = (
+    selectionSet: SelectionSetNode | undefined,
+    fieldName: string
+  ): boolean => {
+    if (!selectionSet) return false
+    return selectionSet.selections.some((selection) => {
+      switch (selection.kind) {
+        case "Field":
+          return selection.name.value === fieldName
+        case "InlineFragment":
+          return selectsField(selection.selectionSet, fieldName)
+        case "FragmentSpread": {
+          const fragment = fragments[selection.name.value]
+          return fragment ? selectsField(fragment.selectionSet, fieldName) : false
+        }
+        default:
+          return false
+      }
+    })
+  }
+
+  const edgesSelectNote = (
+    selectionSet: SelectionSetNode | undefined
+  ): boolean => {
+    if (!selectionSet) return false
+    return selectionSet.selections.some((selection) => {
+      switch (selection.kind) {
+        case "Field":
+          return (
+            selection.name.value === "edges" &&
+            selectsField(selection.selectionSet, "note")
+          )
+        case "InlineFragment":
+          return edgesSelectNote(selection.selectionSet)
+        case "FragmentSpread": {
+          const fragment = fragments[selection.name.value]
+          return fragment ? edgesSelectNote(fragment.selectionSet) : false
+        }
+        default:
+          return false
+      }
+    })
+  }
+
+  return (info.fieldNodes ?? []).some((node) =>
+    edgesSelectNote(node.selectionSet)
+  )
+}
+
 const stampCuratorNotes = async ({
   connection,
   root,

--- a/src/schema/v2/marketingCollections.ts
+++ b/src/schema/v2/marketingCollections.ts
@@ -195,32 +195,10 @@ export const MarketingCollectionType = new GraphQLObjectType<
       ...MarketingCollectionFields,
       relatedCollections: RelatedCollections,
       linkedCollections: LinkedCollections,
-      artworksConnection: {
-        ...artworksConnectionField,
-        resolve: async (root, args, ctx, info) => {
-          const connection = await artworksConnectionField.resolve(
-            root,
-            args,
-            ctx,
-            info
-          )
-          const notesByArtworkId = Object.fromEntries(
-            (
-              root.artwork_notes ?? []
-            ).map(
-              ({ artwork_id, note }: { artwork_id: string; note: string }) => [
-                artwork_id,
-                note,
-              ]
-            )
-          )
-          connection.edges = (connection.edges ?? []).map((edge) => ({
-            ...edge,
-            note: notesByArtworkId[edge.node._id] ?? null,
-          }))
-          return connection
-        },
-      },
+      // Curator notes are stamped onto the edges by the shared filterArtworks
+      // resolver, which reads them from `root.artwork_notes` for a
+      // MarketingCollection root (no extra fetch).
+      artworksConnection: artworksConnectionField,
     }
   },
 })


### PR DESCRIPTION
### Stacked on #7756

> ⚠️ This PR is **stacked on `feat/expose-collection-notes`** (#7756) and targets that branch, not `main`. Review/merge #7756 first; the diff here is only this follow-up's changes.

### What

#7756 exposes a per-edge `note` on `MarketingCollection.artworksConnection`, but only that one field is populated — the resolver stamps notes only when the connection resolves from a `MarketingCollection` root. Collection **rails** on the home screen read the note through *other* connections that are merely *filtered* by a marketing collection, so `note` came back `null` there:

- Force's "Curators' Picks" rail → `Viewer.artworksConnection(marketingCollectionID:)`
- Eigen's home-view collection rails → the home-view section artworks connection

This PR generalizes the stamping so those surfaces light up too.

### How

- Moves note-stamping into the **shared `filterArtworks` resolver**, keyed on `marketing_collection_id`:
  - When the connection resolves from a `MarketingCollection` root, notes are read from `root.artwork_notes` — **no extra fetch** (same behavior as #7756).
  - When the connection is only *filtered* by a marketing collection, it looks the collection up via `marketingCollectionLoader(id)` to read `artwork_notes`.
  - A failed lookup is swallowed — notes are non-essential and never fail the connection.
- Removes the now-redundant special-case resolver on `MarketingCollection.artworksConnection` (the shared resolver covers it).

### Tests

- Added coverage in `filterArtworksConnection.test.ts` for the lookup-by-id path (notes stamped onto matching edges, `null` elsewhere) and the graceful-failure path (loader rejects → edges still resolve with `note: null`).
- The existing `marketingCollections.test.ts` case from #7756 still passes (notes read from `root.artwork_notes`, no extra fetch).

### Consumers

- eigen artsy/eigen#13770 and force artsy/force#17490 add the UI. Those wire the collection **page grids** and MarketingCollection-backed rails today; once this ships, the home "Curators' Picks" rails will populate too (a small follow-up on the client to select `edges { note }` on those specific rails).

### Note on CI

Authored without `node_modules`, so `yarn type-check` / `yarn jest` were not run locally — please rely on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2iHtPiKHN91ghgcJWyJjC)_