### PR TITLE
docs: guide AI reviews to flag per-node loader calls in connections (N+1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,36 +13,39 @@ Metaphysics fields often resolve by calling a REST loader (Gravity, Exchange, et
 
 When writing or reviewing a resolver, flag any field resolver that awaits a loader on a type reachable through a connection. Prefer one of:
 
-- **Batch at the connection resolver**: fetch the data once for the whole page (drop per-node filters like `artwork_id`), index it in-process (e.g. a `Set` of IDs), and stash the precomputed value on each node before returning. The field resolver then just reads the precomputed value.
-- **Keep a fallback for standalone access**: if the type is also reachable outside a connection (e.g. `Artwork.collectorSignals.partnerOffer` returns a single `PartnerOfferToCollector`), the field resolver should use the precomputed value when present and only fall back to a single loader call when it isn't.
+- **Batch at the connection resolver**: fetch the data once for the whole page, index it in-process (e.g. a `Set` of IDs), and stash the precomputed value on each node before returning. The field resolver then just reads the precomputed value.
+- **Keep a fallback for standalone access**: if the type is also reachable outside a connection as a single node, the field resolver should use the precomputed value when present and only fall back to a single loader call when it isn't.
 - **Use a DataLoader** with batching if the upstream endpoint supports fetching by multiple keys.
 
-Example — `isPurchased` on `PartnerOfferToCollector`:
+Example — adding a new `isSaved` field to a type returned by a connection:
 
 ```ts
-// ❌ Per-node: N Exchange calls for a page of N offers
-isPurchased: {
-  resolve: async ({ id, artwork_id }, _args, { meOrdersLoader }) => {
-    const { body: orders } = await meOrdersLoader({
-      artwork_id,
-      buyer_state: PURCHASED_STATES.join(","),
-    })
-    return orders.some((o) =>
-      o.line_items.some((li) => li.partner_offer_id === id)
-    )
+// ❌ Per-node: a page of 10 artworks fires 10 Gravity calls
+isSaved: {
+  type: GraphQLBoolean,
+  resolve: async ({ id }, _args, { savedArtworkLoader }) => {
+    const { body } = await savedArtworkLoader(id)
+    return body.is_saved
   },
 }
 
-// ✅ Batched: one Exchange call per page, set in the connection resolver
-const { body: orders } = await meOrdersLoader({
-  buyer_state: PURCHASED_STATES.join(","),
+// ✅ Batched: one Gravity call for the whole page, in the connection resolver
+const { body: saved } = await savedArtworksLoader({ ids: artworkIds })
+const savedIds = new Set(saved.map((artwork) => artwork.id))
+artworks.forEach((artwork) => {
+  artwork._isSaved = savedIds.has(artwork.id)
 })
-const purchasedIds = new Set(
-  orders.flatMap((o) => o.line_items.map((li) => li.partner_offer_id))
-)
-offers.forEach((o) => (o._isPurchased = purchasedIds.has(o.id)))
-// field resolver: reads o._isPurchased, falling back to a single
-// loader call only when resolved outside a connection
+
+// ✅ Field resolver: read the precomputed value; only when the node was
+// resolved outside a connection, fall back to a single loader call
+isSaved: {
+  type: GraphQLBoolean,
+  resolve: async (artwork, _args, { savedArtworkLoader }) => {
+    if (artwork._isSaved !== undefined) return artwork._isSaved
+    const { body } = await savedArtworkLoader(artwork.id)
+    return body.is_saved
+  },
+}
 ```
 
 Also watch for the error-handling twist: if such a field is non-null (`Boolean!`) and the loader rejects, GraphQL nulls the nearest nullable ancestor and silently drops the node from the response. Wrap the loader call and degrade gracefully instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,46 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - In almost all instances where a query returns data from the DB, we do not use an `id` field but rather an `internalID` field. `id` fields are specifically for Relay and bear no relationship to database IDs.
 - Field _arguments_ do frequently use `id` however (eg, `artist(id: "andy-warhol") { ... }`), and the values passed to them can typically be `slug` or `internalID`.
 
+## Performance: avoid per-node loader calls in connections (N+1)
+
+Metaphysics fields often resolve by calling a REST loader (Gravity, Exchange, etc.). When such a field lives on a type that is returned by a connection, the resolver runs once **per node**, so a `first: 10` page fires 10 upstream REST calls and the fan-out scales with page size. This has caused real incidents: a per-node loader call in conversation message resolvers turned 40k `conversationsConnection` queries into 800k Exchange REST calls.
+
+When writing or reviewing a resolver, flag any field resolver that awaits a loader on a type reachable through a connection. Prefer one of:
+
+- **Batch at the connection resolver**: fetch the data once for the whole page (drop per-node filters like `artwork_id`), index it in-process (e.g. a `Set` of IDs), and stash the precomputed value on each node before returning. The field resolver then just reads the precomputed value.
+- **Keep a fallback for standalone access**: if the type is also reachable outside a connection (e.g. `Artwork.collectorSignals.partnerOffer` returns a single `PartnerOfferToCollector`), the field resolver should use the precomputed value when present and only fall back to a single loader call when it isn't.
+- **Use a DataLoader** with batching if the upstream endpoint supports fetching by multiple keys.
+
+Example — `isPurchased` on `PartnerOfferToCollector`:
+
+```ts
+// ❌ Per-node: N Exchange calls for a page of N offers
+isPurchased: {
+  resolve: async ({ id, artwork_id }, _args, { meOrdersLoader }) => {
+    const { body: orders } = await meOrdersLoader({
+      artwork_id,
+      buyer_state: PURCHASED_STATES.join(","),
+    })
+    return orders.some((o) =>
+      o.line_items.some((li) => li.partner_offer_id === id)
+    )
+  },
+}
+
+// ✅ Batched: one Exchange call per page, set in the connection resolver
+const { body: orders } = await meOrdersLoader({
+  buyer_state: PURCHASED_STATES.join(","),
+})
+const purchasedIds = new Set(
+  orders.flatMap((o) => o.line_items.map((li) => li.partner_offer_id))
+)
+offers.forEach((o) => (o._isPurchased = purchasedIds.has(o.id)))
+// field resolver: reads o._isPurchased, falling back to a single
+// loader call only when resolved outside a connection
+```
+
+Also watch for the error-handling twist: if such a field is non-null (`Boolean!`) and the loader rejects, GraphQL nulls the nearest nullable ancestor and silently drops the node from the response. Wrap the loader call and degrade gracefully instead.
+
 ## Commands
 
 - Starting: `yarn start`


### PR DESCRIPTION
### Motivation

While reviewing this PR: https://github.com/artsy/metaphysics/pull/7769, I noticed a valid comment from Claude https://github.com/artsy/metaphysics/pull/7769#discussion_r3620471999 and it inspired me to instruct Claude about N+1. 


### Description
Adds a section to `AGENTS.md` valid for both the AI PR review and Claude Code sessions — to watch for n+1

### Why
Per-node loader calls fan out with page size: a `first: 10` connection page becomes 10 upstream REST calls. This has bitten us before — a similar pattern in Exchange Messages turned 40k `conversationsConnection` queries into 800k Exchange REST calls — 

### What the guidance says

- Flag any per-node resolver that awaits a loader when the type is reachable through a connection.
- Prefer batching at the connection resolver: fetch once per page, index in-process, stash the precomputed value on each node.
- Keep a single-call fallback in the field resolver for standalone (non-connection) access: if the precomputed value is present, the node came through a connection and the data is already there; otherwise it's a single node and one loader call is fine.
- Includes a simple before/after example (adding a new `isSaved` field to a type returned by a connection), plus a note on the non-null + loader-rejection footgun (a failed loader nulls the nearest nullable ancestor and silently drops nodes).

cc @araujobarret

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMUPWy9QLdeWHDFut78A9q

```
Assisted-by: Claude Fable
```