### PR TITLE
chore: Allow created surface to be passed to artwork mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4647,6 +4647,14 @@ interface ArtworkContextGrid {
   title: String
 }
 
+"""
+The surface an artwork was created from.
+"""
+enum ArtworkCreatedSurface {
+  CMS
+  OS
+}
+
 input ArtworkDuplicateMergeFieldOverridesInput {
   availability: String
   date: String
@@ -14365,6 +14373,11 @@ input CreateArtworkMutationInput {
   """
   artsyListing: Boolean
   clientMutationId: String
+
+  """
+  The surface the artwork is being created from. Defaults to CMS.
+  """
+  createdSurface: ArtworkCreatedSurface
 
   """
   The S3 bucket where the artwork image is stored.

--- a/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/createArtworkMutation.test.ts
@@ -346,4 +346,67 @@ describe("CreateArtworkMutation", () => {
       )
     })
   })
+
+  describe("createdSurface field", () => {
+    it("passes created_surface to the loader when provided", async () => {
+      const mockArtwork = { _id: "artwork123" }
+      const createArtworkLoaderMock = jest.fn().mockResolvedValue(mockArtwork)
+
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        createArtworkLoader: createArtworkLoaderMock,
+        addImageToArtworkLoader: jest.fn(),
+        addArtworkToPartnerShowLoader: jest.fn(),
+      }
+
+      const createdSurfaceMutation = gql`
+        mutation {
+          createArtwork(
+            input: {
+              partnerId: "partner123"
+              artistIds: ["artist123"]
+              createdSurface: OS
+            }
+          ) {
+            artworkOrError {
+              __typename
+              ... on CreateArtworkSuccess {
+                artwork {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `
+
+      await runAuthenticatedQuery(createdSurfaceMutation, context)
+
+      expect(createArtworkLoaderMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          created_surface: "OS",
+        })
+      )
+    })
+
+    it("does not pass created_surface when not provided", async () => {
+      const mockArtwork = { _id: "artwork123" }
+      const createArtworkLoaderMock = jest.fn().mockResolvedValue(mockArtwork)
+
+      const context = {
+        artworkLoader: () => Promise.resolve(mockArtwork),
+        createArtworkLoader: createArtworkLoaderMock,
+        addImageToArtworkLoader: jest.fn(),
+        addArtworkToPartnerShowLoader: jest.fn(),
+      }
+
+      await runAuthenticatedQuery(mutationWithoutImage, context)
+
+      expect(createArtworkLoaderMock).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          created_surface: expect.anything(),
+        })
+      )
+    })
+  })
 })

--- a/src/schema/v2/artwork/artworkCreatedSurface.ts
+++ b/src/schema/v2/artwork/artworkCreatedSurface.ts
@@ -1,0 +1,15 @@
+import { GraphQLEnumType } from "graphql"
+
+export const ArtworkCreatedSurfaceEnumValues = {
+  OS: "OS",
+  CMS: "CMS",
+}
+
+export const ArtworkCreatedSurface = new GraphQLEnumType({
+  name: "ArtworkCreatedSurface",
+  description: "The surface an artwork was created from.",
+  values: {
+    OS: { value: ArtworkCreatedSurfaceEnumValues.OS },
+    CMS: { value: ArtworkCreatedSurfaceEnumValues.CMS },
+  },
+})

--- a/src/schema/v2/artwork/createArtworkMutation.ts
+++ b/src/schema/v2/artwork/createArtworkMutation.ts
@@ -13,6 +13,7 @@ import {
 } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ArtworkType } from "../artwork"
+import { ArtworkCreatedSurface } from "./artworkCreatedSurface"
 
 interface CreateArtworkMutationInputProps {
   artistIds: string[]
@@ -23,6 +24,7 @@ interface CreateArtworkMutationInputProps {
   imageS3Buckets?: string[]
   imageS3Keys?: string[]
   partnerShowId?: string
+  createdSurface?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -99,6 +101,11 @@ export const createArtworkMutation = mutationWithClientMutationId<
       description:
         "The S3 keys for the artwork images. This is a list of object keys.",
     },
+    createdSurface: {
+      type: ArtworkCreatedSurface,
+      description:
+        "The surface the artwork is being created from. Defaults to CMS.",
+    },
   },
   outputFields: {
     artworkOrError: {
@@ -118,6 +125,7 @@ export const createArtworkMutation = mutationWithClientMutationId<
       imageS3Key,
       imageS3Buckets,
       imageS3Keys,
+      createdSurface,
     },
     {
       createArtworkLoader,
@@ -163,6 +171,7 @@ export const createArtworkMutation = mutationWithClientMutationId<
         artsy_listing: artsyListing,
         partner: partnerId,
         sync_to_search: true,
+        created_surface: createdSurface,
       })
 
       // Attach images if provided


### PR DESCRIPTION
Depends on https://github.com/artsy/gravity/pull/20372

Allow the created surface param to be passed when hitting the mutation to create artworks.

If no param is passed, Gravity will default to CMS. If a value is passed, it sets that one.

Possible values: "OS", "CMS".

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 