### PR TITLE
chore(recs): remove the feature flag for WTYL

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -11,8 +11,6 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
 const FEATURE_FLAGS_LIST = [
   "onyx_nwfy-artworks-card-test",
   "diamond_artwork-title-experiment",
-  "onyx_artwork-recommendations-gravity",
-  "onyx_artwork-recommendations-refresh-eigen",
   "onyx_nwfy-gravity",
   "onyx_nwfy-refresh-eigen",
 ] as const

--- a/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
+++ b/src/schema/v2/me/__tests__/artworkRecommendations.test.ts
@@ -1,28 +1,9 @@
 /* eslint-disable promise/always-return */
-import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { HTTPError } from "lib/HTTPError"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
-jest.mock("lib/featureFlags", () => ({
-  isFeatureFlagEnabled: jest.fn(() => false),
-  getExperimentVariant: jest.fn(() => ({ enabled: false, name: "control" })),
-}))
-
-const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
-const mockGetExperimentVariant = getExperimentVariant as jest.Mock
-
 describe("artworkRecommendations", () => {
-  afterEach(() => {
-    mockIsFeatureFlagEnabled.mockReset()
-    mockIsFeatureFlagEnabled.mockReturnValue(false)
-    mockGetExperimentVariant.mockReset()
-    mockGetExperimentVariant.mockReturnValue({
-      enabled: false,
-      name: "control",
-    })
-  })
-
   const query = gql`
     {
       me {
@@ -141,16 +122,56 @@ describe("artworkRecommendations", () => {
     expect(artworksLoader).not.toHaveBeenCalled()
   })
 
-  describe("when the WTYL Gravity recs flag is on", () => {
-    beforeEach(() => {
-      mockIsFeatureFlagEnabled.mockReturnValue(true)
-      // Eligible clients are bucketed into the refresh experiment by default.
-      mockGetExperimentVariant.mockReturnValue({
-        enabled: true,
-        name: "variant",
-      })
-    })
+  it("doesn't fetch artworks when the requested page is past the end", async () => {
+    const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
+    const artworksLoader = jest.fn(async () => artworksResponse)
 
+    const context: any = {
+      artworksLoader,
+      meLoader: () => Promise.resolve({}),
+      userID: "vortex-user-id",
+      authenticatedLoaders: {
+        vortexGraphqlLoader,
+      },
+      unauthenticatedLoaders: {
+        vortexGraphqlLoader: null,
+      },
+    }
+
+    const {
+      me: { artworkRecommendations },
+    } = await runAuthenticatedQuery(
+      gql`
+        {
+          me {
+            artworkRecommendations(first: 2, page: 5) {
+              totalCount
+              edges {
+                node {
+                  internalID
+                }
+              }
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    // Vortex returns 4 IDs, but page 5 starts past the end, so there are no
+    // IDs to look up. Calling artworksLoader with an empty `ids` array would
+    // drop the param and return an unfiltered page of artworks from Gravity.
+    expect(artworksLoader).not.toHaveBeenCalled()
+
+    expect(artworkRecommendations).toMatchInlineSnapshot(`
+      {
+        "edges": [],
+        "totalCount": 4,
+      }
+    `)
+  })
+
+  describe("Gravity vs Vortex routing", () => {
     it("fetches IDs from the Gravity REST endpoint with the same response shape", async () => {
       const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
       const artworkRecommendationsLoader = jest.fn(async () => ({
@@ -291,66 +312,6 @@ describe("artworkRecommendations", () => {
       expect(vortexGraphqlLoader).toHaveBeenCalled()
     })
 
-    it("stays on the Vortex path when not bucketed into the refresh experiment", async () => {
-      mockGetExperimentVariant.mockReturnValue({
-        enabled: false,
-        name: "control",
-      })
-
-      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
-      const artworkRecommendationsLoader = jest.fn()
-      const artworksLoader = jest.fn(async () => artworksResponse)
-
-      const context: any = {
-        artworksLoader,
-        artworkRecommendationsLoader,
-        meLoader: () => Promise.resolve({}),
-        userID: "gravity-user-id",
-        userAgent: "Artsy-Mobile/9.11.0",
-        authenticatedLoaders: {
-          vortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: null,
-        },
-      }
-
-      await runAuthenticatedQuery(query, context)
-
-      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
-      expect(vortexGraphqlLoader).toHaveBeenCalled()
-    })
-
-    it("stays on the Vortex path for the control variant", async () => {
-      mockGetExperimentVariant.mockReturnValue({
-        enabled: true,
-        name: "control",
-      })
-
-      const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
-      const artworkRecommendationsLoader = jest.fn()
-      const artworksLoader = jest.fn(async () => artworksResponse)
-
-      const context: any = {
-        artworksLoader,
-        artworkRecommendationsLoader,
-        meLoader: () => Promise.resolve({}),
-        userID: "gravity-user-id",
-        userAgent: "Artsy-Mobile/9.11.0",
-        authenticatedLoaders: {
-          vortexGraphqlLoader,
-        },
-        unauthenticatedLoaders: {
-          vortexGraphqlLoader: null,
-        },
-      }
-
-      await runAuthenticatedQuery(query, context)
-
-      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
-      expect(vortexGraphqlLoader).toHaveBeenCalled()
-    })
-
     it("stays on the Vortex path for eigen versions below 9.11.0", async () => {
       const vortexGraphqlLoader = jest.fn(() => async () => vortexResponse)
       const artworkRecommendationsLoader = jest.fn()
@@ -385,6 +346,7 @@ describe("artworkRecommendations", () => {
         artworksLoader,
         artworkRecommendationsLoader,
         meLoader: () => Promise.resolve({}),
+        userAgent: "Artsy-Mobile/9.11.0",
         xImpersonateUserID: "impersonated-user-id",
         authenticatedLoaders: {
           vortexGraphqlLoader,

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -1,6 +1,5 @@
 import { GraphQLFieldConfig, GraphQLInt } from "graphql"
 import { connectionFromArraySlice } from "graphql-relay"
-import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import gql from "lib/gql"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
 import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
@@ -13,35 +12,17 @@ import { ResolverContext } from "types/graphql"
 // backend and is related to how we implement the Connection in this resolver.
 const MAX_ARTWORKS = 50
 
-// WTYL canary: route to the Gravity REST endpoint (live) instead of Vortex
-// GraphQL (legacy daily-batch). Flipped per-user in the Unleash admin UI.
-const GRAVITY_RAIL_FLAG = "onyx_artwork-recommendations-gravity"
-
-// Gravity-backed rail ships in eigen 9.11.0+. Checked before the flag so older
-// eigen builds (and non-eigen clients like web) never enter the rollout bucket.
+// WTYL: the Gravity-backed rail (the winning variant, now the default) ships in
+// eigen 9.11.0+, so older eigen builds and non-eigen clients (like web) stay on
+// the Vortex path.
 const MINIMUM_EIGEN_VERSION = { major: 9, minor: 11, patch: 0 }
-
-// Eigen refresh experiment: the front-end flag that controls the rollout split
-// and unlocks experiment tracking in eigen. Only clients bucketed into the
-// "variant" cohort (vs "control") get the Gravity rail, matching eigen's check
-// in useEnableLiveHomeRecommendations.
-const REFRESH_EIGEN_FLAG = "onyx_artwork-recommendations-refresh-eigen"
-
-const isInRefreshExperiment = (context: ResolverContext): boolean => {
-  const variant = getExperimentVariant(REFRESH_EIGEN_FLAG, {
-    userId: context.userID,
-  })
-
-  return !!variant && variant.enabled && variant.name === "variant"
-}
 
 const isEligibleClient = (context: ResolverContext): boolean => {
   const actualEigenVersion = getEigenVersionNumber(context.userAgent as string)
 
   return (
     !!actualEigenVersion &&
-    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION) &&
-    isInRefreshExperiment(context)
+    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION)
   )
 }
 
@@ -130,26 +111,23 @@ export const ArtworkRecommendations: GraphQLFieldConfig<
     const userId = userID || xImpersonateUserID
 
     // The Gravity endpoint accepts a `user_id` param for trusted apps (see the
-    // NWFY rail in artworksForUser), but WTYL hasn't wired impersonation through
-    // it, so impersonated/app requests still stay on the Vortex path.
+    // NWFY rail in artworksForUser), but impersonation isn't wired through it,
+    // so impersonated/app requests still stay on the Vortex path.
     const useGravity =
       !!artworkRecommendationsLoader &&
       !xImpersonateUserID &&
-      isEligibleClient(context) &&
-      isFeatureFlagEnabled(GRAVITY_RAIL_FLAG, { userId })
+      isEligibleClient(context)
 
     // Fetching artwork IDs from the selected recommendation backend.
     const artworkIds = useGravity
       ? await getArtworkIdsFromGravity(context)
       : await getArtworkIdsFromVortex(userId, context)
 
-    const pageArtworkIDs = artworkIds?.slice(offset, offset + size)
+    const pageArtworkIDs = artworkIds.slice(offset, offset + size)
 
     // Fetching artwork details from Gravity
-    const artworks = artworkIds?.length
-      ? await artworksLoader({
-          ids: pageArtworkIDs,
-        })
+    const artworks = pageArtworkIDs.length
+      ? await artworksLoader({ ids: pageArtworkIDs })
       : []
 
     const totalCount = artworkIds.length


### PR DESCRIPTION
This PR retires the WTYL feature flag. The Gravity endpoint is still only available for Eigen traffic.