### PR TITLE
fix(recs): keep NWFY backfill after recs

### DIFF
--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -314,4 +314,170 @@ describe("artworksForUser", () => {
       expect(response.artworksForUser.totalCount).toBe(2)
     })
   })
+
+  // Loaders that model Gravity: the /artworks batch loader silently drops ids
+  // that don't hydrate, and honors the ids it's actually given.
+  const buildFaithfulContext = ({
+    recIds,
+    deadIds = [],
+    titles = {},
+    backfillItems = [],
+  }: {
+    recIds: string[]
+    deadIds?: string[]
+    titles?: Record<string, string>
+    backfillItems?: Array<{ id: string; title: string }>
+  }) => {
+    const artworksLoader = jest.fn(async ({ ids }: { ids: string[] }) =>
+      ids
+        .filter((id) => !deadIds.includes(id))
+        .map((id) => ({ id, _id: id, title: titles[id] || id }))
+    )
+
+    return {
+      artworkRecommendationsLoader: jest.fn(async () => ({
+        artwork_ids: recIds,
+      })),
+      artworksLoader,
+      setsLoader: jest.fn(async () => ({ body: [{ id: "backfill-set" }] })),
+      setItemsLoader: jest.fn(async () => ({
+        body: backfillItems.map((item) => ({ ...item, _id: item.id })),
+      })),
+      userID: "vortex-user-id",
+      authenticatedLoaders: { vortexGraphqlLoader: null },
+      unauthenticatedLoaders: { vortexGraphqlLoader: null },
+    } as any
+  }
+
+  const buildPaginatedQuery = ({
+    first,
+    after,
+  }: {
+    first: number
+    after?: string
+  }) => gql`
+    {
+      artworksForUser(
+        first: ${first}
+        ${after ? `after: "${after}"` : ""}
+        includeBackfill: true
+        userId: "abc123"
+        excludeDislikedArtworks: true
+      ) {
+        totalCount
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        edges {
+          node {
+            internalID
+            title
+          }
+        }
+      }
+    }
+  `
+
+  describe("when a rec id in the page window does not hydrate", () => {
+    beforeEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = true))
+    afterEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = false))
+
+    it("does not splice backfill in before real recs a larger page would show", async () => {
+      // r2 is stale and won't hydrate; a first: 5 window [r0..r4] loses it,
+      // yet r5 is a real rec that should fill the slot before any backfill.
+      const context = buildFaithfulContext({
+        recIds: ["r0", "r1", "r2", "r3", "r4", "r5"],
+        deadIds: ["r2"],
+        titles: {
+          r0: "Rec 0",
+          r1: "Rec 1",
+          r3: "Rec 3",
+          r4: "Rec 4",
+          r5: "Rec 5",
+        },
+        backfillItems: [{ id: "b0", title: "BACKFILL" }],
+      })
+
+      const { artworksForUser } = await runAuthenticatedQuery(
+        buildPaginatedQuery({ first: 5 }),
+        context
+      )
+
+      const titles = extractNodes(artworksForUser).map((n: any) => n.title)
+
+      expect(titles).not.toContain("BACKFILL")
+      expect(titles).toEqual(["Rec 0", "Rec 1", "Rec 3", "Rec 4", "Rec 5"])
+    })
+  })
+
+  describe("when paginating across multiple pages with backfill", () => {
+    beforeEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = true))
+    afterEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = false))
+
+    it("never returns the same backfill artwork on more than one page", async () => {
+      // 1 real rec, 4 backfill items, paging by 2: page 2 must continue the
+      // backfill window instead of restarting it from the top.
+      const backfillItems = [
+        { id: "b0", title: "Backfill 0" },
+        { id: "b1", title: "Backfill 1" },
+        { id: "b2", title: "Backfill 2" },
+        { id: "b3", title: "Backfill 3" },
+      ]
+      const context = buildFaithfulContext({
+        recIds: ["r0"],
+        titles: { r0: "Rec 0" },
+        backfillItems,
+      })
+
+      const page1 = await runAuthenticatedQuery(
+        buildPaginatedQuery({ first: 2 }),
+        context
+      )
+      const page1Ids = extractNodes(page1.artworksForUser).map(
+        (n: any) => n.internalID
+      )
+
+      const page2 = await runAuthenticatedQuery(
+        buildPaginatedQuery({
+          first: 2,
+          after: page1.artworksForUser.pageInfo.endCursor,
+        }),
+        context
+      )
+      const page2Ids = extractNodes(page2.artworksForUser).map(
+        (n: any) => n.internalID
+      )
+
+      // Real rec first, then the backfill window advances by page size.
+      expect(page1Ids).toEqual(["r0", "b0"])
+      expect(page2Ids).toEqual(["b1", "b2"])
+    })
+  })
+
+  describe("totalCount when some rec ids do not hydrate", () => {
+    beforeEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = true))
+    afterEach(() => ((config as any).ENABLE_NEW_WORKS_FOR_YOU_GRAVITY = false))
+
+    it("counts surviving recs, not the raw recommendation ids", async () => {
+      // 3 recommended ids, 1 stale; 2 backfill items. totalCount must reflect
+      // the 2 recs that hydrate (+ backfill), not the 3 ids Gravity returned.
+      const context = buildFaithfulContext({
+        recIds: ["r0", "r1", "r2"],
+        deadIds: ["r1"],
+        titles: { r0: "Rec 0", r2: "Rec 2" },
+        backfillItems: [
+          { id: "b0", title: "Backfill 0" },
+          { id: "b1", title: "Backfill 1" },
+        ],
+      })
+
+      const { artworksForUser } = await runAuthenticatedQuery(
+        buildPaginatedQuery({ first: 10 }),
+        context
+      )
+
+      expect(artworksForUser.totalCount).toBe(4)
+    })
+  })
 })

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -207,41 +207,31 @@ describe("getNewForYouArtworkIDs", () => {
 describe("getNewForYouArtworks", () => {
   it("returns an empty array with empty artwork ids", async () => {
     const artworkIds = []
-    const gravityArgs = {}
     const context = {} as any
 
-    const artworks = await getNewForYouArtworks(
-      { ids: artworkIds },
-      gravityArgs,
-      context
-    )
+    const artworks = await getNewForYouArtworks({ ids: artworkIds }, context)
     expect(artworks).toEqual([])
   })
 
   it("returns artworks for those artwork ids", async () => {
     const artworkIds = ["banksy"]
-    const gravityArgs = {}
     const mockArtworksLoader = jest.fn(() => [{}])
     const context = {
       artworksLoader: mockArtworksLoader,
     } as any
 
-    const artworks = await getNewForYouArtworks(
-      { ids: artworkIds },
-      gravityArgs,
-      context
-    )
+    const artworks = await getNewForYouArtworks({ ids: artworkIds }, context)
     expect(artworks.length).toEqual(1)
     expect(mockArtworksLoader).toBeCalledWith({
       availability: "for sale",
       exclude_disliked_artworks: false,
       ids: artworkIds,
+      size: artworkIds.length,
     })
   })
 
   it("passes exclude_disliked_artworks parameter to Gravity artworksLoader", async () => {
     const artworkIds = ["banksy"]
-    const gravityArgs = {}
     const mockArtworksLoader = jest.fn(() => [{}])
     const context = {
       artworksLoader: mockArtworksLoader,
@@ -249,13 +239,13 @@ describe("getNewForYouArtworks", () => {
 
     await getNewForYouArtworks(
       { ids: artworkIds, excludeDislikedArtworks: true },
-      gravityArgs,
       context
     )
     expect(mockArtworksLoader).toBeCalledWith({
       availability: "for sale",
       exclude_disliked_artworks: true,
       ids: artworkIds,
+      size: artworkIds.length,
     })
   })
 })

--- a/src/schema/v2/artworksForUser/artworksForUser.ts
+++ b/src/schema/v2/artworksForUser/artworksForUser.ts
@@ -65,23 +65,34 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       (artworkId) => !args.excludeArtworkIds.includes(artworkId)
     )
 
-    const slicedArtworkIds = filteredArtworkIds.slice(offset, offset + size)
-
+    // Hydrate before paginating: Gravity silently drops stale ids, so slicing
+    // the id window first would let backfill fill a mid-page gap.
     const newForYouArtworks = await getNewForYouArtworks(
       {
-        ids: slicedArtworkIds,
+        ids: filteredArtworkIds,
         marketable: args.marketable,
         excludeDislikedArtworks: args.excludeDislikedArtworks,
       },
-      gravityArgs,
       context
     )
 
+    // Assumes the id source returned the full set (nwfy/Vortex). onlyAtAuction
+    // pre-paginates via its own loader, so it's page-1-correct only there —
+    // pre-existing behavior, unchanged here.
+    const recsCount = newForYouArtworks.length
+    const pageRecs = newForYouArtworks.slice(offset, offset + size)
+
+    // Connection is the virtual concat [...recs, ...backfill]; offset the
+    // backfill window past the recs so pages draw disjoint slices. This relies
+    // on recsCount staying stable across a client's page requests — if a rec
+    // goes stale mid-pagination the offset shifts and a boundary backfill item
+    // can repeat or skip, which is inherent to recommendation instability.
     const {
       artworks: backfillArtworks,
       totalCount: backfillArtworksTotalCount,
     } = await getBackfillArtworks({
       size: size || 0,
+      offset: Math.max(0, offset - recsCount),
       includeBackfill: args.includeBackfill,
       context,
       marketingCollectionId: args.backfillMarketingCollectionID,
@@ -89,13 +100,12 @@ export const artworksForUser: GraphQLFieldConfig<void, ResolverContext> = {
       excludeDislikedArtworks: args.excludeDislikedArtworks,
     })
 
-    const artworks = uniqBy(
-      newForYouArtworks.concat(backfillArtworks),
-      "id"
-    ).slice(0, size)
+    const artworks = uniqBy(pageRecs.concat(backfillArtworks), "id").slice(
+      0,
+      size
+    )
 
-    const totalCount =
-      filteredArtworkIds.length + (backfillArtworksTotalCount ?? 0)
+    const totalCount = recsCount + (backfillArtworksTotalCount ?? 0)
 
     return {
       totalCount,

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -128,20 +128,18 @@ export const getNewForYouArtworks = async (
     marketable,
     excludeDislikedArtworks = false,
   }: { ids: string[]; marketable?: boolean; excludeDislikedArtworks?: boolean },
-  gravityArgs,
   context: ResolverContext
 ): Promise<any[]> => {
   if (ids.length === 0) return []
 
-  const { size, offset } = gravityArgs
   const { artworksLoader } = context
 
+  // Fetch the whole set; the resolver paginates the recs that actually hydrate.
   const artworkParams = {
     availability: "for sale",
     exclude_disliked_artworks: excludeDislikedArtworks,
     ids: ids,
-    offset,
-    size,
+    size: ids.length,
   }
 
   if (marketable) {
@@ -155,6 +153,7 @@ export const getNewForYouArtworks = async (
 
 export const getBackfillArtworks = async ({
   size,
+  offset = 0,
   includeBackfill,
   context,
   marketingCollectionId,
@@ -162,6 +161,7 @@ export const getBackfillArtworks = async ({
   excludeDislikedArtworks = false,
 }: {
   size: number
+  offset?: number
   includeBackfill: boolean
   context: ResolverContext
   marketingCollectionId?: string
@@ -193,6 +193,8 @@ export const getBackfillArtworks = async ({
       : filterArtworksUnauthenticatedLoader
 
   if (filterArtworksLoader && (onlyAtAuction || marketingCollectionId)) {
+    // Reports `hits.length` as the total, so not safely paginatable past page
+    // 1; offset is deliberately not threaded here (only the set path below).
     const { hits } = await filterArtworksLoader({
       exclude_disliked_artworks: excludeDislikedArtworks,
       size: size,
@@ -217,7 +219,7 @@ export const getBackfillArtworks = async ({
   })
 
   return {
-    artworks: (itemsBody || []).slice(0, size),
+    artworks: (itemsBody || []).slice(offset, offset + size),
     totalCount: itemsBody?.length,
   }
 }


### PR DESCRIPTION
### Descripton

This PR resolves: https://artsyproduct.atlassian.net/browse/ONYX-2198

The "New Works for You" grid pads short pages with curated backfill artworks, but backfill was showing up in the wrong places:

- Backfill appeared mid-grid. We sliced the recommendation ids for a page before fetching the actual artworks. Gravity quietly drops ids it can't resolve anymore (sold, unpublished, index drift), so a page would come up short and we'd fill the gap with backfill even when there were still real recs waiting on the next page.
- The same backfill artwork showed up on multiple pages. Backfill was always taken from the top of the set, and we only deduped within a single page.

This mostly showed up on mobile, where the grid loads in small pages as you scroll and doesn't dedupe, so you'd see backfill jammed between recs.

### What changed

Fetch the full set of recommendations up front, then paginate the ones that actually come back. Treat the whole thing as recs followed by backfill and just take the current page's slice out of that, so backfill only ever shows up after the real recs run out, and each page pulls a different chunk of backfill instead of restarting from the top. `totalCount` now counts the recs that actually resolved instead of the raw id list. 

FYI @ftrifoglio 
This only fixes the regular NWFY backfill. The auction version (onlyAtAuction) still doesn't paginate correctly past page 1, its recommendations come back pre-paginated, so this approach doesn't apply. It's pre-existing (no regression here). We can track it in a separate Metaphysics ticket.