### PR TITLE
feat(hack16): add artworkFilterSuggestions field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4955,6 +4955,50 @@ type ArtworkFilterNode {
   title: String!
 }
 
+type ArtworkFilterSuggestion {
+  """
+  Values the parser rejected as invalid.
+  """
+  dropped: [ArtworkFilterSuggestionDropped!]!
+
+  """
+  True when parsing failed and the query fell back to a plain keyword search.
+  """
+  fellOpen: Boolean
+
+  """
+  Validated hard filters to pass to artworksConnection.
+  """
+  filters: ArtworkFilterSuggestionFilters
+
+  """
+  Leftover 'vibe' text to use as a keyword search.
+  """
+  keyword: String
+}
+
+type ArtworkFilterSuggestionDropped {
+  field: String
+  value: String
+}
+
+type ArtworkFilterSuggestionFilters {
+  acquireable: Boolean
+  artistNationalities: [String]
+  atAuction: Boolean
+  attributionClass: [String]
+  colors: [String]
+  forSale: Boolean
+  framed: Boolean
+  geneIDs: [String]
+  inquireable: Boolean
+  majorPeriods: [String]
+  offerable: Boolean
+  priceRange: String
+  signed: Boolean
+  sizes: [ArtworkSizes]
+}
+
 union ArtworkHighlight = Article | Show
 
 type ArtworkImport implements Node {
@@ -31570,6 +31614,16 @@ type Query {
     """
     status: ArtworkDuplicatePairStatus
   ): ArtworkDuplicatePairConnection
+
+  """
+  Interpret a natural-language search query into validated artwork filters.
+  """
+  artworkFilterSuggestions(
+    """
+    The natural-language search query.
+    """
+    query: String!
+  ): ArtworkFilterSuggestion
   artworkImport(id: String!): ArtworkImport
 
   """
@@ -41330,6 +41384,16 @@ type Viewer {
     """
     status: ArtworkDuplicatePairStatus
   ): ArtworkDuplicatePairConnection
+
+  """
+  Interpret a natural-language search query into validated artwork filters.
+  """
+  artworkFilterSuggestions(
+    """
+    The natural-language search query.
+    """
+    query: String!
+  ): ArtworkFilterSuggestion
   artworkImport(id: String!): ArtworkImport
 
   """

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -102,6 +102,7 @@ export default (accessToken, userID, opts) => {
       { headers: true }
     ),
     artworkLoader: gravityLoader((id) => `artwork/${id}`),
+    artworkFilterSuggestionsLoader: gravityLoader("artwork_filter_suggestions"),
     artworkRecommendationsLoader: gravityLoader("artwork_recommendations"),
     artworkImportLoader: gravityLoader((id) => `artwork_import/${id}`),
     artworkImportMatchImagesLoader: gravityLoader(

--- a/src/schema/v2/artworkFilterSuggestions/__tests__/artworkFilterSuggestions.test.ts
+++ b/src/schema/v2/artworkFilterSuggestions/__tests__/artworkFilterSuggestions.test.ts
@@ -1,0 +1,70 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+const query = gql`
+  {
+    artworkFilterSuggestions(
+      query: "large brutalist sculpture under 5k, japanese"
+    ) {
+      keyword
+      fellOpen
+      filters {
+        geneIDs
+        sizes
+        priceRange
+        artistNationalities
+        framed
+      }
+      dropped {
+        field
+        value
+      }
+    }
+  }
+`
+
+describe("artworkFilterSuggestions", () => {
+  const gravityResponse = {
+    query: "large brutalist sculpture under 5k, japanese",
+    keyword: "brutalist",
+    filters: {
+      gene_ids: ["gene-sculpture"],
+      sizes: ["large"],
+      price_range: "*-5000",
+      artist_nationalities: ["Japanese"],
+      framed: true,
+    },
+    dropped: [{ field: "medium", value: "Hologram" }],
+    fell_open: false,
+  }
+
+  it("calls the loader with nl_query and maps the response to camelCase", async () => {
+    const artworkFilterSuggestionsLoader = jest.fn(async () => gravityResponse)
+
+    const data = await runAuthenticatedQuery(query, {
+      artworkFilterSuggestionsLoader,
+    })
+
+    expect(artworkFilterSuggestionsLoader).toHaveBeenCalledWith({
+      nl_query: "large brutalist sculpture under 5k, japanese",
+    })
+    expect(data.artworkFilterSuggestions).toEqual({
+      keyword: "brutalist",
+      fellOpen: false,
+      filters: {
+        geneIDs: ["gene-sculpture"],
+        sizes: ["LARGE"],
+        priceRange: "*-5000",
+        artistNationalities: ["Japanese"],
+        framed: true,
+      },
+      dropped: [{ field: "medium", value: "Hologram" }],
+    })
+  })
+
+  it("throws when unauthenticated (no loader on context)", async () => {
+    await expect(runQuery(query)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+})

--- a/src/schema/v2/artworkFilterSuggestions/artworkFilterSuggestions.ts
+++ b/src/schema/v2/artworkFilterSuggestions/artworkFilterSuggestions.ts
@@ -1,0 +1,131 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import ArtworkSizes from "schema/v2/artwork/artworkSizes"
+
+const ArtworkFilterSuggestionFiltersType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworkFilterSuggestionFilters",
+  fields: {
+    geneIDs: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ gene_ids }) => gene_ids,
+    },
+    sizes: {
+      // ArtworkSizes enum so values serialize to LARGE/MEDIUM/SMALL and can be
+      // fed straight back into artworksConnection's `sizes: [ArtworkSizes]` arg.
+      type: new GraphQLList(ArtworkSizes),
+      resolve: ({ sizes }) => sizes,
+    },
+    colors: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ colors }) => colors,
+    },
+    attributionClass: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ attribution_class }) => attribution_class,
+    },
+    artistNationalities: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ artist_nationalities }) => artist_nationalities,
+    },
+    majorPeriods: {
+      type: new GraphQLList(GraphQLString),
+      resolve: ({ major_periods }) => major_periods,
+    },
+    priceRange: {
+      type: GraphQLString,
+      resolve: ({ price_range }) => price_range,
+    },
+    framed: { type: GraphQLBoolean, resolve: ({ framed }) => framed },
+    signed: { type: GraphQLBoolean, resolve: ({ signed }) => signed },
+    forSale: { type: GraphQLBoolean, resolve: ({ for_sale }) => for_sale },
+    acquireable: {
+      type: GraphQLBoolean,
+      resolve: ({ acquireable }) => acquireable,
+    },
+    offerable: { type: GraphQLBoolean, resolve: ({ offerable }) => offerable },
+    atAuction: {
+      type: GraphQLBoolean,
+      resolve: ({ at_auction }) => at_auction,
+    },
+    inquireable: {
+      type: GraphQLBoolean,
+      resolve: ({ inquireable }) => inquireable,
+    },
+  },
+})
+
+const ArtworkFilterSuggestionDroppedType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworkFilterSuggestionDropped",
+  fields: {
+    field: { type: GraphQLString, resolve: ({ field }) => field },
+    value: { type: GraphQLString, resolve: ({ value }) => value },
+  },
+})
+
+const ArtworkFilterSuggestionType = new GraphQLObjectType<any, ResolverContext>(
+  {
+    name: "ArtworkFilterSuggestion",
+    fields: {
+      keyword: {
+        type: GraphQLString,
+        description: "Leftover 'vibe' text to use as a keyword search.",
+        resolve: ({ keyword }) => keyword,
+      },
+      filters: {
+        type: ArtworkFilterSuggestionFiltersType,
+        description: "Validated hard filters to pass to artworksConnection.",
+        resolve: ({ filters }) => filters ?? {},
+      },
+      dropped: {
+        type: new GraphQLNonNull(
+          new GraphQLList(
+            new GraphQLNonNull(ArtworkFilterSuggestionDroppedType)
+          )
+        ),
+        description: "Values the parser rejected as invalid.",
+        resolve: ({ dropped }) => dropped ?? [],
+      },
+      fellOpen: {
+        type: GraphQLBoolean,
+        description:
+          "True when parsing failed and the query fell back to a plain keyword search.",
+        resolve: ({ fell_open }) => fell_open,
+      },
+    },
+  }
+)
+
+export const artworkFilterSuggestions: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: ArtworkFilterSuggestionType,
+  description:
+    "Interpret a natural-language search query into validated artwork filters.",
+  args: {
+    query: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The natural-language search query.",
+    },
+  },
+  resolve: async (_root, { query }, { artworkFilterSuggestionsLoader }) => {
+    if (!artworkFilterSuggestionsLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return artworkFilterSuggestionsLoader({ nl_query: query })
+  },
+}

--- a/src/schema/v2/artworkFilterSuggestions/index.ts
+++ b/src/schema/v2/artworkFilterSuggestions/index.ts
@@ -1,0 +1,1 @@
+export * from "./artworkFilterSuggestions"

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -161,6 +161,7 @@ import { updateCatalogEditionSetMutation } from "./artwork/updateCatalogEditionS
 import { syncCatalogToArtworkMutation } from "./artwork/syncCatalogToArtworkMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { repositionArtworkImagesMutation } from "./artwork/repositionArtworkImagesMutation"
+import { artworkFilterSuggestions } from "./artworkFilterSuggestions"
 import { artworksForUser } from "./artworksForUser"
 import { authenticationStatus } from "./authenticationStatus"
 import { BankAccount } from "./bank_account"
@@ -466,6 +467,7 @@ const rootFields = {
   artworkAttributionClasses: ArtworkAttributionClasses,
   artworkDuplicatePair,
   artworkDuplicatePairsConnection,
+  artworkFilterSuggestions,
   artworkMediums: ArtworkMediums,
   artworkImport: ArtworkImport,
   artworkResult: ArtworkResult,


### PR DESCRIPTION
### Description 
Expose Gravity's new `/api/v1/artwork_filter_suggestions` endpoint through GraphQL: a root field artworkFilterSuggestions(query) returning a natural-language query parsed into validated artwork filters plus a leftover "vibe" keyword.

[Follow-up to Gravity PR](https://github.com/artsy/gravity/pull/20361)