### PR TITLE
feat: Private Viewing Rooms for ArtOS

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4818,6 +4818,28 @@ type ArtworkError {
   requestError: RequestError
 }
 
+type ArtworkFieldVisibility {
+  artistName: Boolean
+  artworkTitle: Boolean
+  availability: Boolean
+  dimensions: Boolean
+  editionInfo: Boolean
+  medium: Boolean
+  price: Boolean
+  year: Boolean
+}
+
+input ArtworkFieldVisibilityInput {
+  artistName: Boolean
+  artworkTitle: Boolean
+  availability: Boolean
+  dimensions: Boolean
+  editionInfo: Boolean
+  medium: Boolean
+  price: Boolean
+  year: Boolean
+}
+
 union ArtworkFigures = Image | Video
 
 union ArtworkFilterFacet = Gene | Tag
@@ -6870,6 +6892,41 @@ type AuctionsUser implements AuctionsNode {
   The user's id
   """
   userId: ID!
+}
+
+type AuthenticatePrivateViewingRoomFailure {
+  mutationError: GravityMutationError
+}
+
+input AuthenticatePrivateViewingRoomMutationInput {
+  clientMutationId: String
+
+  """
+  The room's password.
+  """
+  password: String!
+
+  """
+  The slug of the private viewing room.
+  """
+  slug: String!
+}
+
+type AuthenticatePrivateViewingRoomMutationPayload {
+  clientMutationId: String
+
+  """
+  On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect password).
+  """
+  privateViewingRoomOrError: AuthenticatePrivateViewingRoomResponseOrError
+}
+
+union AuthenticatePrivateViewingRoomResponseOrError =
+    AuthenticatePrivateViewingRoomFailure
+  | AuthenticatePrivateViewingRoomSuccess
+
+type AuthenticatePrivateViewingRoomSuccess {
+  privateViewingRoom: PrivateViewingRoomContents
 }
 
 enum AuthenticationProvider {
@@ -15404,7 +15461,7 @@ input CreatePartnerListMutationInput {
   fairID: String
 
   """
-  The type of list (show, fair, or other).
+  The type of list (show, fair, private_viewing_room, or other).
   """
   listType: PartnerListTypeEnum
 
@@ -25225,6 +25282,13 @@ type Mutation {
   ): AssignArtistToPartnerMutationPayload
 
   """
+  Authenticates against a password-protected private viewing room, returning its contents on success.
+  """
+  authenticatePrivateViewingRoom(
+    input: AuthenticatePrivateViewingRoomMutationInput!
+  ): AuthenticatePrivateViewingRoomMutationPayload
+
+  """
   Initiate the Instagram OAuth flow and return the authorization URL
   """
   authorizeInstagramAccount(
@@ -26391,6 +26455,13 @@ type Mutation {
   publishNavigationDraft(
     input: PublishNavigationDraftInput!
   ): PublishNavigationDraftPayload
+
+  """
+  Publishes (or updates and republishes) a private viewing room for a partner list.
+  """
+  publishPartnerListPublication(
+    input: PublishPartnerListPublicationMutationInput!
+  ): PublishPartnerListPublicationMutationPayload
   publishViewingRoom(input: PublishViewingRoomInput!): PublishViewingRoomPayload
 
   """
@@ -26625,6 +26696,13 @@ type Mutation {
   unlinkAuthentication(
     input: UnlinkAuthenticationMutationInput!
   ): UnlinkAuthenticationMutationPayload
+
+  """
+  Unpublishes a partner list's private viewing room. Does not delete the publication.
+  """
+  unpublishPartnerListPublication(
+    input: UnpublishPartnerListPublicationMutationInput!
+  ): UnpublishPartnerListPublicationMutationPayload
   unpublishViewingRoom(
     input: UnpublishViewingRoomInput!
   ): UnpublishViewingRoomPayload
@@ -30285,6 +30363,11 @@ type PartnerList {
   listType: PartnerListTypeEnum!
   name: String!
   partnerShowID: String
+
+  """
+  The private viewing room publication for this list, if one exists (only applies to private_viewing_room lists). Not resolvable through partnerListsConnection.
+  """
+  publication: PartnerListPublication
   startAt(
     format: String
 
@@ -30368,9 +30451,71 @@ type PartnerListEdge {
   node: PartnerList
 }
 
+type PartnerListPublication {
+  applyBrand: Boolean
+
+  """
+  Per-field visibility toggles for artworks in the room. Any key the gallery hasn't set is null.
+  """
+  artworkFieldVisibility: ArtworkFieldVisibility
+  createdAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  description: String
+
+  """
+  Public-facing path for this private viewing room.
+  """
+  href: String
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  A type-specific ID likely used as a database ID.
+  """
+  internalID: ID!
+  lastPublishedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  partnerListID: String
+  passwordProtected: Boolean
+  published: Boolean
+  publishedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  slug: String
+  updatedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+}
+
 enum PartnerListTypeEnum {
   FAIR
   OTHER
+  PRIVATE_VIEWING_ROOM
   SHOW
 }
 
@@ -31197,6 +31342,46 @@ union PricingBreakdownLineUnion =
   | TaxLine
   | TotalLine
 
+type PrivateViewingRoom {
+  applyBrand: Boolean
+  artworks: [PrivateViewingRoomArtwork!]
+  brandKit: BrandKit
+  description: String
+  galleryName: String
+
+  """
+  Whether this room requires a password to view.
+  """
+  passwordRequired: Boolean!
+}
+
+type PrivateViewingRoomArtwork {
+  artistName: String
+  artworkID: String
+  artworkTitle: String
+  availability: String
+  dimensions: String
+  editionInfo: String
+  imageURL: String
+  medium: String
+
+  """
+  The pinned price as a formatted Money object. Null when there's no pinned price or currency (resolveMinorAndCurrencyFieldsToMoney returns null rather than throwing).
+  """
+  price: Money
+  priceCents: Int
+  priceCurrency: String
+  year: String
+}
+
+type PrivateViewingRoomContents {
+  applyBrand: Boolean
+  artworks: [PrivateViewingRoomArtwork!]
+  brandKit: BrandKit
+  description: String
+  galleryName: String
+}
+
 type Profile {
   bio: String
   cached: Int
@@ -31306,6 +31491,55 @@ union PublishNavigationDraftResponseOrError =
 
 type PublishNavigationDraftSuccess {
   navigationVersion: NavigationVersion!
+}
+
+type PublishPartnerListPublicationFailure {
+  mutationError: GravityMutationError
+}
+
+input PublishPartnerListPublicationMutationInput {
+  """
+  Whether to apply the gallery's brand kit to the room.
+  """
+  applyBrand: Boolean
+
+  """
+  Per-field visibility toggles for artworks in the room.
+  """
+  artworkFieldVisibility: ArtworkFieldVisibilityInput
+  clientMutationId: String
+
+  """
+  Plain-text description shown on the published room.
+  """
+  description: String
+
+  """
+  The ID of the partner list to publish as a viewing room.
+  """
+  partnerListID: String!
+
+  """
+  Password to gate the room. Pass an empty string to clear a previously set password.
+  """
+  password: String
+}
+
+type PublishPartnerListPublicationMutationPayload {
+  clientMutationId: String
+
+  """
+  On success: the published partner list publication. On error: the error that occurred.
+  """
+  partnerListPublicationOrError: PublishPartnerListPublicationResponseOrError
+}
+
+union PublishPartnerListPublicationResponseOrError =
+    PublishPartnerListPublicationFailure
+  | PublishPartnerListPublicationSuccess
+
+type PublishPartnerListPublicationSuccess {
+  partnerListPublication: PartnerListPublication
 }
 
 type PublishViewingRoomFailure {
@@ -33365,6 +33599,11 @@ type Query {
     """
     sort: PriceInsightSort
   ): PriceInsightConnection
+
+  """
+  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
+  """
+  privateViewingRoom(slug: String!): PrivateViewingRoom
 
   """
   A Profile
@@ -37467,6 +37706,36 @@ type UnlinkAuthenticationMutationPayload {
   me: Me!
 }
 
+type UnpublishPartnerListPublicationFailure {
+  mutationError: GravityMutationError
+}
+
+input UnpublishPartnerListPublicationMutationInput {
+  clientMutationId: String
+
+  """
+  The ID of the partner list to unpublish.
+  """
+  partnerListID: String!
+}
+
+type UnpublishPartnerListPublicationMutationPayload {
+  clientMutationId: String
+
+  """
+  On success: the unpublished partner list publication. On error: the error that occurred.
+  """
+  partnerListPublicationOrError: UnpublishPartnerListPublicationResponseOrError
+}
+
+union UnpublishPartnerListPublicationResponseOrError =
+    UnpublishPartnerListPublicationFailure
+  | UnpublishPartnerListPublicationSuccess
+
+type UnpublishPartnerListPublicationSuccess {
+  partnerListPublication: PartnerListPublication
+}
+
 type UnpublishViewingRoomFailure {
   mutationError: GravityMutationError
 }
@@ -39257,7 +39526,7 @@ input UpdatePartnerListMutationInput {
   id: String!
 
   """
-  The type of list (show, fair, or other).
+  The type of list (show, fair, private_viewing_room, or other).
   """
   listType: PartnerListTypeEnum
 
@@ -42877,6 +43146,11 @@ type Viewer {
     """
     attributes: PreviewSavedSearchAttributes
   ): PreviewSavedSearch
+
+  """
+  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
+  """
+  privateViewingRoom(slug: String!): PrivateViewingRoom
 
   """
   A Profile

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1921,5 +1921,20 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+
+    // Partner List Publication Loaders (Private Viewing Rooms)
+    partnerListPublicationLoader: gravityLoader(
+      (id) => `partner_list/${id}/publication`
+    ),
+    publishPartnerListPublicationLoader: gravityLoader(
+      (id) => `partner_list/${id}/publication`,
+      {},
+      { method: "POST" }
+    ),
+    unpublishPartnerListPublicationLoader: gravityLoader(
+      (id) => `partner_list/${id}/publication/unpublish`,
+      {},
+      { method: "POST" }
+    ),
   }
 }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -377,5 +377,22 @@ export default (opts) => {
       (id) => `viewing_room/${id}/viewing_room_artworks`
     ),
     viewingRoomsLoader: gravityLoader("viewing_rooms", {}, { headers: true }),
+
+    // Private Viewing Room Loaders
+    // Uncached: publish state (and password_required) can flip between requests,
+    // and gravityLoader would otherwise cache a stale 404/response shape.
+    privateViewingRoomLoader: gravityUncachedLoader(
+      (slug) => `private_viewing_room/${slug}`
+    ),
+    // Not gravityUncachedLoader: that factory drops `method` entirely for gravity
+    // (always issues a GET), so a POST here must go through the regular cached
+    // factory instead — it already skips the cache automatically for
+    // POST/PUT/DELETE (see apiOptions.method check in
+    // loader_without_authentication_factory.ts), so nothing is ever cached here.
+    authenticatePrivateViewingRoomLoader: gravityLoader(
+      (slug) => `private_viewing_room/${slug}/authenticate`,
+      {},
+      { method: "POST" }
+    ),
   }
 }

--- a/src/schema/v2/__tests__/partnerListPublication.test.ts
+++ b/src/schema/v2/__tests__/partnerListPublication.test.ts
@@ -1,0 +1,159 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("PartnerList.publication", () => {
+  const query = gql`
+    {
+      partner(id: "gallery-1") {
+        partnerList(id: "list-abc") {
+          publication {
+            internalID
+            published
+            passwordProtected
+            slug
+            href
+            description
+          }
+        }
+      }
+    }
+  `
+
+  it("returns the publication for a partner list", async () => {
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListLoader: jest.fn().mockResolvedValue({ id: "list-abc" }),
+      partnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        partner_list_id: "list-abc",
+        published: true,
+        password_protected: false,
+        slug: "some-gallery-for-anna",
+        description: "For Anna",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(context.partnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc"
+    )
+    expect(result.partner.partnerList.publication).toEqual({
+      internalID: "pub-1",
+      published: true,
+      passwordProtected: false,
+      slug: "some-gallery-for-anna",
+      href: "/private-viewing-room/some-gallery-for-anna",
+      description: "For Anna",
+    })
+  })
+
+  it("returns null when no publication exists yet", async () => {
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListLoader: jest.fn().mockResolvedValue({ id: "list-abc" }),
+      partnerListPublicationLoader: jest
+        .fn()
+        .mockRejectedValue({ statusCode: 404 }),
+    }
+
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(result.partner.partnerList.publication).toBeNull()
+  })
+
+  it("re-throws a non-404 error instead of swallowing it", async () => {
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListLoader: jest.fn().mockResolvedValue({ id: "list-abc" }),
+      partnerListPublicationLoader: jest
+        .fn()
+        .mockRejectedValue({ statusCode: 500, message: "Gravity is down" }),
+    }
+
+    await expect(runAuthenticatedQuery(query, context)).rejects.toThrow()
+  })
+
+  it("does not resolve publication for a list reached through partnerListsConnection (N+1 guard)", async () => {
+    const connectionQuery = gql`
+      {
+        partner(id: "gallery-1") {
+          partnerListsConnection(first: 1) {
+            edges {
+              node {
+                internalID
+                publication {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListsLoader: jest.fn().mockResolvedValue({
+        body: [{ id: "list-abc" }],
+        headers: { "x-total-count": "1" },
+      }),
+      // If the connection path ever resolves `publication`, this would fire —
+      // it must not, since there's no Gravity endpoint to batch this and the
+      // resolver refuses to call it outside the single-list lookup.
+      partnerListPublicationLoader: jest
+        .fn()
+        .mockRejectedValue(new Error("should not be called")),
+    }
+
+    const result = await runAuthenticatedQuery(connectionQuery, context)
+
+    expect(context.partnerListPublicationLoader).not.toHaveBeenCalled()
+    expect(
+      result.partner.partnerListsConnection.edges[0].node.publication
+    ).toBeNull()
+  })
+
+  it("resolves publication on a PartnerList returned from a mutation payload", async () => {
+    // Regression guard: a first-pass fix inverted this the wrong way around
+    // (opted single-list nodes in via a flag set only in Partner.partnerList),
+    // which broke every mutation that returns a PartnerList — updatePartnerList
+    // among them — via the same partnerListLoader(id) call. The connection is
+    // the one place this must NOT resolve; everywhere else, it should.
+    const mutation = gql`
+      mutation {
+        updatePartnerList(input: { id: "list-abc", name: "New name" }) {
+          partnerListOrError {
+            ... on UpdatePartnerListSuccess {
+              partnerList {
+                publication {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      updatePartnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        name: "New name",
+      }),
+      partnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        slug: "some-gallery-for-anna",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.partnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc"
+    )
+    expect(
+      result.updatePartnerList.partnerListOrError.partnerList.publication
+    ).toEqual({ slug: "some-gallery-for-anna" })
+  })
+})

--- a/src/schema/v2/__tests__/privateViewingRoom.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoom.test.ts
@@ -1,0 +1,123 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("PrivateViewingRoom", () => {
+  const query = gql`
+    {
+      privateViewingRoom(slug: "some-gallery-for-anna") {
+        passwordRequired
+        galleryName
+        description
+        applyBrand
+        brandKit {
+          textColor
+        }
+        artworks {
+          artworkID
+          artworkTitle
+          artistName
+        }
+      }
+    }
+  `
+
+  it("returns password_required: true without room contents", async () => {
+    const context = {
+      privateViewingRoomLoader: jest
+        .fn()
+        .mockResolvedValue({ password_required: true }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(context.privateViewingRoomLoader).toHaveBeenCalledWith(
+      "some-gallery-for-anna"
+    )
+    expect(result.privateViewingRoom).toEqual({
+      passwordRequired: true,
+      galleryName: null,
+      description: null,
+      applyBrand: null,
+      brandKit: null,
+      artworks: null,
+    })
+  })
+
+  it("returns room contents when no password is required", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        password_required: false,
+        gallery_name: "Isabel Croxatto Galeria",
+        description: "For Anna",
+        apply_brand: true,
+        brand_kit: { text_color: "#111111" },
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            artwork_title: "Mountains and Sea",
+            artist_name: "Helen Frankenthaler",
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom).toEqual({
+      passwordRequired: false,
+      galleryName: "Isabel Croxatto Galeria",
+      description: "For Anna",
+      applyBrand: true,
+      brandKit: { textColor: "#111111" },
+      artworks: [
+        {
+          artworkID: "artwork-1",
+          artworkTitle: "Mountains and Sea",
+          artistName: "Helen Frankenthaler",
+        },
+      ],
+    })
+  })
+
+  it("returns null for an unknown or unpublished slug instead of a GraphQL error", async () => {
+    const context = {
+      privateViewingRoomLoader: jest
+        .fn()
+        .mockRejectedValue({ statusCode: 404 }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom).toBeNull()
+  })
+
+  it("re-throws a non-404 error instead of swallowing it", async () => {
+    const context = {
+      privateViewingRoomLoader: jest
+        .fn()
+        .mockRejectedValue({ statusCode: 500, message: "Gravity is down" }),
+    }
+
+    await expect(runQuery(query, context)).rejects.toThrow()
+  })
+
+  it("coerces a missing password_required to false rather than nulling the whole room", async () => {
+    // Regression guard: passwordRequired is Boolean!, so if Gravity's GET
+    // ever omitted this key on either branch, a bare pass-through would
+    // violate the non-null constraint and null out the entire
+    // privateViewingRoom field — losing gallery name/artworks along with it.
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        gallery_name: "Isabel Croxatto Galeria",
+        artworks: [],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.passwordRequired).toBe(false)
+    expect(result.privateViewingRoom.galleryName).toEqual(
+      "Isabel Croxatto Galeria"
+    )
+  })
+})

--- a/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
@@ -1,0 +1,101 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("PrivateViewingRoomArtwork.price", () => {
+  const query = gql`
+    {
+      privateViewingRoom(slug: "some-gallery-for-anna") {
+        artworks {
+          priceCents
+          priceCurrency
+          price {
+            minor
+            major
+            currencyCode
+            display
+          }
+        }
+      }
+    }
+  `
+
+  it("formats the pinned price as Money", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        password_required: false,
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            price_cents: 500000,
+            price_currency: "USD",
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0]).toEqual({
+      priceCents: 500000,
+      priceCurrency: "USD",
+      price: {
+        minor: 500000,
+        major: 5000,
+        currencyCode: "USD",
+        display: "US$5,000",
+      },
+    })
+  })
+
+  it("returns null price when there is no pinned price", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        password_required: false,
+        artworks: [{ artwork_id: "artwork-1" }],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0].price).toBeNull()
+  })
+
+  it("returns null price when there's a pinned price but no currency", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        password_required: false,
+        artworks: [{ artwork_id: "artwork-1", price_cents: 500000 }],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0].price).toBeNull()
+  })
+
+  it("uses the correct subunit factor for a zero-decimal currency (regression)", async () => {
+    // JPY has subunit_to_unit: 1 (currency_codes.json), so 500000 minor units
+    // is ¥500,000, not ¥5,000. A prior version of this resolver always
+    // divided by 100, which is only correct for currencies like USD.
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        password_required: false,
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            price_cents: 500000,
+            price_currency: "JPY",
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    // major = minor / subunit_to_unit (1 for JPY) = 500000, not 500000 / 100
+    expect(result.privateViewingRoom.artworks[0].price.major).toEqual(500000)
+    expect(result.privateViewingRoom.artworks[0].price.display).toEqual(
+      "JPY ¥500,000"
+    )
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/createPartnerListMutation.ts
@@ -66,7 +66,8 @@ export const createPartnerListMutation = mutationWithClientMutationId<
     },
     listType: {
       type: PartnerListTypeEnum,
-      description: "The type of list (show, fair, or other).",
+      description:
+        "The type of list (show, fair, private_viewing_room, or other).",
     },
     startAt: {
       type: GraphQLString,

--- a/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerList/updatePartnerListMutation.ts
@@ -66,7 +66,8 @@ export const updatePartnerListMutation = mutationWithClientMutationId<
     },
     listType: {
       type: PartnerListTypeEnum,
-      description: "The type of list (show, fair, or other).",
+      description:
+        "The type of list (show, fair, private_viewing_room, or other).",
     },
     startAt: {
       type: GraphQLString,

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
@@ -1,0 +1,248 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("PublishPartnerListPublicationMutation", () => {
+  const mutation = gql`
+    mutation {
+      publishPartnerListPublication(
+        input: {
+          partnerListID: "list-abc"
+          description: "For Anna"
+          applyBrand: true
+          artworkFieldVisibility: { artistName: true, artworkTitle: false }
+        }
+      ) {
+        partnerListPublicationOrError {
+          __typename
+          ... on PublishPartnerListPublicationSuccess {
+            partnerListPublication {
+              internalID
+              published
+              description
+              applyBrand
+              passwordProtected
+            }
+          }
+          ... on PublishPartnerListPublicationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("publishes a partner list publication", async () => {
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        partner_list_id: "list-abc",
+        published: true,
+        description: "For Anna",
+        apply_brand: true,
+        password_protected: false,
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.publishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        description: "For Anna",
+        apply_brand: true,
+        artwork_field_visibility: {
+          artist_name: true,
+          artwork_title: false,
+        },
+      }
+    )
+
+    expect(result).toEqual({
+      publishPartnerListPublication: {
+        partnerListPublicationOrError: {
+          __typename: "PublishPartnerListPublicationSuccess",
+          partnerListPublication: {
+            internalID: "pub-1",
+            published: true,
+            description: "For Anna",
+            applyBrand: true,
+            passwordProtected: false,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockRejectedValue({
+        body: { error: "Only private_viewing_room lists can be published" },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      publishPartnerListPublication: {
+        partnerListPublicationOrError: {
+          __typename: "PublishPartnerListPublicationFailure",
+          mutationError: {
+            message: "Only private_viewing_room lists can be published",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        publishPartnerListPublicationLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+
+  it("sets a password", async () => {
+    const withPassword = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: { partnerListID: "list-abc", password: "letmein" }
+        ) {
+          partnerListPublicationOrError {
+            __typename
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                passwordProtected
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        password_protected: true,
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(withPassword, context)
+
+    expect(
+      context.publishPartnerListPublicationLoader
+    ).toHaveBeenCalledWith("list-abc", { password: "letmein" })
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication.passwordProtected
+    ).toBe(true)
+  })
+
+  it("passes an empty string through when clearing a password", async () => {
+    // Regression guard: `password: ""` must reach the loader as "" (not be
+    // dropped), since that's what signals "clear the password" — the query
+    // string round trip further down in lib/apis/fetch.ts is what turns it
+    // into a `null` on the wire, which is out of scope for this mutation to
+    // guard against; this test only proves the mutation itself forwards it.
+    const clearPassword = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: { partnerListID: "list-abc", password: "" }
+        ) {
+          partnerListPublicationOrError {
+            __typename
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                passwordProtected
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        password_protected: false,
+      }),
+    }
+
+    await runAuthenticatedQuery(clearPassword, context)
+
+    expect(
+      context.publishPartnerListPublicationLoader
+    ).toHaveBeenCalledWith("list-abc", { password: "" })
+  })
+
+  it("omits artwork_field_visibility entirely when not provided", async () => {
+    const withoutVisibility = gql`
+      mutation {
+        publishPartnerListPublication(input: { partnerListID: "list-abc" }) {
+          partnerListPublicationOrError {
+            __typename
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest
+        .fn()
+        .mockResolvedValue({ id: "pub-1" }),
+    }
+
+    await runAuthenticatedQuery(withoutVisibility, context)
+
+    expect(context.publishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {}
+    )
+  })
+
+  it("reads artworkFieldVisibility back as typed booleans, casting stored string values", async () => {
+    const readVisibility = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: {
+            partnerListID: "list-abc"
+            artworkFieldVisibility: { artistName: true, artworkTitle: false }
+          }
+        ) {
+          partnerListPublicationOrError {
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                artworkFieldVisibility {
+                  artistName
+                  artworkTitle
+                  price
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        // Gravity may store either real booleans or the literal strings
+        // "true"/"false" (untyped Grape Hash param) — both must cast right.
+        artwork_field_visibility: {
+          artist_name: true,
+          artwork_title: "false",
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(readVisibility, context)
+
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication.artworkFieldVisibility
+    ).toEqual({
+      artistName: true,
+      artworkTitle: false,
+      price: null,
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/unpublishPartnerListPublicationMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/unpublishPartnerListPublicationMutation.test.ts
@@ -1,0 +1,82 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UnpublishPartnerListPublicationMutation", () => {
+  const mutation = gql`
+    mutation {
+      unpublishPartnerListPublication(input: { partnerListID: "list-abc" }) {
+        partnerListPublicationOrError {
+          __typename
+          ... on UnpublishPartnerListPublicationSuccess {
+            partnerListPublication {
+              internalID
+              published
+            }
+          }
+          ... on UnpublishPartnerListPublicationFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("unpublishes a partner list publication", async () => {
+    const context = {
+      unpublishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        partner_list_id: "list-abc",
+        published: false,
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(context.unpublishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc"
+    )
+
+    expect(result).toEqual({
+      unpublishPartnerListPublication: {
+        partnerListPublicationOrError: {
+          __typename: "UnpublishPartnerListPublicationSuccess",
+          partnerListPublication: {
+            internalID: "pub-1",
+            published: false,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      unpublishPartnerListPublicationLoader: jest
+        .fn()
+        .mockRejectedValue({ body: { error: "Publication Not Found" } }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toEqual({
+      unpublishPartnerListPublication: {
+        partnerListPublicationOrError: {
+          __typename: "UnpublishPartnerListPublicationFailure",
+          mutationError: {
+            message: "Publication Not Found",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when not authenticated", async () => {
+    await expect(
+      runAuthenticatedQuery(mutation, {
+        unpublishPartnerListPublicationLoader: undefined,
+      })
+    ).rejects.toThrow("You need to be signed in to perform this action")
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
@@ -1,0 +1,162 @@
+import { camelCase } from "lodash"
+import {
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import {
+  ARTWORK_FIELD_VISIBILITY_KEYS,
+  PartnerListPublicationType,
+} from "schema/v2/partnerListPublication"
+
+// Generated from ARTWORK_FIELD_VISIBILITY_KEYS (schema/v2/partnerListPublication.ts) —
+// the write-side counterpart of ArtworkFieldVisibilityType there. Both are
+// built from the same list so a key can't drift between read and write.
+const ArtworkFieldVisibilityInputType = new GraphQLInputObjectType({
+  name: "ArtworkFieldVisibilityInput",
+  fields: Object.fromEntries(
+    ARTWORK_FIELD_VISIBILITY_KEYS.map((key) => [
+      camelCase(key),
+      { type: GraphQLBoolean },
+    ])
+  ),
+})
+
+interface PublishPartnerListPublicationMutationInputProps {
+  partnerListID: string
+  password?: string
+  description?: string
+  applyBrand?: boolean
+  artworkFieldVisibility?: Record<string, boolean>
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PublishPartnerListPublicationSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerListPublication: {
+      type: PartnerListPublicationType,
+      resolve: (publication) => publication,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "PublishPartnerListPublicationFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "PublishPartnerListPublicationResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const publishPartnerListPublicationMutation = mutationWithClientMutationId<
+  PublishPartnerListPublicationMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "PublishPartnerListPublicationMutation",
+  description:
+    "Publishes (or updates and republishes) a private viewing room for a partner list.",
+  inputFields: {
+    partnerListID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list to publish as a viewing room.",
+    },
+    password: {
+      type: GraphQLString,
+      description:
+        "Password to gate the room. Pass an empty string to clear a previously set password.",
+    },
+    description: {
+      type: GraphQLString,
+      description: "Plain-text description shown on the published room.",
+    },
+    applyBrand: {
+      type: GraphQLBoolean,
+      description: "Whether to apply the gallery's brand kit to the room.",
+    },
+    artworkFieldVisibility: {
+      type: ArtworkFieldVisibilityInputType,
+      description: "Per-field visibility toggles for artworks in the room.",
+    },
+  },
+  outputFields: {
+    partnerListPublicationOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the published partner list publication. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    {
+      partnerListID,
+      password,
+      description,
+      applyBrand,
+      artworkFieldVisibility,
+    },
+    { publishPartnerListPublicationLoader }
+  ) => {
+    if (!publishPartnerListPublicationLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    const gravityArgs: Record<string, unknown> = {}
+
+    // password: "" is intentional here, not a bug — it's how a client clears
+    // a previously-set password. The loader layer's query-string round trip
+    // (lib/apis/fetch.ts `constructUrlAndParams`) rewrites an empty string to
+    // `null` before it reaches Gravity, and Gravity's own `password=` setter
+    // treats `nil` (via `new_password.presence`) as "clear the digest" — so
+    // an empty string here and an explicit `null` arrive at the same place.
+    if (password !== undefined) gravityArgs.password = password
+    if (description !== undefined) gravityArgs.description = description
+    if (applyBrand !== undefined) gravityArgs.apply_brand = applyBrand
+    if (artworkFieldVisibility !== undefined) {
+      const visibility: Record<string, boolean> = {}
+
+      // artworkFieldVisibility is keyed camelCase (it came through
+      // ArtworkFieldVisibilityInputType, whose fields are generated the same
+      // way), so camelCase(key) is how we read back each snake_case Gravity
+      // key from it.
+      ARTWORK_FIELD_VISIBILITY_KEYS.forEach((key) => {
+        const value = artworkFieldVisibility[camelCase(key)]
+        if (value !== undefined) visibility[key] = value
+      })
+
+      gravityArgs.artwork_field_visibility = visibility
+    }
+
+    try {
+      return await publishPartnerListPublicationLoader(
+        partnerListID,
+        gravityArgs
+      )
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/unpublishPartnerListPublicationMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/unpublishPartnerListPublicationMutation.ts
@@ -1,0 +1,87 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerListPublicationType } from "schema/v2/partnerListPublication"
+
+interface UnpublishPartnerListPublicationMutationInputProps {
+  partnerListID: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UnpublishPartnerListPublicationSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    partnerListPublication: {
+      type: PartnerListPublicationType,
+      resolve: (publication) => publication,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UnpublishPartnerListPublicationFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UnpublishPartnerListPublicationResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const unpublishPartnerListPublicationMutation = mutationWithClientMutationId<
+  UnpublishPartnerListPublicationMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "UnpublishPartnerListPublicationMutation",
+  description:
+    "Unpublishes a partner list's private viewing room. Does not delete the publication.",
+  inputFields: {
+    partnerListID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner list to unpublish.",
+    },
+  },
+  outputFields: {
+    partnerListPublicationOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the unpublished partner list publication. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerListID },
+    { unpublishPartnerListPublicationLoader }
+  ) => {
+    if (!unpublishPartnerListPublicationLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await unpublishPartnerListPublicationLoader(partnerListID)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1544,12 +1544,25 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           const { body, headers } = await partnerListsLoader(gravityArgs)
           const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
+          // Marks every node as reached through this connection —
+          // PartnerListType.publication refuses to resolve when this is set,
+          // since a page of N lists would otherwise fire N Gravity
+          // `partner_list/:id/publication` calls with no batch endpoint to
+          // collapse them into one (see the resolver for the full
+          // explanation). Every other single-list access path (the
+          // `partnerList(id:)` lookup above, and every PartnerList mutation
+          // payload) is unflagged and resolves `publication` normally.
+          const flaggedBody = body.map((list) => ({
+            ...list,
+            _fromConnection: true,
+          }))
+
           return paginationResolver({
             totalCount,
             offset,
             page,
             size,
-            body,
+            body: flaggedBody,
             args,
           })
         },

--- a/src/schema/v2/partnerList.ts
+++ b/src/schema/v2/partnerList.ts
@@ -15,12 +15,14 @@ import {
   connectionWithCursorInfo,
   paginationResolver,
 } from "./fields/pagination"
+import { PartnerListPublicationType } from "./partnerListPublication"
 
 export const PartnerListTypeEnum = new GraphQLEnumType({
   name: "PartnerListTypeEnum",
   values: {
     SHOW: { value: "show" },
     FAIR: { value: "fair" },
+    PRIVATE_VIEWING_ROOM: { value: "private_viewing_room" },
     OTHER: { value: "other" },
   },
 })
@@ -99,6 +101,40 @@ export const PartnerListType = new GraphQLObjectType<any, ResolverContext>({
             args,
             resolveNode: (node) => node.artwork,
           })
+        },
+      },
+      publication: {
+        type: PartnerListPublicationType,
+        description:
+          "The private viewing room publication for this list, if one exists (only applies to private_viewing_room lists). Not resolvable through partnerListsConnection.",
+        resolve: async (
+          { id, _fromConnection },
+          _args,
+          { partnerListPublicationLoader }
+        ) => {
+          if (!partnerListPublicationLoader) return null
+
+          // A PartnerList has at most one publication (Gravity enforces
+          // uniqueness on partner_list_id), and there's no Gravity endpoint to
+          // fetch publications for many lists at once — resolving this per
+          // node in partnerListsConnection would be an N+1 (one Gravity call
+          // per row on every page). There's no product need to list
+          // publications in bulk, so instead of batching, this field simply
+          // refuses to resolve when reached that way — see
+          // Partner.partnerListsConnection's resolver, the only place
+          // `_fromConnection` gets set. Every other access path (the single
+          // `partnerList(id:)` lookup, and every PartnerList mutation
+          // payload) is unflagged and resolves normally — inverted this way
+          // on purpose so new single-list return sites don't have to
+          // remember to opt in.
+          if (_fromConnection) return null
+
+          try {
+            return await partnerListPublicationLoader(id)
+          } catch (error) {
+            if (error?.statusCode === 404) return null
+            throw error
+          }
         },
       },
     }

--- a/src/schema/v2/partnerListPublication.ts
+++ b/src/schema/v2/partnerListPublication.ts
@@ -1,0 +1,97 @@
+import { camelCase } from "lodash"
+import { GraphQLBoolean, GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "./object_identification"
+import { date } from "./fields/date"
+
+// Single source of truth for the 8 keys Gravity's
+// VALID_ARTWORK_FIELD_VISIBILITY_KEYS allowlist accepts (snake_case, as
+// stored). Both ArtworkFieldVisibilityType below (read) and
+// ArtworkFieldVisibilityInputType (write, in
+// publishPartnerListPublicationMutation) are generated from this list. Keep
+// it in sync with Gravity's PartnerListPublicationsEndpoint.
+export const ARTWORK_FIELD_VISIBILITY_KEYS = [
+  "artist_name",
+  "artwork_title",
+  "year",
+  "medium",
+  "dimensions",
+  "price",
+  "availability",
+  "edition_info",
+] as const
+
+// Gravity stores each value as either a real boolean or the literal string
+// "true"/"false" (an untyped Grape Hash param isn't coerced for nested keys —
+// see PartnerListPublicationArtwork#field_visible? on the Gravity side, which
+// casts the same way via ActiveModel::Type::Boolean). Plain JS truthiness
+// would treat the string "false" as visible, so cast explicitly here too.
+const castVisibility = (value: unknown): boolean | null => {
+  if (value === undefined || value === null) return null
+  if (typeof value === "boolean") return value
+  return String(value).toLowerCase() === "true"
+}
+
+export const ArtworkFieldVisibilityType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ArtworkFieldVisibility",
+  fields: () =>
+    Object.fromEntries(
+      ARTWORK_FIELD_VISIBILITY_KEYS.map((key) => [
+        camelCase(key),
+        {
+          type: GraphQLBoolean,
+          resolve: (visibility: Record<string, unknown>) =>
+            castVisibility(visibility[key]),
+        },
+      ])
+    ),
+})
+
+export const PartnerListPublicationType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PartnerListPublication",
+  fields: () => ({
+    ...InternalIDFields,
+    partnerListID: {
+      type: GraphQLString,
+      resolve: ({ partner_list_id }) => partner_list_id,
+    },
+    published: {
+      type: GraphQLBoolean,
+    },
+    publishedAt: date(({ published_at }) => published_at),
+    lastPublishedAt: date(({ last_published_at }) => last_published_at),
+    description: {
+      type: GraphQLString,
+    },
+    slug: {
+      type: GraphQLString,
+    },
+    href: {
+      type: GraphQLString,
+      description: "Public-facing path for this private viewing room.",
+      resolve: ({ slug }) => (slug ? `/private-viewing-room/${slug}` : null),
+    },
+    artworkFieldVisibility: {
+      type: ArtworkFieldVisibilityType,
+      description:
+        "Per-field visibility toggles for artworks in the room. Any key the gallery hasn't set is null.",
+      resolve: ({ artwork_field_visibility }) => artwork_field_visibility,
+    },
+    applyBrand: {
+      type: GraphQLBoolean,
+      resolve: ({ apply_brand }) => apply_brand,
+    },
+    passwordProtected: {
+      type: GraphQLBoolean,
+      resolve: ({ password_protected }) => password_protected,
+    },
+    createdAt: date(),
+    updatedAt: date(),
+  }),
+})

--- a/src/schema/v2/privateViewingRoom.ts
+++ b/src/schema/v2/privateViewingRoom.ts
@@ -1,0 +1,105 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { BrandKitType } from "./partner/brandKit"
+import { PrivateViewingRoomArtworkType } from "./privateViewingRoomArtwork"
+
+// Shared by PrivateViewingRoomType and PrivateViewingRoomContentsType — every
+// field Gravity's room_json actually returns, regardless of whether it's
+// reached via the plain GET (password_required: false branch) or via a
+// successful authenticate. Kept as one field map so the two types can't
+// silently drift apart.
+const contentFields = () => ({
+  galleryName: {
+    type: GraphQLString,
+    resolve: ({ gallery_name }) => gallery_name,
+  },
+  description: {
+    type: GraphQLString,
+  },
+  applyBrand: {
+    type: GraphQLBoolean,
+    resolve: ({ apply_brand }) => apply_brand,
+  },
+  brandKit: {
+    type: BrandKitType,
+    resolve: ({ brand_kit }) => brand_kit,
+  },
+  artworks: {
+    type: new GraphQLList(new GraphQLNonNull(PrivateViewingRoomArtworkType)),
+    resolve: ({ artworks }) => artworks,
+  },
+})
+
+// Backed by Gravity's public, unauthenticated `private_viewing_room/:slug`
+// endpoint (PartnerListPublication + PartnerListPublicationArtwork). Distinct
+// from the pre-existing, unrelated `ViewingRoom` type/model in this schema.
+//
+// Used only by the `privateViewingRoom` query below, where `passwordRequired`
+// has one clear meaning: whether the room is gated at all. Gravity's GET
+// endpoint returns just `{password_required: true}` (no content fields) when
+// it's gated and unauthenticated, or `{password_required: false, ...content}`
+// otherwise — so every content field here is nullable.
+export const PrivateViewingRoomType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PrivateViewingRoom",
+  fields: () => ({
+    passwordRequired: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description: "Whether this room requires a password to view.",
+      // Coerced rather than passed straight through: if Gravity's GET ever
+      // omitted this key on either branch, a bare `undefined` would violate
+      // Boolean! and null the entire privateViewingRoom field — losing
+      // gallery name/description/artworks along with it, not just this flag.
+      resolve: ({ password_required }) => !!password_required,
+    },
+    ...contentFields(),
+  }),
+})
+
+// Returned by authenticatePrivateViewingRoomMutation on success. Deliberately
+// has no `passwordRequired` field: reaching a Success payload only ever
+// happens after Gravity's authenticate endpoint has already confirmed the
+// password, so the field would always be `false` there and add nothing —
+// see the PrivateViewingRoomType doc comment above for the query's version,
+// which does carry real signal.
+export const PrivateViewingRoomContentsType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PrivateViewingRoomContents",
+  fields: contentFields,
+})
+
+export const PrivateViewingRoom: GraphQLFieldConfig<void, ResolverContext> = {
+  type: PrivateViewingRoomType,
+  description:
+    "Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.",
+  args: {
+    slug: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  resolve: async (_root, { slug }, { privateViewingRoomLoader }) => {
+    if (!privateViewingRoomLoader) return null
+
+    try {
+      return await privateViewingRoomLoader(slug)
+    } catch (error) {
+      // A public, slug-addressed lookup: an unknown or unpublished room
+      // should read as "doesn't exist" to the front end, not as a GraphQL
+      // error it has to special-case — same reasoning as
+      // PartnerList.publication's 404 handling.
+      if (error?.statusCode === 404) return null
+      throw error
+    }
+  },
+}

--- a/src/schema/v2/privateViewingRoom/mutations/__tests__/authenticatePrivateViewingRoomMutation.test.ts
+++ b/src/schema/v2/privateViewingRoom/mutations/__tests__/authenticatePrivateViewingRoomMutation.test.ts
@@ -1,0 +1,96 @@
+import gql from "lib/gql"
+import { runQuery } from "schema/v2/test/utils"
+
+describe("AuthenticatePrivateViewingRoomMutation", () => {
+  const mutation = gql`
+    mutation {
+      authenticatePrivateViewingRoom(
+        input: { slug: "some-gallery-for-anna", password: "letmein" }
+      ) {
+        privateViewingRoomOrError {
+          __typename
+          ... on AuthenticatePrivateViewingRoomSuccess {
+            privateViewingRoom {
+              galleryName
+              artworks {
+                artworkID
+              }
+            }
+          }
+          ... on AuthenticatePrivateViewingRoomFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns the room contents on a correct password", async () => {
+    const context = {
+      // Gravity's authenticate endpoint reuses room_json as-is and never
+      // includes a `password_required` key (unlike the plain GET) — omitted
+      // here deliberately to match the real response shape. There's no
+      // corresponding field to assert on either: PrivateViewingRoomContentsType
+      // (this mutation's success payload) doesn't expose passwordRequired at
+      // all, since reaching Success already means the password check passed.
+      authenticatePrivateViewingRoomLoader: jest.fn().mockResolvedValue({
+        gallery_name: "Isabel Croxatto Galeria",
+        artworks: [{ artwork_id: "artwork-1" }],
+      }),
+    }
+
+    const result = await runQuery(mutation, context)
+
+    expect(
+      context.authenticatePrivateViewingRoomLoader
+    ).toHaveBeenCalledWith("some-gallery-for-anna", { password: "letmein" })
+
+    expect(result).toEqual({
+      authenticatePrivateViewingRoom: {
+        privateViewingRoomOrError: {
+          __typename: "AuthenticatePrivateViewingRoomSuccess",
+          privateViewingRoom: {
+            galleryName: "Isabel Croxatto Galeria",
+            artworks: [{ artworkID: "artwork-1" }],
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on an incorrect password", async () => {
+    const context = {
+      authenticatePrivateViewingRoomLoader: jest
+        .fn()
+        .mockRejectedValue({ body: { error: "Incorrect Password" } }),
+    }
+
+    const result = await runQuery(mutation, context)
+
+    expect(result).toEqual({
+      authenticatePrivateViewingRoom: {
+        privateViewingRoomOrError: {
+          __typename: "AuthenticatePrivateViewingRoomFailure",
+          mutationError: {
+            message: "Incorrect Password",
+          },
+        },
+      },
+    })
+  })
+
+  it("throws when the rejection can't be parsed as a Gravity error", async () => {
+    // formatGravityError returns null when the error has no `.body`, isn't an
+    // HTTPError, and doesn't match its legacy " - "-delimited fallback — e.g.
+    // a network failure or a plain JS error thrown before a response exists.
+    const context = {
+      authenticatePrivateViewingRoomLoader: jest
+        .fn()
+        .mockRejectedValue(new Error("socket hang up")),
+    }
+
+    await expect(runQuery(mutation, context)).rejects.toThrow("socket hang up")
+  })
+})

--- a/src/schema/v2/privateViewingRoom/mutations/authenticatePrivateViewingRoomMutation.ts
+++ b/src/schema/v2/privateViewingRoom/mutations/authenticatePrivateViewingRoomMutation.ts
@@ -1,0 +1,88 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PrivateViewingRoomContentsType } from "schema/v2/privateViewingRoom"
+
+interface AuthenticatePrivateViewingRoomMutationInputProps {
+  slug: string
+  password: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AuthenticatePrivateViewingRoomSuccess",
+  isTypeOf: (data) => !data._type,
+  fields: () => ({
+    privateViewingRoom: {
+      type: PrivateViewingRoomContentsType,
+      resolve: (room) => room,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "AuthenticatePrivateViewingRoomFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "AuthenticatePrivateViewingRoomResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const authenticatePrivateViewingRoomMutation = mutationWithClientMutationId<
+  AuthenticatePrivateViewingRoomMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "AuthenticatePrivateViewingRoomMutation",
+  description:
+    "Authenticates against a password-protected private viewing room, returning its contents on success.",
+  inputFields: {
+    slug: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The slug of the private viewing room.",
+    },
+    password: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The room's password.",
+    },
+  },
+  outputFields: {
+    privateViewingRoomOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect password).",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { slug, password },
+    { authenticatePrivateViewingRoomLoader }
+  ) => {
+    try {
+      return await authenticatePrivateViewingRoomLoader(slug, { password })
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/privateViewingRoomArtwork.ts
+++ b/src/schema/v2/privateViewingRoomArtwork.ts
@@ -1,0 +1,80 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import {
+  Money,
+  resolveMinorAndCurrencyFieldsToMoney,
+} from "schema/v2/fields/money"
+
+// A point-in-time snapshot of an artwork as included in a published private
+// viewing room (Gravity's PartnerListPublicationArtwork#visible_json) — not
+// the live Artwork type, since fields here are pinned as of the room's last
+// publish and only include whatever the gallery has toggled visible.
+export const PrivateViewingRoomArtworkType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PrivateViewingRoomArtwork",
+  fields: () => ({
+    artworkID: {
+      type: GraphQLString,
+      resolve: ({ artwork_id }) => artwork_id,
+    },
+    imageURL: {
+      type: GraphQLString,
+      resolve: ({ image_url }) => image_url,
+    },
+    artistName: {
+      type: GraphQLString,
+      resolve: ({ artist_name }) => artist_name,
+    },
+    artworkTitle: {
+      type: GraphQLString,
+      resolve: ({ artwork_title }) => artwork_title,
+    },
+    year: {
+      type: GraphQLString,
+    },
+    medium: {
+      type: GraphQLString,
+    },
+    dimensions: {
+      type: GraphQLString,
+    },
+    priceCents: {
+      type: GraphQLInt,
+      resolve: ({ price_cents }) => price_cents,
+    },
+    priceCurrency: {
+      type: GraphQLString,
+      resolve: ({ price_currency }) => price_currency,
+    },
+    price: {
+      type: Money,
+      description:
+        "The pinned price as a formatted Money object. Null when there's no pinned price " +
+        "or currency (resolveMinorAndCurrencyFieldsToMoney returns null rather than throwing).",
+      resolve: (
+        { price_cents: minor, price_currency: currencyCode },
+        args,
+        context,
+        info
+      ) => {
+        if (minor == null || !currencyCode) return null
+
+        return resolveMinorAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          args,
+          context,
+          info
+        )
+      },
+    },
+    availability: {
+      type: GraphQLString,
+    },
+    editionInfo: {
+      type: GraphQLString,
+      resolve: ({ edition_info }) => edition_info,
+    },
+  }),
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -322,6 +322,9 @@ import { bulkDeleteArtworksFromPartnerListMutation } from "./partner/Mutations/P
 import { moveArtworksBetweenPartnerListsMutation } from "./partner/Mutations/PartnerList/moveArtworksBetweenPartnerListsMutation"
 import { updatePartnerListArtworkPositionMutation } from "./partner/Mutations/PartnerList/updatePartnerListArtworkPositionMutation"
 import { repositionPartnerListArtworksMutation } from "./partner/Mutations/PartnerList/repositionPartnerListArtworksMutation"
+import { publishPartnerListPublicationMutation } from "./partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation"
+import { unpublishPartnerListPublicationMutation } from "./partner/Mutations/PartnerListPublication/unpublishPartnerListPublicationMutation"
+import { authenticatePrivateViewingRoomMutation } from "./privateViewingRoom/mutations/authenticatePrivateViewingRoomMutation"
 import { createShippingPresetMutation } from "./ShippingPreset/createShippingPresetMutation"
 import { updateShippingPresetMutation } from "./ShippingPreset/updateShippingPresetMutation"
 import { deleteShippingPresetMutation } from "./ShippingPreset/deleteShippingPresetMutation"
@@ -342,6 +345,7 @@ import { PrincipalFieldDirective } from "directives/principalField/principalFiel
 import { commerceOptInMutation } from "./partner/CommerceOptIn/commerceOptInMutation"
 import { commerceOptInReportMutation } from "./partner/CommerceOptIn/commerceOptInReportMutation"
 import { ViewingRoom } from "./viewingRoom"
+import { PrivateViewingRoom } from "./privateViewingRoom"
 import { ViewingRoomsConnection } from "./viewingRoomConnection"
 import { Invoice } from "./Invoice/invoice"
 import { createInvoicePaymentMutation } from "./Invoice/createInvoicePaymentMutation"
@@ -556,6 +560,7 @@ const rootFields = {
   partnerShowDocumentsConnection: PartnerShowDocumentsConnection,
   phoneNumber: PhoneNumber,
   previewSavedSearch: PreviewSavedSearchField,
+  privateViewingRoom: PrivateViewingRoom,
   profile: Profile,
   profilesConnection: Profiles,
   purchase: Purchase,
@@ -684,6 +689,9 @@ export default new GraphQLSchema({
       deleteBrandKit: deleteBrandKitMutation,
       updateBrandKitLogo: updateBrandKitLogoMutation,
       deleteBrandKitLogo: deleteBrandKitLogoMutation,
+      publishPartnerListPublication: publishPartnerListPublicationMutation,
+      unpublishPartnerListPublication: unpublishPartnerListPublicationMutation,
+      authenticatePrivateViewingRoom: authenticatePrivateViewingRoomMutation,
       createPurchase: createPurchaseMutation,
       createSaleAgreement: CreateSaleAgreementMutation,
       createSmsSecondFactor: createSmsSecondFactorMutation,


### PR DESCRIPTION
Rely on https://github.com/artsy/gravity/pull/20415

Add queries and mutations to expose the new API endpoints added on Gravity to allow users to manage and access Private Viewing Rooms in OS

Queries and Mutations:

<details>
<summary>partnerListPublication</summary>

```graphql
query  {
   partner(id: <partner-id>) {
     partnerList(id: <list-id>) {
     listType
     publication {
       internalID
       published
       passwordProtected
       slug
       href
       description
      }
    }
  }
}
```
</details>

<details>
<summary>publishPartnerListPublication</summary>

```graphql
mutation {
 publishPartnerListPublication(
   input: {
     partnerListID: "021e0559-86b7-4d93-bf56-b5db06322b7c"
     description: "My description here"
     applyBrand: true
     artworkFieldVisibility: {
       artistName: true,
       artworkTitle: true,
       price: true,
       medium: true,
       availability: true,
     },
     password: "123456"
   }
  ) {
    partnerListPublicationOrError {
      __typename
      ... on PublishPartnerListPublicationSuccess {
        partnerListPublication {
          internalID
          published
          description
          applyBrand
          passwordProtected
        }
      }
      ... on PublishPartnerListPublicationFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```
</details>

<details>
<summary>unpublishPartnerListPublication</summary>

```graphql
mutation {
  unpublishPartnerListPublication(input: { partnerListID: "021e0559-86b7-4d93-bf56-b5db06322b7c" }) {
    partnerListPublicationOrError {
      __typename
      ... on UnpublishPartnerListPublicationSuccess {
        partnerListPublication {
          internalID
          published
        }
      }
      ... on UnpublishPartnerListPublicationFailure {
        mutationError {
        message
      }
     }
    }
  }
}
```
</details>

<details>
<summary>privateViewingRoom</summary>

```graphql
query {
  privateViewingRoom(slug: "commerce-test-partner-vr-testing") {
    passwordRequired
    galleryName
    description
    applyBrand
    brandKit {
      textColor
    }
    artworks {
      artworkID
      artworkTitle
      artistName
      medium
      price {
        display
      }
      availability
    }
  }
}
```
</details>

<details>
<summary>authenticatePrivateViewingRoom</summary>

```graphql
mutation {
  authenticatePrivateViewingRoom(
    input: { slug: "rogallery-private-vr-testing", password: "123456" }
  ) {
    privateViewingRoomOrError {
      __typename
      ... on AuthenticatePrivateViewingRoomSuccess {
        privateViewingRoom {
          galleryName
          artworks {
            artworkID
            imageURL
            artworkTitle
            artistName
            price {
              display
            }
            availability
          }
        }
      }
      ... on AuthenticatePrivateViewingRoomFailure {
        mutationError {
          message
        }
      }
   }
  }
}
```
</details>

All the queries and mutations examples above were also added to the [Tech Discovery doc](https://app.notion.com/p/artsy/Technical-discovery-3b2cab0764a08074b423ec44dcc02f3d#3b3cab0764a0800b8f80e53e395c147b) in Notion, se we can use as reference during development in Volt.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 