### PR TITLE
fix: prevent partial artwork nodes from crashing non-null Artwork fields (PHIRE-3304)

### DIFF
--- a/src/schema/v2/__tests__/quiz.test.ts
+++ b/src/schema/v2/__tests__/quiz.test.ts
@@ -1,0 +1,104 @@
+/* eslint-disable promise/always-return */
+import { runQuery } from "schema/v2/test/utils"
+
+describe("Quiz type", () => {
+  const completeArtwork = {
+    id: "andy-warhol-skull",
+    _id: "artwork-1",
+    title: "Skull",
+  }
+
+  // A saved-artwork (or related-artwork) record can outlive the artwork it
+  // points to, e.g. when the underlying artwork is later deleted or
+  // unlisted. Gravity then hands back a partial record that's missing `id`
+  // (the slug) — this reproduces that shape.
+  const partialArtwork = {
+    _id: "artwork-2",
+    is_saved: true,
+  }
+
+  const context = {
+    meLoader: () => Promise.resolve({}),
+    quizLoader: () =>
+      Promise.resolve({
+        id: "quiz-1",
+        quiz_artworks: [
+          { artwork_id: "artwork-1" },
+          { artwork_id: "artwork-2" },
+        ],
+      }),
+  }
+
+  describe("savedArtworks", () => {
+    it("filters out partial/malformed artwork nodes instead of throwing", () => {
+      const savedArtworkLoader = jest.fn().mockImplementation((id) => {
+        if (id === "artwork-1") {
+          return Promise.resolve({ ...completeArtwork, is_saved: true })
+        }
+        return Promise.resolve(partialArtwork)
+      })
+
+      const query = `
+        {
+          me {
+            quiz {
+              savedArtworks {
+                slug
+                internalID
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, { ...context, savedArtworkLoader }).then(
+        (data) => {
+          expect(data.me.quiz.savedArtworks).toEqual([
+            { slug: "andy-warhol-skull", internalID: "artwork-1" },
+          ])
+        }
+      )
+    })
+  })
+
+  describe("recommendedArtworks", () => {
+    it("filters out partial/malformed related-artwork nodes instead of throwing", () => {
+      const savedArtworkLoader = jest.fn().mockImplementation((id) => {
+        if (id === "artwork-1") {
+          return Promise.resolve({ ...completeArtwork, is_saved: true })
+        }
+        return Promise.resolve(partialArtwork)
+      })
+
+      const relatedLayerArtworksLoader = jest
+        .fn()
+        .mockResolvedValue([
+          completeArtwork,
+          { _id: "artwork-3" }, // missing `id` (slug)
+        ])
+
+      const query = `
+        {
+          me {
+            quiz {
+              recommendedArtworks {
+                slug
+                internalID
+              }
+            }
+          }
+        }
+      `
+
+      return runQuery(query, {
+        ...context,
+        savedArtworkLoader,
+        relatedLayerArtworksLoader,
+      }).then((data) => {
+        expect(data.me.quiz.recommendedArtworks).toEqual([
+          { slug: "andy-warhol-skull", internalID: "artwork-1" },
+        ])
+      })
+    })
+  })
+})

--- a/src/schema/v2/artist/__tests__/index.test.js
+++ b/src/schema/v2/artist/__tests__/index.test.js
@@ -1161,4 +1161,74 @@ describe("Artist type", () => {
       )
     })
   })
+
+  describe("notableArtworks", () => {
+    // A saved-artwork (or artist-index) record can outlive the artwork it
+    // points to, e.g. when the underlying artwork is later deleted or
+    // unlisted. Gravity then hands back a partial record that's missing
+    // `id` (the slug) — this reproduces that shape.
+    const partialArtwork = { _id: "artwork-partial" }
+    const completeArtwork = { id: "andy-warhol-skull", _id: "artwork-1" }
+
+    it("filters out partial/malformed artwork nodes instead of throwing", () => {
+      artist.cover_artwork_id = "cover-artwork-id"
+
+      context.artistArtworksLoader = jest
+        .fn()
+        .mockResolvedValue([completeArtwork, partialArtwork])
+      context.unauthenticatedLoaders = {
+        artworkLoader: jest
+          .fn()
+          .mockResolvedValue({ id: "cover-artwork", _id: "cover-artwork-id" }),
+      }
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            notableArtworks(size: 5) {
+              slug
+              internalID
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.artist.notableArtworks).toEqual([
+          { slug: "cover-artwork", internalID: "cover-artwork-id" },
+          { slug: "andy-warhol-skull", internalID: "artwork-1" },
+        ])
+      })
+    })
+
+    it("drops the cover artwork entirely if it comes back partial", () => {
+      artist.cover_artwork_id = "cover-artwork-id"
+
+      context.artistArtworksLoader = jest
+        .fn()
+        .mockResolvedValue([completeArtwork])
+      context.unauthenticatedLoaders = {
+        artworkLoader: jest
+          .fn()
+          .mockResolvedValue({ _id: "cover-artwork-id" }), // missing `id`
+      }
+
+      const query = `
+        {
+          artist(id: "foo-bar") {
+            notableArtworks(size: 5) {
+              slug
+              internalID
+            }
+          }
+        }
+      `
+
+      return runQuery(query, context).then((data) => {
+        expect(data.artist.notableArtworks).toEqual([
+          { slug: "andy-warhol-skull", internalID: "artwork-1" },
+        ])
+      })
+    })
+  })
 })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -918,14 +918,24 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
             }).catch(() => []),
           ])
 
-          const remaining = iconicArtworks.filter(
-            (artwork) => artwork.id !== coverArtwork?.id
+          // Gravity can hand back a partial/malformed artwork document (e.g.
+          // for an artwork that's been deleted or unlisted but hasn't been
+          // removed from the artist's index yet). Such a document is missing
+          // `id` (the slug), which would otherwise crash the non-null
+          // `Artwork.slug` field and null out this entire list. Drop those
+          // incomplete nodes instead of crashing.
+          const validCoverArtwork =
+            coverArtwork && coverArtwork.id ? coverArtwork : null
+
+          const remaining = compact(iconicArtworks).filter(
+            (artwork: any) =>
+              artwork.id && artwork.id !== validCoverArtwork?.id
           )
 
-          return [...(coverArtwork ? [coverArtwork] : []), ...remaining].slice(
-            0,
-            size
-          )
+          return [
+            ...(validCoverArtwork ? [validCoverArtwork] : []),
+            ...remaining,
+          ].slice(0, size)
         },
       },
       first: { type: GraphQLString },

--- a/src/schema/v2/quiz.ts
+++ b/src/schema/v2/quiz.ts
@@ -5,7 +5,7 @@ import { quizArtworkConnection } from "./quizArtworkConnection"
 import { ResolverContext } from "types/graphql"
 import { date } from "schema/v2/fields/date"
 import { ArtworkType } from "./artwork"
-import { flatten, take } from "lodash"
+import { compact, flatten, take } from "lodash"
 
 export const QuizType = new GraphQLObjectType<any, ResolverContext>({
   name: "Quiz",
@@ -29,7 +29,12 @@ export const QuizType = new GraphQLObjectType<any, ResolverContext>({
             })
           )
 
-          return artworks.filter(({ is_saved }) => is_saved)
+          // A saved-artwork record can outlive the artwork it points to (e.g.
+          // the artwork was later deleted or unlisted). Gravity then hands
+          // back a partial record with `is_saved: true` but no `id` (the
+          // slug), which would crash the non-null `Artwork.slug` field.
+          // Drop those incomplete nodes rather than crash the whole list.
+          return artworks.filter(({ is_saved, id }) => is_saved && id)
         } catch (error) {
           return []
         }
@@ -53,7 +58,12 @@ export const QuizType = new GraphQLObjectType<any, ResolverContext>({
             })
           )
 
-          const savedArtworks = artworks.filter(({ is_saved }) => is_saved)
+          // See the comment in `savedArtworks` above: a saved-artwork record
+          // can point at an artwork that no longer exists, in which case
+          // Gravity returns a partial record with no `id` (slug).
+          const savedArtworks = artworks.filter(
+            ({ is_saved, id }) => is_saved && id
+          )
 
           if (savedArtworks.length === 0) return []
 
@@ -73,9 +83,17 @@ export const QuizType = new GraphQLObjectType<any, ResolverContext>({
           const filtered = recommendedArtworks
             .filter((artworks) => artworks.length > 0)
             .map((artworks) => {
-              if (savedArtworks.length === 1) return artworks
-              if (savedArtworks.length <= 3) return take(artworks, 8)
-              return take(artworks, 4)
+              // Related-artwork results can likewise include a stale entry
+              // for an artwork that's since been deleted/unlisted and is
+              // missing its `id` (slug). Drop those before slicing/nulling
+              // the non-null `Artwork.slug` field for the whole list.
+              const completeArtworks = compact(artworks).filter(
+                (artwork: any) => artwork.id
+              )
+
+              if (savedArtworks.length === 1) return completeArtworks
+              if (savedArtworks.length <= 3) return take(completeArtworks, 8)
+              return take(completeArtworks, 4)
             })
 
           return flatten(filtered)


### PR DESCRIPTION
## Summary

PHIRE-3304: https://artsyproduct.atlassian.net/browse/PHIRE-3304

"Cannot return null for non-nullable field Artwork.slug" was our single highest-volume production GraphQL error (~4,100/day).

**Root cause.** `SlugAndInternalIDFields.slug` in `src/schema/v2/object_identification.ts` resolves from an `id` property (`resolve: ({ id }) => id`) and is typed `GraphQLNonNull(GraphQLID)`. It throws whenever the artwork object handed to it lacks `id`. Two call sites wrap `ArtworkType` in `GraphQLNonNull`, so a single incomplete node in the list nulls out the entire field:

- `Artist.notableArtworks` (`src/schema/v2/artist/index.ts`)
- `Quiz.savedArtworks` and `Quiz.recommendedArtworks` (`src/schema/v2/quiz.ts`)

**Why an incomplete node shows up.** A saved-artwork record (or an artist's artwork index entry) can outlive the artwork it refers to — the artwork gets deleted or unlisted afterwards, but the referencing record isn't cleaned up in lockstep. Gravity then hands back a partial record for it (missing `id`, the slug) instead of erroring, so it slips past the existing `.catch()` guards, which only cover outright request failures.

**Fix.** Filter out artwork nodes missing `id` before they reach the non-null field, in each of the three resolvers above, instead of relaxing `GraphQLNonNull` to nullable. Artworks are not optional in these contexts (a quiz's saved/recommended artworks and an artist's notable artworks are meant to always be real artworks), so dropping the incomplete node from the list is the correct behavior rather than making the field nullable.

## What I verified

- Confirmed the resolver in `object_identification.ts` reads `id`, not `slug`, and is non-null.
- Traced the loaders feeding each call site (`artistArtworksLoader`/`artworkLoader` for `Artist.notableArtworks`; `savedArtworkLoader`/`relatedLayerArtworksLoader` for `Quiz.savedArtworks`/`recommendedArtworks`) and confirmed none of them guarantee `id` presence on every returned item — only on request success.
- Ran `yarn type-check` and `yarn lint` on the changed files — both pass.
- Ran the full `artist`, `quiz`, `me`, and `object_identification` Jest suites (98 suites, 346 tests) — all pass.

## Test plan

- [x] `yarn type-check`
- [x] `yarn lint` (on changed files; a pre-existing unrelated ESLint crash on `src/lib/tracer.ts` occurs repo-wide and is unrelated to this change)
- [x] `yarn jest src/schema/v2/__tests__/quiz.test.ts` — new regression tests for `Quiz.savedArtworks` / `Quiz.recommendedArtworks`
- [x] `yarn jest src/schema/v2/artist/__tests__/index.test.js` — new regression tests for `Artist.notableArtworks`
- [x] `yarn jest src/schema/v2/me src/schema/v2/__tests__/object_identification` — full suite sanity check

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)