### PR TITLE
chore(recs): enable NWFY only for future eigen versions

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -14,6 +14,7 @@ const FEATURE_FLAGS_LIST = [
   "onyx_artwork-recommendations-gravity",
   "onyx_artwork-recommendations-refresh-eigen",
   "onyx_nwfy-gravity",
+  "onyx_nwfy-refresh-eigen",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/artworksForUser.test.ts
@@ -5,9 +5,12 @@ import { runAuthenticatedQuery } from "schema/v2/test/utils"
 
 jest.mock("lib/featureFlags", () => ({
   isFeatureFlagEnabled: jest.fn(() => false),
+  getExperimentVariant: jest.fn(() => ({ enabled: true, name: "variant" })),
 }))
 
 const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+
+const ELIGIBLE_USER_AGENT = "Artsy-Mobile/9.14.0"
 
 const buildQuery = (args: any = {}) => {
   const first = args.first || 10
@@ -54,6 +57,7 @@ const buildContext = (responses: any = {}) => {
     setsLoader: mockSetsLoader,
     setItemsLoader: mockSetItemsLoader,
     userID: "vortex-user-id",
+    userAgent: ELIGIBLE_USER_AGENT,
     authenticatedLoaders: {
       vortexGraphqlLoader: mockVortexGraphqlLoader,
     },
@@ -351,6 +355,7 @@ describe("artworksForUser", () => {
         body: backfillItems.map((item) => ({ ...item, _id: item.id })),
       })),
       userID: "vortex-user-id",
+      userAgent: ELIGIBLE_USER_AGENT,
       authenticatedLoaders: { vortexGraphqlLoader: null },
       unauthenticatedLoaders: { vortexGraphqlLoader: null },
     } as any

--- a/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
+++ b/src/schema/v2/artworksForUser/__tests__/helpers.test.ts
@@ -1,4 +1,4 @@
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import { HTTPError } from "lib/HTTPError"
 import {
   getBackfillArtworks,
@@ -8,9 +8,13 @@ import {
 
 jest.mock("lib/featureFlags", () => ({
   isFeatureFlagEnabled: jest.fn(() => false),
+  getExperimentVariant: jest.fn(() => ({ enabled: false, name: "control" })),
 }))
 
 const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
+const mockGetExperimentVariant = getExperimentVariant as jest.Mock
+
+const ELIGIBLE_USER_AGENT = "Artsy-Mobile/9.14.0"
 
 const mockLoaderFactory = (affinities) => {
   const edges = affinities.map((affinity) => {
@@ -67,11 +71,20 @@ describe("getNewForYouArtworkIDs", () => {
   describe("when the Gravity NWFY rail is enabled", () => {
     beforeEach(() => {
       mockIsFeatureFlagEnabled.mockReturnValue(true)
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: true,
+        name: "variant",
+      })
     })
 
     afterEach(() => {
       mockIsFeatureFlagEnabled.mockReset()
       mockIsFeatureFlagEnabled.mockReturnValue(false)
+      mockGetExperimentVariant.mockReset()
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: false,
+        name: "control",
+      })
     })
 
     it("sources IDs from the Gravity nwfy rail and skips Vortex", async () => {
@@ -81,6 +94,7 @@ describe("getNewForYouArtworkIDs", () => {
       }))
       const context = {
         artworkRecommendationsLoader,
+        userAgent: ELIGIBLE_USER_AGENT,
         authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
         unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
       } as any
@@ -105,6 +119,7 @@ describe("getNewForYouArtworkIDs", () => {
       })
       const context = {
         artworkRecommendationsLoader,
+        userAgent: ELIGIBLE_USER_AGENT,
         authenticatedLoaders: { vortexGraphqlLoader: () => jest.fn() },
         unauthenticatedLoaders: { vortexGraphqlLoader: jest.fn() },
       } as any
@@ -123,6 +138,7 @@ describe("getNewForYouArtworkIDs", () => {
       })
       const context = {
         artworkRecommendationsLoader,
+        userAgent: ELIGIBLE_USER_AGENT,
         authenticatedLoaders: { vortexGraphqlLoader: () => jest.fn() },
         unauthenticatedLoaders: { vortexGraphqlLoader: jest.fn() },
       } as any
@@ -161,6 +177,7 @@ describe("getNewForYouArtworkIDs", () => {
       }))
       const context = {
         artworkRecommendationsLoader,
+        userAgent: ELIGIBLE_USER_AGENT,
         authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
         unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
       } as any
@@ -193,6 +210,7 @@ describe("getNewForYouArtworkIDs", () => {
       const context = {
         artworkRecommendationsLoader,
         userID: "logged-in-user",
+        userAgent: ELIGIBLE_USER_AGENT,
         authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
         unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
       } as any
@@ -214,6 +232,73 @@ describe("getNewForYouArtworkIDs", () => {
       })
       expect(vortexLoader).not.toHaveBeenCalled()
       expect(artworkIds).toEqual(["a1"])
+    })
+
+    it("stays on Vortex for non-eigen clients (e.g. web)", async () => {
+      const vortexLoader = mockLoaderFactory([{ artworkId: "banksy" }])
+      const artworkRecommendationsLoader = jest.fn()
+      const context = {
+        artworkRecommendationsLoader,
+        userID: "logged-in-user",
+        authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
+        unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
+      } as any
+
+      const artworkIds = await getNewForYouArtworkIDs(
+        { excludeArtworkIds: [] },
+        context
+      )
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexLoader).toHaveBeenCalled()
+      expect(artworkIds).toEqual(["banksy"])
+    })
+
+    it("stays on Vortex for eigen versions below 9.14.0", async () => {
+      const vortexLoader = mockLoaderFactory([{ artworkId: "banksy" }])
+      const artworkRecommendationsLoader = jest.fn()
+      const context = {
+        artworkRecommendationsLoader,
+        userID: "logged-in-user",
+        userAgent: "Artsy-Mobile/9.13.0",
+        authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
+        unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
+      } as any
+
+      const artworkIds = await getNewForYouArtworkIDs(
+        { excludeArtworkIds: [] },
+        context
+      )
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexLoader).toHaveBeenCalled()
+      expect(artworkIds).toEqual(["banksy"])
+    })
+
+    it("stays on Vortex for the control variant", async () => {
+      mockGetExperimentVariant.mockReturnValue({
+        enabled: true,
+        name: "control",
+      })
+
+      const vortexLoader = mockLoaderFactory([{ artworkId: "banksy" }])
+      const artworkRecommendationsLoader = jest.fn()
+      const context = {
+        artworkRecommendationsLoader,
+        userID: "logged-in-user",
+        userAgent: ELIGIBLE_USER_AGENT,
+        authenticatedLoaders: { vortexGraphqlLoader: () => vortexLoader },
+        unauthenticatedLoaders: { vortexGraphqlLoader: vortexLoader },
+      } as any
+
+      const artworkIds = await getNewForYouArtworkIDs(
+        { excludeArtworkIds: [] },
+        context
+      )
+
+      expect(artworkRecommendationsLoader).not.toHaveBeenCalled()
+      expect(vortexLoader).toHaveBeenCalled()
+      expect(artworkIds).toEqual(["banksy"])
     })
 
     it("stays on the auction path for onlyAtAuction requests", async () => {

--- a/src/schema/v2/artworksForUser/helpers.ts
+++ b/src/schema/v2/artworksForUser/helpers.ts
@@ -1,6 +1,7 @@
 import gql from "lib/gql"
-import { isFeatureFlagEnabled } from "lib/featureFlags"
+import { getExperimentVariant, isFeatureFlagEnabled } from "lib/featureFlags"
 import { convertConnectionArgsToGravityArgs, extractNodes } from "lib/helpers"
+import { getEigenVersionNumber, isAtLeastVersion } from "lib/semanticVersioning"
 import { CursorPageable } from "relay-cursor-paging"
 import { ResolverContext } from "types/graphql"
 
@@ -8,6 +9,29 @@ import { ResolverContext } from "types/graphql"
 const MAX_ARTWORKS = 50
 
 const NWFY_GRAVITY_RAIL_FLAG = "onyx_nwfy-gravity"
+
+// Gravity-backed NWFY rail ships in eigen 9.14.0+.
+const MINIMUM_EIGEN_VERSION = { major: 9, minor: 14, patch: 0 }
+
+const REFRESH_EIGEN_FLAG = "onyx_nwfy-refresh-eigen"
+
+const isInRefreshExperiment = (context: ResolverContext): boolean => {
+  const variant = getExperimentVariant(REFRESH_EIGEN_FLAG, {
+    userId: context.userID,
+  })
+
+  return !!variant && variant.enabled && variant.name === "variant"
+}
+
+const isEligibleClient = (context: ResolverContext): boolean => {
+  const actualEigenVersion = getEigenVersionNumber(context.userAgent as string)
+
+  return (
+    !!actualEigenVersion &&
+    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION) &&
+    isInRefreshExperiment(context)
+  )
+}
 
 // Gravity-backed NWFY rail: source IDs from the live Gravity REST endpoint
 const getNewForYouArtworkIDsFromGravity = async (
@@ -83,6 +107,7 @@ export const getNewForYouArtworkIDs = async (
   const useGravity =
     !!artworkRecommendationsLoader &&
     !xImpersonateUserID &&
+    isEligibleClient(context) &&
     isFeatureFlagEnabled(NWFY_GRAVITY_RAIL_FLAG, {
       userId: userID || context.userID,
     })

--- a/src/schema/v2/me/artworkRecommendations.ts
+++ b/src/schema/v2/me/artworkRecommendations.ts
@@ -40,8 +40,8 @@ const isEligibleClient = (context: ResolverContext): boolean => {
 
   return (
     !!actualEigenVersion &&
-    isInRefreshExperiment(context) &&
-    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION)
+    isAtLeastVersion(actualEigenVersion, MINIMUM_EIGEN_VERSION) &&
+    isInRefreshExperiment(context)
   )
 }
 


### PR DESCRIPTION
This PR adds the eigen feature flag for NWFY and enables the traffic only for mobile versions.

Follow-up to https://github.com/artsy/eigen/pull/13787