### PR TITLE
fix: add ArticleImageSection to ArticleHero union to prevent resolveType crash (PHIRE-3306)

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2075,7 +2075,7 @@ type ArticleFeaturedArtistNotificationItem {
   ): ArtistConnection
 }
 
-union ArticleHero = ArticleFeatureSection
+union ArticleHero = ArticleFeatureSection | ArticleImageSection
 
 type ArticleImageSection {
   caption: String

--- a/src/schema/v2/article/__tests__/article.test.ts
+++ b/src/schema/v2/article/__tests__/article.test.ts
@@ -159,6 +159,64 @@ describe("Article", () => {
     })
   })
 
+  describe("hero", () => {
+    const heroQuery = gql`
+      {
+        article(id: "example") {
+          hero {
+            __typename
+            ... on ArticleImageSection {
+              caption
+              layout
+            }
+            ... on ArticleFeatureSection {
+              title
+            }
+          }
+        }
+      }
+    `
+
+    it("resolves an image-type hero section without throwing", async () => {
+      const articleLoader = jest.fn(() =>
+        Promise.resolve({
+          hero_section: {
+            type: "image",
+            url: "https://example.com/image.jpg",
+            caption: "A caption",
+            layout: "overflow_fillwidth",
+          },
+        })
+      )
+
+      const { article } = await runQuery(heroQuery, { articleLoader })
+
+      expect(article.hero).toEqual({
+        __typename: "ArticleImageSection",
+        caption: "A caption",
+        layout: "overflow_fillwidth",
+      })
+    })
+
+    it("resolves a feature-type hero section", async () => {
+      const articleLoader = jest.fn(() =>
+        Promise.resolve({
+          hero_section: {
+            type: "basic",
+            title: "A feature title",
+          },
+        })
+      )
+
+      const { article } = await runQuery(heroQuery, { articleLoader })
+
+      expect(article.hero).toEqual({
+        __typename: "ArticleFeatureSection",
+        title: "A feature title",
+      })
+    })
+  })
+
   describe("outline", () => {
     const outlineQuery = gql`
       {

--- a/src/schema/v2/article/models.ts
+++ b/src/schema/v2/article/models.ts
@@ -163,7 +163,7 @@ export const ArticleFeatureSection = new GraphQLObjectType({
 
 export const ArticleHero = new GraphQLUnionType({
   name: "ArticleHero",
-  types: [ArticleFeatureSection],
+  types: [ArticleFeatureSection, ArticleImageSection],
 })
 
 export const ARTICLE_LAYOUTS = {


### PR DESCRIPTION
## Summary

- Fixes [PHIRE-3306](https://artsyproduct.atlassian.net/browse/PHIRE-3306): `Abstract type "ArticleHero" must resolve to an Object type at runtime for field "Article.hero"`, occurring ~230 times/day in production and burning a reliability SLO.
- Root cause: `Article.hero` (`src/schema/v2/article/index.ts`) resolves to the raw `hero_section` value and passes it straight into the `ArticleHero` union. That union (`src/schema/v2/article/models.ts`) only listed `ArticleFeatureSection` as a possible type. `ArticleImageSection` is a real concrete type defined in the same file, with a correct `isTypeOf: ({ type }) => type === "image"` check, but it was never added to the union's `types` list. Whenever `hero_section.type === "image"`, graphql-js had no matching union member and threw.
- Fix: add `ArticleImageSection` to `ArticleHero`'s `types` array. Both member types (`ArticleFeatureSection`, `ArticleImageSection`) already have working `isTypeOf` checks, so graphql-js can resolve the union without an explicit `resolveType`.

## Verified

- Confirmed `hero_section.type` values used across the two concrete section types: `ArticleFeatureSection.isTypeOf` matches `fullscreen`, `split`, `text`, `basic`; `ArticleImageSection.isTypeOf` matches `image`. No other concrete hero-section type exists in `models.ts`, so these two are the union's complete member set.
- Added a regression test in `src/schema/v2/article/__tests__/article.test.ts` that queries `Article.hero` for an article whose `hero_section.type === "image"` and asserts it resolves to `ArticleImageSection` instead of throwing, plus a companion test for the existing `basic` (feature) type.
- `yarn type-check` passes.
- `yarn lint` on the changed files passes (`npx eslint` on the touched files is clean); the repo-wide `yarn lint` run currently fails independently of this change with an eslint-plugin-import crash on `src/lib/tracer.ts`, unrelated to this fix.
- `yarn jest src/schema/v2/article/__tests__/article.test.ts` — all 13 tests pass, including the 2 new ones.
- Regenerated `_schemaV2.graphql` locally via `yarn dump:local` to reflect the widened union.

## Test plan

- [x] `yarn jest src/schema/v2/article/__tests__/article.test.ts`
- [x] `yarn type-check`
- [x] `npx eslint` on changed files
- [ ] Confirm in production/staging that the `resolveType` GraphQL error for `Article.hero` stops recurring after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Assisted-by: Claude:Sonnet-5

[PHIRE-3306]: https://artsyproduct.atlassian.net/browse/PHIRE-3306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ