### PR TITLE
fix: classify MeOrder not-found errors instead of letting them propagate raw (PHIRE-3307)

### DIFF
--- a/src/schema/v2/order/MeOrder.ts
+++ b/src/schema/v2/order/MeOrder.ts
@@ -1,6 +1,17 @@
 import { GraphQLFieldConfig, GraphQLNonNull, GraphQLID } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { HTTPError } from "lib/HTTPError"
+import { safeJsonParse } from "lib/jsonParse"
 import { OrderType } from "./types/OrderType"
+
+// Shape of the raw validation-error rejection Exchange returns for
+// `me/orders/:id` when the order doesn't exist, e.g.
+// { type: "validation", code: "not_found", data: { message: "Couldn't find Order..." } }
+const isOrderNotFoundError = (error: any): boolean => {
+  const body = safeJsonParse<{ code?: string }>(error?.body) || error?.body
+
+  return body?.code === "not_found"
+}
 
 export const MeOrder: GraphQLFieldConfig<void, ResolverContext> = {
   args: {
@@ -11,8 +22,17 @@ export const MeOrder: GraphQLFieldConfig<void, ResolverContext> = {
   type: OrderType,
   resolve: async (_root, { id }, { meOrderLoader }) => {
     if (!meOrderLoader) return null
-    const order = await meOrderLoader(id)
 
-    return order
+    try {
+      const order = await meOrderLoader(id)
+
+      return order
+    } catch (error) {
+      if (isOrderNotFoundError(error)) {
+        throw new HTTPError("Order Not Found", 404)
+      }
+
+      throw error
+    }
   },
 }

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable promise/always-return */
 import gql from "lib/gql"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
+import { deepestOriginalError } from "lib/graphqlErrorHandler"
 import { baseArtwork, baseOrderJson } from "./support"
 
 let context
@@ -2479,6 +2481,117 @@ describe("Me", () => {
           { type: "DOMESTIC_FLAT", shippingQuoteId: "quote-abc-123" },
           { type: "PICKUP", shippingQuoteId: null },
         ])
+      })
+    })
+
+    describe("when the order is not found", () => {
+      const query = gql`
+        query {
+          me {
+            order(id: "missing-order-id") {
+              internalID
+            }
+          }
+        }
+      `
+
+      it("throws a classified 404 HTTPError instead of the raw Exchange rejection", async () => {
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockRejectedValue({
+            statusCode: 404,
+            body: {
+              type: "validation",
+              code: "not_found",
+              data: {
+                message: 'Couldn\'t find Order with [WHERE "orders"."id" = $1]',
+              },
+            },
+          }),
+        }
+
+        const error = await runAuthenticatedQuery(query, context).catch(
+          (e) => e
+        )
+        const originalError = deepestOriginalError(error) as HTTPError
+
+        expect(originalError).toBeInstanceOf(HTTPError)
+        expect(originalError.statusCode).toEqual(404)
+        expect(originalError.message).toEqual("Order Not Found")
+      })
+
+      it("still handles a not-found body that arrives as a JSON string", async () => {
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockRejectedValue({
+            statusCode: 404,
+            body: JSON.stringify({
+              type: "validation",
+              code: "not_found",
+              data: { message: "Couldn't find Order" },
+            }),
+          }),
+        }
+
+        const error = await runAuthenticatedQuery(query, context).catch(
+          (e) => e
+        )
+        const originalError = deepestOriginalError(error) as HTTPError
+
+        expect(originalError).toBeInstanceOf(HTTPError)
+        expect(originalError.statusCode).toEqual(404)
+      })
+
+      it("lets a genuine unexpected error propagate unchanged", async () => {
+        const upstreamError = Object.assign(new Error("Exchange is down"), {
+          statusCode: 500,
+          body: { type: "error", code: "internal_error" },
+        })
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockRejectedValue(upstreamError),
+        }
+
+        const error = await runAuthenticatedQuery(query, context).catch(
+          (e) => e
+        )
+        const originalError = deepestOriginalError(
+          error
+        ) as typeof upstreamError
+
+        expect(originalError).not.toBeInstanceOf(HTTPError)
+        expect(originalError.message).toEqual("Exchange is down")
+        expect(originalError.statusCode).toEqual(500)
+      })
+
+      it("propagates other validation error codes without reclassifying them", async () => {
+        const upstreamError = Object.assign(
+          new Error("Order is in an invalid state"),
+          {
+            statusCode: 422,
+            body: {
+              type: "validation",
+              code: "invalid_state",
+              data: { message: "Order is in an invalid state" },
+            },
+          }
+        )
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockRejectedValue(upstreamError),
+        }
+
+        const error = await runAuthenticatedQuery(query, context).catch(
+          (e) => e
+        )
+        const originalError = deepestOriginalError(
+          error
+        ) as typeof upstreamError
+
+        expect(originalError).not.toBeInstanceOf(HTTPError)
+        expect(originalError.body.code).toEqual("invalid_state")
       })
     })
   })


### PR DESCRIPTION
## Summary

Fixes [PHIRE-3307](https://artsyproduct.atlassian.net/browse/PHIRE-3307).

`src/schema/v2/order/MeOrder.ts` called `meOrderLoader(id)` (Exchange's `me/orders/:id`) with no `.catch`. When the order doesn't exist, Exchange rejects with a raw validation error (`type: validation, code: not_found, data: { message: "Couldn't find Order..." }`), and that rejection propagated as an unhandled exception instead of a classified GraphQL error. This happens roughly 1,400 times/day in production and shows up as noise against our reliability SLO.

## What changed

- `MeOrder.ts` now wraps the `meOrderLoader` call in a try/catch. When the rejection matches the `not_found` validation-error shape (checked via `code`, handling both parsed-object and JSON-string bodies), it throws `HTTPError("Order Not Found", 404)` — the same classified-error pattern already used in `show.ts`, `auction_result.ts`, and `city/index.ts`.
- Any other rejection (5xx, network failure, other validation codes like `payment_requires_action` or `invalid_state`) is rethrown unchanged, so genuine errors still surface as genuine errors.
- Added regression tests in `MeOrder.test.ts` covering: the `not_found` object-body case, a `not_found` body arriving as a JSON string, a genuine 500 propagating unchanged, and a different validation code (`invalid_state`) propagating unchanged (not misclassified as not-found).

## Verified

- `yarn type-check` — clean
- `yarn eslint src/schema/v2/order/MeOrder.ts src/schema/v2/order/__tests__/MeOrder.test.ts` — clean
- `yarn jest src/schema/v2/order` — 20 suites / 200 tests passing
- Confirmed the fix follows the exact `HTTPError` pattern already established in `show.ts:881`, and did not touch `graphqlErrorHandler.ts`, `object_identification.ts`, `quiz.ts`, `artist/index.ts`, `notifications/index.ts`, or `article/models.ts` (out of scope, being handled by other tickets).

## Test plan

- [x] Regression test: `meOrderLoader` rejects with `not_found` body → resolver throws `HTTPError` 404 (`Order Not Found`), not an unhandled exception
- [x] Regression test: same, with body as a JSON string
- [x] Regression test: genuine unexpected error (500) still propagates unchanged
- [x] Regression test: a different validation code (`invalid_state`, 422) still propagates unchanged, confirming we only special-case `not_found`

Assisted-by: Claude:Sonnet-5

[PHIRE-3307]: https://artsyproduct.atlassian.net/browse/PHIRE-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ