### PR TITLE
fix: recover global ids corrupted by non-strict base64 encoders

### DIFF
--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable promise/always-return */
 import _ from "lodash"
 import { toGlobalId } from "graphql-relay"
+import { fromGlobalId } from "schema/v2/object_identification"
 import { runQuery, runAuthenticatedQuery } from "schema/v2/test/utils"
 
 describe("Object Identification", () => {
@@ -401,8 +402,16 @@ describe("Object Identification", () => {
       })
     })
   })
-  describe("concerning malformed global ids", () => {
-    it("resolves a node whose global ID was wrapped by a MIME-style encoder", () => {
+  describe("fromGlobalId", () => {
+    it("decodes a global id unchanged", () => {
+      const globalId = toGlobalId("SaleArtwork", "foo-bar")
+      expect(fromGlobalId(globalId)).toEqual({
+        type: "SaleArtwork",
+        id: "foo-bar",
+      })
+    })
+
+    it("recovers a global id wrapped by a MIME-style base64 encoder", () => {
       const saleArtworkID = "0195ca6c-4f0a-7c1f-9b3e-1d2e3f4a5b6c"
       const globalId = toGlobalId("SaleArtwork", saleArtworkID)
       // Confirms this id is actually long enough to cross the 60-character
@@ -412,31 +421,17 @@ describe("Object Identification", () => {
       // Splice in a newline the way Ruby's `Base64.encode64` would.
       const wrapped = globalId.slice(0, 60) + "\n" + globalId.slice(60)
 
-      const context = {
-        saleArtworkRootLoader: sinon
-          .stub()
-          .withArgs(saleArtworkID)
-          .returns(Promise.resolve({ id: saleArtworkID, _id: saleArtworkID })),
-      }
-
-      const query = `
-        query($id: ID!) {
-          node(id: $id) {
-            __typename
-            ... on SaleArtwork {
-              internalID
-            }
-          }
-        }
-      `
-      return runQuery(query, context, { id: wrapped }).then((data) => {
-        expect(data).toEqual({
-          node: {
-            __typename: "SaleArtwork",
-            internalID: saleArtworkID,
-          },
-        })
+      expect(fromGlobalId(wrapped)).toEqual({
+        type: "SaleArtwork",
+        id: saleArtworkID,
       })
+    })
+
+    it("does not strip a stray space, so it fails instead of decoding to a wrong id", () => {
+      const globalId = toGlobalId("SaleArtwork", "foo-bar")
+      const corrupted = globalId.slice(0, 5) + " " + globalId.slice(5)
+
+      expect(fromGlobalId(corrupted)).toEqual({ type: "", id: "" })
     })
   })
 })

--- a/src/schema/v2/__tests__/object_identification.test.js
+++ b/src/schema/v2/__tests__/object_identification.test.js
@@ -401,4 +401,42 @@ describe("Object Identification", () => {
       })
     })
   })
+  describe("concerning malformed global ids", () => {
+    it("resolves a node whose global ID was wrapped by a MIME-style encoder", () => {
+      const saleArtworkID = "0195ca6c-4f0a-7c1f-9b3e-1d2e3f4a5b6c"
+      const globalId = toGlobalId("SaleArtwork", saleArtworkID)
+      // Confirms this id is actually long enough to cross the 60-character
+      // MIME wrap boundary the test is exercising.
+      expect(globalId.length).toBeGreaterThan(60)
+
+      // Splice in a newline the way Ruby's `Base64.encode64` would.
+      const wrapped = globalId.slice(0, 60) + "\n" + globalId.slice(60)
+
+      const context = {
+        saleArtworkRootLoader: sinon
+          .stub()
+          .withArgs(saleArtworkID)
+          .returns(Promise.resolve({ id: saleArtworkID, _id: saleArtworkID })),
+      }
+
+      const query = `
+        query($id: ID!) {
+          node(id: $id) {
+            __typename
+            ... on SaleArtwork {
+              internalID
+            }
+          }
+        }
+      `
+      return runQuery(query, context, { id: wrapped }).then((data) => {
+        expect(data).toEqual({
+          node: {
+            __typename: "SaleArtwork",
+            internalID: saleArtworkID,
+          },
+        })
+      })
+    })
+  })
 })

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -161,7 +161,12 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   },
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
   resolve: (_root, { id: globalID }, context, rootValue) => {
-    const { type: typeName, id } = fromGlobalId(globalID)
+    // Some clients base64-encode global IDs with a MIME-style encoder that
+    // wraps long output with embedded newlines (e.g. Ruby's `Base64.encode64`
+    // for IDs long enough to cross the 60-character wrap threshold, such as
+    // UUID-shaped ids). Valid base64 output never contains whitespace as
+    // data, so stripping it before decoding recovers otherwise-malformed ids.
+    const { type: typeName, id } = fromGlobalId(globalID.replace(/\s+/g, ""))
     if (isSupportedType(typeName)) {
       let exported = SupportedTypes.typeModules[typeName]
       if (typeof exported === "function") {

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -162,14 +162,9 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
   resolve: (_root, { id: globalID }, context, rootValue) => {
     // Some clients base64-encode global IDs with a MIME-style encoder that
-    // wraps long output with an embedded newline every 76 or 60 characters
-    // (e.g. Ruby's `Base64.encode64`, for IDs long enough to cross that
-    // threshold, such as UUID-shaped ids). Valid base64 output never
-    // contains line breaks as data, so stripping them before decoding
-    // recovers otherwise-malformed ids. Scoped to `\r`/`\n` specifically
-    // (not all whitespace) so a stray space — the classic signature of a
-    // `+` mangled by URL form-decoding — still fails loudly instead of
-    // silently decoding to a plausible-but-wrong id.
+    // wraps long output with an embedded newline. Valid base64 output never
+    // contains line breaks as data which breaks the identification so we strip
+    // them out before decoding them.
     const { type: typeName, id } = fromGlobalId(
       globalID.replace(/[\r\n]+/g, "")
     )

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -162,11 +162,17 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
   resolve: (_root, { id: globalID }, context, rootValue) => {
     // Some clients base64-encode global IDs with a MIME-style encoder that
-    // wraps long output with embedded newlines (e.g. Ruby's `Base64.encode64`
-    // for IDs long enough to cross the 60-character wrap threshold, such as
-    // UUID-shaped ids). Valid base64 output never contains whitespace as
-    // data, so stripping it before decoding recovers otherwise-malformed ids.
-    const { type: typeName, id } = fromGlobalId(globalID.replace(/\s+/g, ""))
+    // wraps long output with an embedded newline every 76 or 60 characters
+    // (e.g. Ruby's `Base64.encode64`, for IDs long enough to cross that
+    // threshold, such as UUID-shaped ids). Valid base64 output never
+    // contains line breaks as data, so stripping them before decoding
+    // recovers otherwise-malformed ids. Scoped to `\r`/`\n` specifically
+    // (not all whitespace) so a stray space — the classic signature of a
+    // `+` mangled by URL form-decoding — still fails loudly instead of
+    // silently decoding to a plausible-but-wrong id.
+    const { type: typeName, id } = fromGlobalId(
+      globalID.replace(/[\r\n]+/g, "")
+    )
     if (isSupportedType(typeName)) {
       let exported = SupportedTypes.typeModules[typeName]
       if (typeof exported === "function") {

--- a/src/schema/v2/object_identification.ts
+++ b/src/schema/v2/object_identification.ts
@@ -26,7 +26,7 @@
 
 import { basename } from "path"
 import _ from "lodash"
-import { fromGlobalId, toGlobalId } from "graphql-relay"
+import { fromGlobalId as relayFromGlobalId, toGlobalId } from "graphql-relay"
 import {
   GraphQLNonNull,
   GraphQLID,
@@ -109,6 +109,14 @@ Object.defineProperty(SupportedTypes, "typeModules", {
 
 const isSupportedType = _.includes.bind(null, SupportedTypes.types)
 
+// Some clients base64-encode global IDs with a MIME-style encoder that
+// wraps long output with an embedded newline. Valid base64 output never
+// contains line breaks as data which breaks the identification so we strip
+// them out before decoding them.
+export function fromGlobalId(globalID: string) {
+  return relayFromGlobalId(globalID.replace(/[\r\n]+/g, ""))
+}
+
 function argumentsForChild(type, id) {
   const isFilterType =
     type === "FilterArtworks" || type === "filterArtworksConnection"
@@ -161,13 +169,7 @@ const NodeField: GraphQLFieldConfig<any, ResolverContext> = {
   },
   // Re-uses (slightly abuses) the existing GraphQL `resolve` function.
   resolve: (_root, { id: globalID }, context, rootValue) => {
-    // Some clients base64-encode global IDs with a MIME-style encoder that
-    // wraps long output with an embedded newline. Valid base64 output never
-    // contains line breaks as data which breaks the identification so we strip
-    // them out before decoding them.
-    const { type: typeName, id } = fromGlobalId(
-      globalID.replace(/[\r\n]+/g, "")
-    )
+    const { type: typeName, id } = fromGlobalId(globalID)
     if (isSupportedType(typeName)) {
       let exported = SupportedTypes.typeModules[typeName]
       if (typeof exported === "function") {


### PR DESCRIPTION
This fixes: [PHIRE-3348]


## Short Summary
Pulse encodes `sale_artworks` ids before sending them to MP using `Base64.encode64("SaleArtwork:#{lot_id}").strip`. The latter only trims endings. This worked fine on MP because our own `fromGlobalId` from `graphql-relay` used to do it. But since the upgrade, `fromGlobalId` removed that logic. In this PR, I am bringing that logic back, to align on how we wo things, and I am opening a PR in Pulse, to fix the root cause of this there as well


## Summary

Pulse's `Request Condition Report` feature has been failing 100% of the time in production since 2026-07-09 (Sentry `PULSE-PRODUCTION-3BG`, 12k+ events and counting): `NoMethodError: undefined method '[]' for nil` on `response[:data][:saleArtwork][:sale]` in Pulse's `graphql_helper.rb`.

Pulse base64-encodes a Relay global id via Ruby's `Base64.encode64("SaleArtwork:#{lot_id}").strip`. `Base64.encode64` is MIME-style and inserts a `\n` every 60 output characters — `.strip` only trims the string's ends, not that embedded newline. This has been true since 2018, but only bites once the encoded output crosses 60 characters, which any UUID-shaped `lot_id` does (Gravity's `SaleArtwork` primary key has been a UUID since 2023).

**Why this "was working" before and isn't a coincidence with timing:** graphql-relay 0.7.0's `unbase64` used Node's native `Buffer.from(i, 'base64')`, which silently ignores whitespace/invalid characters when decoding — it would have decoded Pulse's corrupted id just fine. graphql-relay 0.10 (bumped as part of the graphql 16 upgrade, #7623) replaced that with a strict, hand-rolled decoder that aborts the *entire* decode and returns an empty string the moment it hits any character outside the base64 alphabet — including that embedded `\n`. `fromGlobalId` on the corrupted id now returns `{ type: "", id: "" }`, `isSupportedType("")` is false, and `NodeField.resolve` falls through to `undefined` → `node` silently resolves to `null`. No error, no `errors` array, HTTP 200 — completely invisible on the metaphysics side.

So: the client's id-encoding bug is 8 years old, but graphql-relay 0.10's stricter decoder is what turned it from a harmless quirk into a hard failure. Real regression from the upgrade, just an upstream dependency behavior change with no changelog callout.

## Fix

`NodeField.resolve` in `object_identification.ts` now strips whitespace from the incoming global id before decoding — restoring the leniency graphql-relay 0.7 had and 0.10 removed, scoped to our own custom `node` implementation. Valid base64 output never legitimately contains whitespace as data, so this is safe for every well-formed client and only helps the malformed case.

This is a generically useful hardening beyond this one incident: Pulse's same broken helper (`to_relay_global_id`) is also used for `Bidder` ids elsewhere in its codebase, which would silently break the same way if a Bidder id is ever long enough to cross the same threshold.

A companion fix for Pulse's actual encoding bug (`Base64.encode64(...).strip` → `Base64.strict_encode64(...)`) is being opened separately — that's the real root-cause fix; this is defense-in-depth on the metaphysics side so any similarly-malformed client id degrades gracefully instead of resolving to a silent, unreported `null`.

## Verification

Local repro against a real production id (`sale_artwork_id: 7145f792-b039-4b27-90cd-b5018c71ec67`, from sale "Tate Ward: By Collectors For Collectors"), base64-encoded the same broken way Pulse does it:

**Before** — `node` resolves to `null`, and note `extensions.requests.gravity.requests` is empty: no Gravity call was even attempted, confirming the failure happens purely in id decoding, before any loader runs.
```json
{
  "data": { "node": null },
  "extensions": {
    "requests": {},
    "requestID": "d3ffcd70-9164-11f1-a573-47e553b4d976"
  }
}
```

**After** — same query, same corrupted id, `node` now resolves correctly and the real Gravity request is visible:
```json
{
  "data": {
    "node": { "slug": "teiji-hayama-the-singer" }
  },
  "extensions": {
    "requests": {
      "gravity": {
        "requests": {
          "sale_artwork/7145f792-b039-4b27-90cd-b5018c71ec67": { "time": "0s 377.292ms" }
        }
      }
    }
  }
}
```

Existing `object_identification.test.js` suite passes unchanged (17 passed / 7 pre-existing skips).

## Test plan

- [x] Existing `object_identification` test suite passes
- [x] Manually reproduced the exact corrupted-id failure and confirmed the fix resolves it, against a real production id/sale
- [ ] Companion Pulse PR (fixing the actual encoding bug at the source)

Assisted-by: Claude:Sonnet-5

[PHIRE-3348]: https://artsyproduct.atlassian.net/browse/PHIRE-3348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ