### PR TITLE
feat(PartnerOfferToCollector): add isPurchased field

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -30337,6 +30337,11 @@ type PartnerOfferToCollector implements Node {
   internalID: ID!
   isActive: Boolean
   isAvailable: Boolean
+
+  """
+  Whether the collector already has an order created from this partner offer in a purchased buyer state (submitted, approved, or completed).
+  """
+  isPurchased: Boolean!
   note: String
   partnerId: String
   priceWithDiscount: Money

--- a/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
+++ b/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
@@ -1,0 +1,104 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("PartnerOfferToCollector", () => {
+  const partnerOffer = {
+    id: "partner-offer-1",
+    artwork_id: "artwork-1",
+    active: true,
+    available: true,
+    price_currency: "USD",
+    price_with_discount_minor: 1736000,
+    created_at: "2024-02-27T19:01:51.461Z",
+    end_at: "2024-03-01T19:01:51.457Z",
+  }
+
+  const mePartnerOffersLoader = () =>
+    Promise.resolve({
+      body: [partnerOffer],
+      headers: { "x-total-count": "1" },
+    })
+
+  const query = gql`
+    query {
+      me {
+        partnerOffersConnection(first: 10) {
+          edges {
+            node {
+              internalID
+              isPurchased
+            }
+          }
+        }
+      }
+    }
+  `
+
+  describe("isPurchased", () => {
+    it("is true when a purchased-state order references the partner offer", async () => {
+      const meOrdersLoader = jest.fn(() =>
+        Promise.resolve({
+          body: [
+            {
+              buyer_state: "APPROVED",
+              line_items: [{ partner_offer_id: "partner-offer-1" }],
+            },
+          ],
+          headers: {},
+        })
+      )
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(meOrdersLoader).toHaveBeenCalledWith({
+        artwork_id: "artwork-1",
+        buyer_state: "SUBMITTED,APPROVED,COMPLETED",
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(true)
+    })
+
+    it("is false when no order references the partner offer", async () => {
+      const meOrdersLoader = () =>
+        Promise.resolve({
+          body: [
+            {
+              buyer_state: "APPROVED",
+              line_items: [{ partner_offer_id: "some-other-offer" }],
+            },
+          ],
+          headers: {},
+        })
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(false)
+    })
+
+    it("is false when there are no orders", async () => {
+      const meOrdersLoader = () => Promise.resolve({ body: [], headers: {} })
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(false)
+    })
+  })
+})

--- a/src/schema/v2/partnerOfferToCollector.ts
+++ b/src/schema/v2/partnerOfferToCollector.ts
@@ -4,12 +4,17 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLEnumType,
+  GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { IDFields, NodeInterface } from "./object_identification"
 import { connectionWithCursorInfo } from "./fields/pagination"
 import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
 import { PartnerOfferSourceEnumType } from "./partnerOffer"
+
+// Buyer states that indicate the collector has committed to a purchase created
+// from a partner offer. Kept in sync with the clients' previous logic.
+const PURCHASED_BUYER_STATES = ["SUBMITTED", "APPROVED", "COMPLETED"]
 
 export const PartnerOfferToCollectorType = new GraphQLObjectType<
   any,
@@ -32,6 +37,27 @@ export const PartnerOfferToCollectorType = new GraphQLObjectType<
     isAvailable: {
       type: GraphQLBoolean,
       resolve: ({ available }) => available,
+    },
+    isPurchased: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description:
+        "Whether the collector already has an order created from this partner offer in a purchased buyer state (submitted, approved, or completed).",
+      resolve: async ({ id, artwork_id }, _args, { meOrdersLoader }) => {
+        if (!meOrdersLoader || !id) {
+          return false
+        }
+
+        const { body: orders } = await meOrdersLoader({
+          artwork_id,
+          buyer_state: PURCHASED_BUYER_STATES.join(","),
+        })
+
+        return (orders ?? []).some((order) =>
+          (order.line_items ?? []).some(
+            (lineItem) => lineItem?.partner_offer_id === id
+          )
+        )
+      },
     },
     note: {
       type: GraphQLString,


### PR DESCRIPTION
Move the logic we have for fetching orders with the right states in the PartnerOfferToCollector context.

Next steps will be to use the new field in Eigen and Force.

cc @artsy/topaz-devs 