### PR TITLE
feat: add isPurchased to PartnerOfferToCollector

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -13545,6 +13545,23 @@ type Conversation implements Node {
   ): MeOrdersConnection
 
   """
+  The current (collector) user's partner offers for this conversation's artwork.
+  """
+  collectorPartnerOffersConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    """
+    Filter by offer type(s). Gravity defaults to all of the user's partner offers when omitted.
+    """
+    offerType: [PartnerOfferTypeEnum]
+    page: Int
+    size: Int
+  ): PartnerOfferToCollectorConnection
+
+  """
   The collector profile of the user who initiated the conversation. Do not use this field for Partners
   """
   collectorResume: CollectorResume
@@ -30337,6 +30354,11 @@ type PartnerOfferToCollector implements Node {
   internalID: ID!
   isActive: Boolean
   isAvailable: Boolean
+
+  """
+  Whether the collector already has an order created from this partner offer in a purchased buyer state (submitted, approved, or completed).
+  """
+  isPurchased: Boolean!
   note: String
   partnerId: String
   priceWithDiscount: Money

--- a/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
+++ b/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
@@ -1,0 +1,90 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("PartnerOfferToCollector", () => {
+  const partnerOffer = {
+    id: "partner-offer-1",
+    artwork_id: "artwork-1",
+    active: true,
+    available: true,
+    price_currency: "USD",
+    price_with_discount_minor: 1736000,
+    created_at: "2024-02-27T19:01:51.461Z",
+    end_at: "2024-03-01T19:01:51.457Z",
+  }
+
+  const mePartnerOffersLoader = () =>
+    Promise.resolve({
+      body: [partnerOffer],
+      headers: { "x-total-count": "1" },
+    })
+
+  const query = gql`
+    query {
+      me {
+        partnerOffersConnection(first: 10) {
+          edges {
+            node {
+              internalID
+              isPurchased
+            }
+          }
+        }
+      }
+    }
+  `
+
+  describe("isPurchased (fallback)", () => {
+    it("is true when Exchange returns a purchased-state order for the offer", async () => {
+      const meOrdersLoader = jest.fn(() =>
+        Promise.resolve({
+          body: [{ id: "order-1" }],
+          headers: {},
+        })
+      )
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(meOrdersLoader).toHaveBeenCalledWith({
+        partner_offer_ids: "partner-offer-1",
+        buyer_state: "SUBMITTED,APPROVED,COMPLETED",
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(true)
+    })
+
+    it("is false when Exchange returns no orders for the offer", async () => {
+      const meOrdersLoader = () => Promise.resolve({ body: [], headers: {} })
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(false)
+    })
+
+    it("is false when the orders loader rejects", async () => {
+      const meOrdersLoader = () => Promise.reject(new Error("Exchange down"))
+
+      const response = await runAuthenticatedQuery(query, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(
+        response.me.partnerOffersConnection.edges[0].node.isPurchased
+      ).toBe(false)
+    })
+  })
+})

--- a/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
+++ b/src/schema/v2/__tests__/partnerOfferToCollector.test.ts
@@ -34,11 +34,16 @@ describe("PartnerOfferToCollector", () => {
     }
   `
 
-  describe("isPurchased (fallback)", () => {
-    it("is true when Exchange returns a purchased-state order for the offer", async () => {
+  describe("isPurchased", () => {
+    it("batches the lookup into one Exchange request when selected", async () => {
       const meOrdersLoader = jest.fn(() =>
         Promise.resolve({
-          body: [{ id: "order-1" }],
+          body: [
+            {
+              buyer_state: "APPROVED",
+              line_items: [{ partner_offer_id: "partner-offer-1" }],
+            },
+          ],
           headers: {},
         })
       )
@@ -49,9 +54,11 @@ describe("PartnerOfferToCollector", () => {
         meOrdersLoader,
       })
 
+      expect(meOrdersLoader).toHaveBeenCalledTimes(1)
       expect(meOrdersLoader).toHaveBeenCalledWith({
         partner_offer_ids: "partner-offer-1",
         buyer_state: "SUBMITTED,APPROVED,COMPLETED",
+        size: 1,
       })
 
       expect(
@@ -59,8 +66,17 @@ describe("PartnerOfferToCollector", () => {
       ).toBe(true)
     })
 
-    it("is false when Exchange returns no orders for the offer", async () => {
-      const meOrdersLoader = () => Promise.resolve({ body: [], headers: {} })
+    it("is false when no order references the offer", async () => {
+      const meOrdersLoader = () =>
+        Promise.resolve({
+          body: [
+            {
+              buyer_state: "APPROVED",
+              line_items: [{ partner_offer_id: "some-other-offer" }],
+            },
+          ],
+          headers: {},
+        })
 
       const response = await runAuthenticatedQuery(query, {
         meLoader: () => Promise.resolve({}),
@@ -73,7 +89,7 @@ describe("PartnerOfferToCollector", () => {
       ).toBe(false)
     })
 
-    it("is false when the orders loader rejects", async () => {
+    it("is false (and does not fail the connection) when the orders loader rejects", async () => {
       const meOrdersLoader = () => Promise.reject(new Error("Exchange down"))
 
       const response = await runAuthenticatedQuery(query, {
@@ -85,6 +101,32 @@ describe("PartnerOfferToCollector", () => {
       expect(
         response.me.partnerOffersConnection.edges[0].node.isPurchased
       ).toBe(false)
+    })
+
+    it("does not query Exchange when isPurchased is not selected", async () => {
+      const meOrdersLoader = jest.fn()
+
+      const queryWithoutIsPurchased = gql`
+        query {
+          me {
+            partnerOffersConnection(first: 10) {
+              edges {
+                node {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      await runAuthenticatedQuery(queryWithoutIsPurchased, {
+        meLoader: () => Promise.resolve({}),
+        mePartnerOffersLoader,
+        meOrdersLoader,
+      })
+
+      expect(meOrdersLoader).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/schema/v2/conversation/__tests__/conversationCollectorPartnerOffersConnection.test.ts
+++ b/src/schema/v2/conversation/__tests__/conversationCollectorPartnerOffersConnection.test.ts
@@ -1,0 +1,247 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("conversation collectorPartnerOffersConnection", () => {
+  let mePartnerOffersLoader
+  let context
+
+  beforeEach(() => {
+    mePartnerOffersLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            id: "offer-1",
+            active: true,
+            artwork_id: "artwork-1",
+            available: true,
+            partner_id: "partner-id",
+            price_currency: "USD",
+            source: "Conversation",
+            created_at: "2024-02-27T19:01:51.461Z",
+            end_at: "2024-03-01T19:01:51.457Z",
+          },
+        ],
+        headers: { "x-total-count": "1" },
+      })
+    )
+
+    context = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          from_type: "User",
+          to_id: "partner-id",
+          to_type: "Partner",
+          items: [
+            {
+              item_type: "Artwork",
+              item_id: "artwork-1",
+              properties: {
+                id: "artwork-1",
+                _id: "artwork-1",
+              },
+            },
+          ],
+        }),
+      mePartnerOffersLoader,
+    }
+  })
+
+  it("scopes the current user's offers to the conversation's artwork and passes offerType", async () => {
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          collectorPartnerOffersConnection(
+            first: 10
+            offerType: [PERSONALIZED]
+          ) {
+            totalCount
+            edges {
+              node {
+                internalID
+                artworkId
+                source
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(mePartnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artwork_id: "artwork-1",
+        offer_type: ["personalized"],
+        total_count: true,
+      })
+    )
+
+    expect(data).toEqual({
+      conversation: {
+        collectorPartnerOffersConnection: {
+          totalCount: 1,
+          edges: [
+            {
+              node: {
+                internalID: "offer-1",
+                artworkId: "artwork-1",
+                source: "CONVERSATION",
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  it("omits offer_type when the arg is not given", async () => {
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          collectorPartnerOffersConnection(first: 10) {
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(mePartnerOffersLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artwork_id: "artwork-1",
+        offer_type: undefined,
+      })
+    )
+  })
+
+  it("stamps isPurchased for the whole page in a single Exchange request", async () => {
+    const mePartnerOffersLoader = () =>
+      Promise.resolve({
+        body: [
+          { id: "offer-1", artwork_id: "artwork-1" },
+          { id: "offer-2", artwork_id: "artwork-1" },
+        ],
+        headers: { "x-total-count": "2" },
+      })
+
+    const meOrdersLoader = jest.fn(() =>
+      Promise.resolve({
+        body: [
+          {
+            buyer_state: "APPROVED",
+            line_items: [{ partner_offer_id: "offer-2" }],
+          },
+        ],
+        headers: {},
+      })
+    )
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          collectorPartnerOffersConnection(first: 10) {
+            edges {
+              node {
+                internalID
+                isPurchased
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      ...context,
+      mePartnerOffersLoader,
+      meOrdersLoader,
+    })
+
+    // One batched Exchange call for the whole page — not one per offer node.
+    expect(meOrdersLoader).toHaveBeenCalledTimes(1)
+    expect(meOrdersLoader).toHaveBeenCalledWith({
+      partner_offer_ids: "offer-1,offer-2",
+      buyer_state: "SUBMITTED,APPROVED,COMPLETED",
+      size: 2,
+    })
+
+    expect(
+      data.conversation.collectorPartnerOffersConnection.edges.map(
+        (edge) => edge.node
+      )
+    ).toEqual([
+      { internalID: "offer-1", isPurchased: false },
+      { internalID: "offer-2", isPurchased: true },
+    ])
+  })
+
+  it("returns null when the conversation has no artwork item", async () => {
+    const contextWithNoArtwork = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          items: [],
+        }),
+      mePartnerOffersLoader,
+    }
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          collectorPartnerOffersConnection(first: 10) {
+            totalCount
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, contextWithNoArtwork)
+
+    expect(data).toEqual({
+      conversation: {
+        collectorPartnerOffersConnection: null,
+      },
+    })
+    expect(mePartnerOffersLoader).not.toHaveBeenCalled()
+  })
+
+  it("throws when mePartnerOffersLoader is unavailable (signed out)", async () => {
+    const contextWithoutLoader = {
+      conversationLoader: () =>
+        Promise.resolve({
+          id: "conversation-1",
+          from_id: "buyer-1",
+          items: [
+            {
+              item_type: "Artwork",
+              item_id: "artwork-1",
+              properties: { id: "artwork-1", _id: "artwork-1" },
+            },
+          ],
+        }),
+    }
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          collectorPartnerOffersConnection(first: 10) {
+            totalCount
+          }
+        }
+      }
+    `
+
+    await expect(runQuery(query, contextWithoutLoader)).rejects.toThrow(
+      "You need to be signed in to perform this action"
+    )
+  })
+})

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -41,6 +41,10 @@ import {
   PartnerOfferConnectionType,
   PartnerOfferTypeEnumType,
 } from "../partnerOffer"
+import {
+  PartnerOfferToCollectorConnectionType,
+  stampPartnerOfferPurchases,
+} from "../partnerOfferToCollector"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -339,6 +343,59 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
             user_id: from_id,
             offer_type: args.offerType,
           })
+
+          const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+          return paginationResolver({
+            args,
+            body,
+            offset,
+            page,
+            size,
+            totalCount,
+          })
+        },
+      },
+      collectorPartnerOffersConnection: {
+        description:
+          "The current (collector) user's partner offers for this conversation's artwork.",
+        type: PartnerOfferToCollectorConnectionType,
+        args: pageable({
+          page: { type: GraphQLInt },
+          size: { type: GraphQLInt },
+          offerType: {
+            type: new GraphQLList(PartnerOfferTypeEnumType),
+            description:
+              "Filter by offer type(s). Gravity defaults to all of the user's partner offers when omitted.",
+          },
+        }),
+        resolve: async (
+          { items },
+          args,
+          { mePartnerOffersLoader, meOrdersLoader }
+        ) => {
+          if (!mePartnerOffersLoader)
+            throw new Error("You need to be signed in to perform this action")
+
+          // Assume a conversation only has one item
+          const artwork = items?.find((item) => item.item_type === "Artwork")
+          if (!artwork) return null
+
+          const { page, size, offset } = convertConnectionArgsToGravityArgs(
+            args
+          )
+
+          const { body, headers } = await mePartnerOffersLoader({
+            total_count: true,
+            page,
+            size,
+            artwork_id: artwork.properties.id,
+            offer_type: args.offerType,
+          })
+
+          // Resolve `isPurchased` for the whole page in one Exchange request
+          // rather than one per offer node.
+          await stampPartnerOfferPurchases(body, meOrdersLoader)
 
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/conversation/index.ts
+++ b/src/schema/v2/conversation/index.ts
@@ -45,6 +45,7 @@ import {
   PartnerOfferToCollectorConnectionType,
   stampPartnerOfferPurchases,
 } from "../partnerOfferToCollector"
+import { isFieldRequested } from "lib/isFieldRequested"
 
 export const BuyerOutcomeTypes = new GraphQLEnumType({
   name: "BuyerOutcomeTypes",
@@ -372,7 +373,8 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
         resolve: async (
           { items },
           args,
-          { mePartnerOffersLoader, meOrdersLoader }
+          { mePartnerOffersLoader, meOrdersLoader },
+          resolveInfo
         ) => {
           if (!mePartnerOffersLoader)
             throw new Error("You need to be signed in to perform this action")
@@ -393,9 +395,9 @@ export const ConversationType = new GraphQLObjectType<any, ResolverContext>({
             offer_type: args.offerType,
           })
 
-          // Resolve `isPurchased` for the whole page in one Exchange request
-          // rather than one per offer node.
-          await stampPartnerOfferPurchases(body, meOrdersLoader)
+          if (isFieldRequested("edges.node.isPurchased", resolveInfo)) {
+            await stampPartnerOfferPurchases(body, meOrdersLoader)
+          }
 
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -48,7 +48,9 @@ import { PartnerOfferTypeEnumType } from "../partnerOffer"
 import {
   PartnerOfferToCollectorConnectionType,
   PartnerOfferToCollectorSortsType,
+  stampPartnerOfferPurchases,
 } from "../partnerOfferToCollector"
+import { isFieldRequested } from "lib/isFieldRequested"
 import { PhoneNumber, resolvePhoneNumber } from "../phoneNumber"
 import { PreviewSavedSearchAttributesType } from "../previewSavedSearch"
 import { quiz } from "../quiz"
@@ -527,7 +529,12 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         size: { type: GraphQLInt },
         sort: { type: PartnerOfferToCollectorSortsType },
       }),
-      resolve: async (_me, args, { mePartnerOffersLoader }) => {
+      resolve: async (
+        _me,
+        args,
+        { mePartnerOffersLoader, meOrdersLoader },
+        resolveInfo
+      ) => {
         if (!mePartnerOffersLoader)
           throw new Error("You need to be signed in to perform this action")
 
@@ -551,6 +558,10 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         }
 
         const { body, headers } = await mePartnerOffersLoader(gravityArgs)
+
+        if (isFieldRequested("edges.node.isPurchased", resolveInfo)) {
+          await stampPartnerOfferPurchases(body, meOrdersLoader)
+        }
 
         const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 

--- a/src/schema/v2/partnerOfferToCollector.ts
+++ b/src/schema/v2/partnerOfferToCollector.ts
@@ -4,12 +4,56 @@ import {
   GraphQLString,
   GraphQLBoolean,
   GraphQLEnumType,
+  GraphQLNonNull,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
 import { IDFields, NodeInterface } from "./object_identification"
 import { connectionWithCursorInfo } from "./fields/pagination"
 import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
 import { PartnerOfferSourceEnumType } from "./partnerOffer"
+
+// Buyer states that indicate the collector has committed to a purchase created
+// from a partner offer. Kept in sync with the clients' previous logic.
+const PURCHASED_BUYER_STATES = ["SUBMITTED", "APPROVED", "COMPLETED"]
+
+/**
+ * Fetches, in a single Exchange request, which of the given partner offers the
+ * current user has a purchased-state order for, and stamps `_isPurchased` on
+ * each offer.
+ *
+ * Call this from connection resolvers that return `PartnerOfferToCollector` so
+ * the `isPurchased` field reads a precomputed value instead of firing one
+ * Exchange `me/orders` request per node (an N+1 that scales with page size).
+ */
+export const stampPartnerOfferPurchases = async (
+  offers: Array<{ id?: string; _isPurchased?: boolean }>,
+  meOrdersLoader?: ResolverContext["meOrdersLoader"]
+) => {
+  if (!meOrdersLoader) return offers
+
+  const ids = offers.map((offer) => offer.id).filter(Boolean)
+  if (ids.length === 0) return offers
+
+  const { body: orders } = await meOrdersLoader({
+    partner_offer_ids: ids.join(","),
+    buyer_state: PURCHASED_BUYER_STATES.join(","),
+    size: ids.length,
+  })
+
+  const purchasedIds = new Set(
+    (orders ?? []).flatMap((order) =>
+      (order.line_items ?? [])
+        .map((lineItem) => lineItem?.partner_offer_id)
+        .filter(Boolean)
+    )
+  )
+
+  offers.forEach((offer) => {
+    offer._isPurchased = offer.id ? purchasedIds.has(offer.id) : false
+  })
+
+  return offers
+}
 
 export const PartnerOfferToCollectorType = new GraphQLObjectType<
   any,
@@ -32,6 +76,36 @@ export const PartnerOfferToCollectorType = new GraphQLObjectType<
     isAvailable: {
       type: GraphQLBoolean,
       resolve: ({ available }) => available,
+    },
+    isPurchased: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description:
+        "Whether the collector already has an order created from this partner offer in a purchased buyer state (submitted, approved, or completed).",
+      resolve: async ({ id, _isPurchased }, _args, { meOrdersLoader }) => {
+        // Precomputed in one batched Exchange request by connection resolvers
+        // (see `stampPartnerOfferPurchases`). Fall back to a single lookup only
+        // when the offer is reached outside such a connection.
+        if (_isPurchased !== undefined) {
+          return _isPurchased
+        }
+
+        if (!meOrdersLoader || !id) {
+          return false
+        }
+
+        try {
+          const { body: orders } = await meOrdersLoader({
+            partner_offer_ids: id,
+            buyer_state: PURCHASED_BUYER_STATES.join(","),
+          })
+
+          return (orders ?? []).length > 0
+        } catch (error) {
+          // A transient Exchange failure shouldn't null out this non-null field
+          // and drop the whole offer from the list; treat it as "not purchased".
+          return false
+        }
+      },
     },
     note: {
       type: GraphQLString,

--- a/src/schema/v2/partnerOfferToCollector.ts
+++ b/src/schema/v2/partnerOfferToCollector.ts
@@ -34,23 +34,29 @@ export const stampPartnerOfferPurchases = async (
   const ids = offers.map((offer) => offer.id).filter(Boolean)
   if (ids.length === 0) return offers
 
-  const { body: orders } = await meOrdersLoader({
-    partner_offer_ids: ids.join(","),
-    buyer_state: PURCHASED_BUYER_STATES.join(","),
-    size: ids.length,
-  })
+  try {
+    const { body: orders } = await meOrdersLoader({
+      partner_offer_ids: ids.join(","),
+      buyer_state: PURCHASED_BUYER_STATES.join(","),
+      size: ids.length,
+    })
 
-  const purchasedIds = new Set(
-    (orders ?? []).flatMap((order) =>
-      (order.line_items ?? [])
-        .map((lineItem) => lineItem?.partner_offer_id)
-        .filter(Boolean)
+    const purchasedIds = new Set(
+      (orders ?? []).flatMap((order) =>
+        (order.line_items ?? [])
+          .map((lineItem) => lineItem?.partner_offer_id)
+          .filter(Boolean)
+      )
     )
-  )
 
-  offers.forEach((offer) => {
-    offer._isPurchased = offer.id ? purchasedIds.has(offer.id) : false
-  })
+    offers.forEach((offer) => {
+      offer._isPurchased = offer.id ? purchasedIds.has(offer.id) : false
+    })
+  } catch (error) {
+    offers.forEach((offer) => {
+      offer._isPurchased = false
+    })
+  }
 
   return offers
 }


### PR DESCRIPTION
Related to [TOP-325] and https://github.com/artsy/exchange/pull/3148

- Add `collectorPartnerOffersConnection` to a conversation context
- Add `isPurchased` to the `PartnerOfferToCollector` type, which fetches orders in purchased states given the `partner_offer_id`. It's in a way that prevents N+1 requests(not in the past we had, usually is 1, max of 2 partner offers per artwork but it's a good safe-guard)

cc @artsy/topaz-devs 


[TOP-325]: https://artsyproduct.atlassian.net/browse/TOP-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ