### PR TITLE
[DO NOT MERGE] chore: opt-in curator-note test data stub

### DIFF
--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -985,12 +985,15 @@ const selectsEdgeNote = (info: GraphQLResolveInfo): boolean => {
  * connection.
  */
 // TEST-DATA STUB samples — see the STUB_CURATOR_NOTES block below. Throwaway.
+// Deliberately spans a range of lengths (short one-liners through a ~300-word
+// note) so the clients can be tested against both compact and long descriptions.
 const STUB_CURATOR_NOTE_SAMPLES = [
   "A standout work — chosen for its bold, confident use of color.",
   "Included for the way it reframes a familiar subject.",
-  "One of the curator’s favorites in this collection.",
-  "A quietly ambitious piece worth spending time with.",
-  "Selected for its striking composition and scale.",
+  "One of the curator’s favorites in this collection — a quietly ambitious piece that rewards a second look, both for its composition and for the restraint of its palette.",
+  "Selected for its striking composition and scale. It holds a room without shouting, and it pairs unexpectedly well with both historical and contemporary works — a rare quality that made it an easy inclusion here.",
+  // ~300-word sample for testing long descriptions.
+  "This work anchors the entire collection, and it rewards the kind of slow looking that a curated selection is meant to encourage. The artist arrived at this composition after years of returning to the same motif, and you can feel that accumulated attention in every decision on the surface — the way the horizon sits slightly higher than expected, the almost architectural balance of the negative space, the restraint of a palette that never reaches for easy drama. We chose it not because it is the loudest work here, but because it quietly reorganizes everything around it; hang it beside the other pieces and they suddenly read as a conversation rather than a group. There is also a biographical thread worth knowing: this was made during a period of significant transition for the artist, when a move to a new city and an unfamiliar quality of light forced a rethinking of long-held habits. That tension between mastery and uncertainty is, for us, the heart of the piece. Collectors often respond first to its scale and presence, but the details are where it earns a place on the wall for decades — the layered underpainting that surfaces only in raking light, the deliberate roughness at the edges that keeps the image from feeling precious. It sits comfortably alongside both historical and contemporary works, which is rare, and it shifts in mood with the time of day. If you are building a collection with a point of view rather than simply accumulating names, this is the sort of acquisition that becomes a reference point — the work you return to when deciding what else belongs. We think it will reward you, and whoever you share your walls with, for a very long time.",
 ]
 
 const stampCuratorNotes = async ({

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -984,6 +984,15 @@ const selectsEdgeNote = (info: GraphQLResolveInfo): boolean => {
  * to read its notes. Notes are non-essential, so a failed lookup never fails the
  * connection.
  */
+// TEST-DATA STUB samples — see the STUB_CURATOR_NOTES block below. Throwaway.
+const STUB_CURATOR_NOTE_SAMPLES = [
+  "A standout work — chosen for its bold, confident use of color.",
+  "Included for the way it reframes a familiar subject.",
+  "One of the curator’s favorites in this collection.",
+  "A quietly ambitious piece worth spending time with.",
+  "Selected for its striking composition and scale.",
+]
+
 const stampCuratorNotes = async ({
   connection,
   root,
@@ -1020,6 +1029,27 @@ const stampCuratorNotes = async ({
     } catch (_error) {
       artworkNotes = undefined
     }
+  }
+
+  // TEST-DATA STUB (opt-in via STUB_CURATOR_NOTES=true, off by default): before
+  // Gravity ships real curator notes, synthesize a sample note on ~1 in 4 works of
+  // any marketing-collection connection so the eigen/force UIs can be exercised
+  // end-to-end. This is throwaway scaffolding and must not be enabled in production.
+  if (
+    (!artworkNotes || artworkNotes.length === 0) &&
+    marketingCollectionID &&
+    process.env.STUB_CURATOR_NOTES === "true"
+  ) {
+    connection.edges = connection.edges.map((edge, index) => ({
+      ...edge,
+      note:
+        index % 4 === 0 && edge?.node?._id
+          ? STUB_CURATOR_NOTE_SAMPLES[
+              Math.floor(index / 4) % STUB_CURATOR_NOTE_SAMPLES.length
+            ]
+          : edge?.note ?? null,
+    }))
+    return
   }
 
   if (!artworkNotes?.length) return


### PR DESCRIPTION
### ⚠️ Temporary — do not merge

Throwaway scaffolding so the eigen/force curator-note UIs can be exercised end-to-end **before Gravity ships real curator notes**. Stacked on the follow-up branch (`claude/collector-notes-home-rails`, PR #7763) so it includes the full note plumbing.

### What it does

When the env flag `STUB_CURATOR_NOTES=true` is set, any **marketing-collection** `artworksConnection` that has no real `artwork_notes` yet gets a **synthetic sample note on ~1 in 4 works** (`index % 4`). It's gated exactly like the real stamping (only when `edges { note }` is selected, only for marketing-collection-scoped connections), so nothing changes for non-marketing connections.

Off by default — with the flag unset, behavior is identical to #7763.

### How to use it for UI testing

```bash
STUB_CURATOR_NOTES=true yarn dev
```

Then point eigen/force at your local Metaphysics and open any marketing collection (its page, its rails, or the Curators' Picks home rail). Roughly every 4th work will show a curator's note badge (tap/click it for the full note). Samples rotate through a small fixed set.

### Notes

- This must **not** be enabled in production — it fabricates data.
- Once Gravity's `artwork_notes` ships and #7756/#7763 land, this branch can be deleted; no code from it should be merged.
- Authored without `node_modules`, so `yarn type-check`/`jest` were not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01X2iHtPiKHN91ghgcJWyJjC)_