### PR TITLE
feat: add keywordTypoTolerance filter arg to artworksConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -631,6 +631,11 @@ type Alert {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -2595,6 +2600,11 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -3230,6 +3240,11 @@ type ArtistPartnerEdge {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -3477,6 +3492,11 @@ type ArtistSeries implements Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -4891,6 +4911,11 @@ type ArtworkFilterNode {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -18230,6 +18255,11 @@ interface EntityWithFilterArtworksConnectionInterface {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -18701,6 +18731,11 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -19490,6 +19525,11 @@ input FilterArtworksInput {
   When true, will only return exact keyword match
   """
   keywordMatchExact: Boolean
+
+  """
+  When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+  """
+  keywordTypoTolerance: Boolean
   last: Int
   locationCities: [String]
   locationId: String
@@ -20282,6 +20322,11 @@ type Gene implements Node & Searchable {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -23439,6 +23484,11 @@ type MarketingCollection implements Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -28798,6 +28848,11 @@ type Partner implements Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -29363,6 +29418,11 @@ type PartnerArtist {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -29657,6 +29717,11 @@ type PartnerArtistEdge {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -31799,6 +31864,11 @@ type Query {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -32409,6 +32479,11 @@ type Query {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -36188,6 +36263,11 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -37050,6 +37130,11 @@ type Tag implements Node {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -41589,6 +41674,11 @@ type Viewer {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String
@@ -41988,6 +42078,11 @@ type Viewer {
     When true, will only return exact keyword match
     """
     keywordMatchExact: Boolean
+
+    """
+    When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.
+    """
+    keywordTypoTolerance: Boolean
     last: Int
     locationCities: [String]
     locationId: String

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1015,6 +1015,89 @@ describe("artworksConnection", () => {
     })
   })
 
+  describe("keyword typo tolerance", () => {
+    const mockFilterArtworksLoader = jest.fn((_args) => {
+      return Promise.resolve({
+        hits: [
+          {
+            id: "kaws-toys",
+          },
+        ],
+        aggregations: {
+          total: {
+            value: 1,
+          },
+        },
+      })
+    })
+
+    const context = {
+      authenticatedLoaders: {},
+      unauthenticatedLoaders: {
+        filterArtworksLoader: mockFilterArtworksLoader,
+      },
+    }
+
+    beforeEach(() => {
+      mockFilterArtworksLoader.mockClear()
+    })
+
+    it("passes keywordTypoTolerance: true to Gravity", async () => {
+      const query = gql`
+        {
+          artworksConnection(
+            input: {
+              keyword: "kaes-toys"
+              keywordTypoTolerance: true
+              first: 10
+            }
+          ) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      const { artworksConnection } = await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          keyword: "kaes-toys",
+          keyword_typo_tolerance: true,
+        })
+      )
+
+      expect(artworksConnection.edges).toEqual([
+        { node: { slug: "kaws-toys" } },
+      ])
+    })
+
+    it("does not pass keywordTypoTolerance to Gravity when omitted", async () => {
+      const query = gql`
+        {
+          artworksConnection(input: { keyword: "kaws", first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+      await runQuery(query, context)
+
+      expect(mockFilterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          keyword_typo_tolerance: expect.anything(),
+        })
+      )
+    })
+  })
+
   describe("hybrid search tuning args", () => {
     const mockFilterArtworksLoader = jest.fn((_args) => {
       return Promise.resolve({

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -212,6 +212,11 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
     type: GraphQLBoolean,
     description: "When true, will only return exact keyword match",
   },
+  keywordTypoTolerance: {
+    type: GraphQLBoolean,
+    description:
+      "When true and a `keyword` search returns no results, retries once with typo tolerance. Ignored with `keywordMatchExact`.",
+  },
   locationCities: {
     type: new GraphQLList(GraphQLString),
   },
@@ -523,6 +528,7 @@ const convertFilterArgs = ({
   includeUnpublished,
   inquireableOnly,
   keywordMatchExact,
+  keywordTypoTolerance,
   locationCities,
   locationId,
   majorPeriods,
@@ -573,6 +579,7 @@ const convertFilterArgs = ({
     include_unpublished: includeUnpublished,
     inquireable_only: inquireableOnly,
     keyword_match_exact: keywordMatchExact,
+    keyword_typo_tolerance: keywordTypoTolerance,
     location_cities: locationCities,
     location_id: locationId,
     major_periods: majorPeriods,


### PR DESCRIPTION
Assisted-by: Claude Code

Proxies Gravity's new `keyword_typo_tolerance` option on `filter/artworks` (https://github.com/artsy/gravity/pull/20397) through the artwork filter args, so clients can opt into typo-tolerant keyword search.

Without `keywordTypoTolerance`:

```graphql
{ 
  artworksConnection(input: {keyword: "alwx katz", first: 1}) {
    edges {
      node {
        slug
      }
    }
  }
}
```

=>

```json
{
  "data": {
    "artworksConnection": {
      "edges": []
    }
  }
}
```

With `keywordTypoTolerance: true`:

```graphql
{ 
  artworksConnection(input: {keyword: "alwx katz", keywordTypoTolerance: true, first: 1}) {
    edges {
      node {
        slug
      }
    }
  }
}
```

=>

```json
{
  "data": {
    "artworksConnection": {
      "edges": [
        {
          "node": {
            "slug": "alex-katz-ursula-21"
          }
        }
      ]
    }
  }
}
```