### PR TITLE
chore: Expose passcode for Private Viewing Rooms query and mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -6902,9 +6902,9 @@ input AuthenticatePrivateViewingRoomMutationInput {
   clientMutationId: String
 
   """
-  The room's password.
+  The room's passcode.
   """
-  password: String!
+  passcode: String!
 
   """
   The slug of the private viewing room.
@@ -6916,7 +6916,7 @@ type AuthenticatePrivateViewingRoomMutationPayload {
   clientMutationId: String
 
   """
-  On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect password).
+  On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect passcode).
   """
   privateViewingRoomOrError: AuthenticatePrivateViewingRoomResponseOrError
 }
@@ -25282,7 +25282,7 @@ type Mutation {
   ): AssignArtistToPartnerMutationPayload
 
   """
-  Authenticates against a password-protected private viewing room, returning its contents on success.
+  Authenticates against a passcode-protected private viewing room, returning its contents on success.
   """
   authenticatePrivateViewingRoom(
     input: AuthenticatePrivateViewingRoomMutationInput!
@@ -30491,7 +30491,12 @@ type PartnerListPublication {
     timezone: String
   ): String
   partnerListID: String
-  passwordProtected: Boolean
+
+  """
+  Plain-text passcode gating this room, if one is set.
+  """
+  passcode: String
+  passcodeProtected: Boolean
   published: Boolean
   publishedAt(
     format: String
@@ -31350,9 +31355,9 @@ type PrivateViewingRoom {
   galleryName: String
 
   """
-  Whether this room requires a password to view.
+  Whether this room requires a passcode to view.
   """
-  passwordRequired: Boolean!
+  passcodeRequired: Boolean!
 }
 
 type PrivateViewingRoomArtwork {
@@ -31520,9 +31525,9 @@ input PublishPartnerListPublicationMutationInput {
   partnerListID: String!
 
   """
-  Password to gate the room. Pass an empty string to clear a previously set password.
+  Passcode to gate the room. Pass an empty string to clear a previously set passcode.
   """
-  password: String
+  passcode: String
 }
 
 type PublishPartnerListPublicationMutationPayload {
@@ -33601,7 +33606,7 @@ type Query {
   ): PriceInsightConnection
 
   """
-  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
+  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a passcode is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
   """
   privateViewingRoom(slug: String!): PrivateViewingRoom
 
@@ -43148,7 +43153,7 @@ type Viewer {
   ): PreviewSavedSearch
 
   """
-  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
+  Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a passcode is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.
   """
   privateViewingRoom(slug: String!): PrivateViewingRoom
 

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -379,7 +379,7 @@ export default (opts) => {
     viewingRoomsLoader: gravityLoader("viewing_rooms", {}, { headers: true }),
 
     // Private Viewing Room Loaders
-    // Uncached: publish state (and password_required) can flip between requests,
+    // Uncached: publish state (and passcode_required) can flip between requests,
     // and gravityLoader would otherwise cache a stale 404/response shape.
     privateViewingRoomLoader: gravityUncachedLoader(
       (slug) => `private_viewing_room/${slug}`

--- a/src/schema/v2/__tests__/partnerListPublication.test.ts
+++ b/src/schema/v2/__tests__/partnerListPublication.test.ts
@@ -9,7 +9,8 @@ describe("PartnerList.publication", () => {
           publication {
             internalID
             published
-            passwordProtected
+            passcodeProtected
+            passcode
             slug
             href
             description
@@ -27,7 +28,8 @@ describe("PartnerList.publication", () => {
         id: "pub-1",
         partner_list_id: "list-abc",
         published: true,
-        password_protected: false,
+        passcode_protected: true,
+        passcode: "letmein",
         slug: "some-gallery-for-anna",
         description: "For Anna",
       }),
@@ -41,7 +43,8 @@ describe("PartnerList.publication", () => {
     expect(result.partner.partnerList.publication).toEqual({
       internalID: "pub-1",
       published: true,
-      passwordProtected: false,
+      passcodeProtected: true,
+      passcode: "letmein",
       slug: "some-gallery-for-anna",
       href: "/private-viewing-room/some-gallery-for-anna",
       description: "For Anna",

--- a/src/schema/v2/__tests__/privateViewingRoom.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoom.test.ts
@@ -5,7 +5,7 @@ describe("PrivateViewingRoom", () => {
   const query = gql`
     {
       privateViewingRoom(slug: "some-gallery-for-anna") {
-        passwordRequired
+        passcodeRequired
         galleryName
         description
         applyBrand
@@ -21,11 +21,11 @@ describe("PrivateViewingRoom", () => {
     }
   `
 
-  it("returns password_required: true without room contents", async () => {
+  it("returns passcode_required: true without room contents", async () => {
     const context = {
       privateViewingRoomLoader: jest
         .fn()
-        .mockResolvedValue({ password_required: true }),
+        .mockResolvedValue({ passcode_required: true }),
     }
 
     const result = await runQuery(query, context)
@@ -34,7 +34,7 @@ describe("PrivateViewingRoom", () => {
       "some-gallery-for-anna"
     )
     expect(result.privateViewingRoom).toEqual({
-      passwordRequired: true,
+      passcodeRequired: true,
       galleryName: null,
       description: null,
       applyBrand: null,
@@ -43,10 +43,10 @@ describe("PrivateViewingRoom", () => {
     })
   })
 
-  it("returns room contents when no password is required", async () => {
+  it("returns room contents when no passcode is required", async () => {
     const context = {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
-        password_required: false,
+        passcode_required: false,
         gallery_name: "Isabel Croxatto Galeria",
         description: "For Anna",
         apply_brand: true,
@@ -64,7 +64,7 @@ describe("PrivateViewingRoom", () => {
     const result = await runQuery(query, context)
 
     expect(result.privateViewingRoom).toEqual({
-      passwordRequired: false,
+      passcodeRequired: false,
       galleryName: "Isabel Croxatto Galeria",
       description: "For Anna",
       applyBrand: true,
@@ -101,8 +101,8 @@ describe("PrivateViewingRoom", () => {
     await expect(runQuery(query, context)).rejects.toThrow()
   })
 
-  it("coerces a missing password_required to false rather than nulling the whole room", async () => {
-    // Regression guard: passwordRequired is Boolean!, so if Gravity's GET
+  it("coerces a missing passcode_required to false rather than nulling the whole room", async () => {
+    // Regression guard: passcodeRequired is Boolean!, so if Gravity's GET
     // ever omitted this key on either branch, a bare pass-through would
     // violate the non-null constraint and null out the entire
     // privateViewingRoom field — losing gallery name/artworks along with it.
@@ -115,7 +115,7 @@ describe("PrivateViewingRoom", () => {
 
     const result = await runQuery(query, context)
 
-    expect(result.privateViewingRoom.passwordRequired).toBe(false)
+    expect(result.privateViewingRoom.passcodeRequired).toBe(false)
     expect(result.privateViewingRoom.galleryName).toEqual(
       "Isabel Croxatto Galeria"
     )

--- a/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
@@ -22,7 +22,7 @@ describe("PrivateViewingRoomArtwork.price", () => {
   it("formats the pinned price as Money", async () => {
     const context = {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
-        password_required: false,
+        passcode_required: false,
         artworks: [
           {
             artwork_id: "artwork-1",
@@ -50,7 +50,7 @@ describe("PrivateViewingRoomArtwork.price", () => {
   it("returns null price when there is no pinned price", async () => {
     const context = {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
-        password_required: false,
+        passcode_required: false,
         artworks: [{ artwork_id: "artwork-1" }],
       }),
     }
@@ -63,7 +63,7 @@ describe("PrivateViewingRoomArtwork.price", () => {
   it("returns null price when there's a pinned price but no currency", async () => {
     const context = {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
-        password_required: false,
+        passcode_required: false,
         artworks: [{ artwork_id: "artwork-1", price_cents: 500000 }],
       }),
     }
@@ -79,7 +79,7 @@ describe("PrivateViewingRoomArtwork.price", () => {
     // divided by 100, which is only correct for currencies like USD.
     const context = {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
-        password_required: false,
+        passcode_required: false,
         artworks: [
           {
             artwork_id: "artwork-1",

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
@@ -20,7 +20,7 @@ describe("PublishPartnerListPublicationMutation", () => {
               published
               description
               applyBrand
-              passwordProtected
+              passcodeProtected
             }
           }
           ... on PublishPartnerListPublicationFailure {
@@ -41,7 +41,7 @@ describe("PublishPartnerListPublicationMutation", () => {
         published: true,
         description: "For Anna",
         apply_brand: true,
-        password_protected: false,
+        passcode_protected: false,
       }),
     }
 
@@ -68,7 +68,7 @@ describe("PublishPartnerListPublicationMutation", () => {
             published: true,
             description: "For Anna",
             applyBrand: true,
-            passwordProtected: false,
+            passcodeProtected: false,
           },
         },
       },
@@ -104,17 +104,18 @@ describe("PublishPartnerListPublicationMutation", () => {
     ).rejects.toThrow("You need to be signed in to perform this action")
   })
 
-  it("sets a password", async () => {
-    const withPassword = gql`
+  it("sets a passcode", async () => {
+    const withPasscode = gql`
       mutation {
         publishPartnerListPublication(
-          input: { partnerListID: "list-abc", password: "letmein" }
+          input: { partnerListID: "list-abc", passcode: "letmein" }
         ) {
           partnerListPublicationOrError {
             __typename
             ... on PublishPartnerListPublicationSuccess {
               partnerListPublication {
-                passwordProtected
+                passcodeProtected
+                passcode
               }
             }
           }
@@ -124,37 +125,42 @@ describe("PublishPartnerListPublicationMutation", () => {
     const context = {
       publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
         id: "pub-1",
-        password_protected: true,
+        passcode_protected: true,
+        passcode: "letmein",
       }),
     }
 
-    const result = await runAuthenticatedQuery(withPassword, context)
+    const result = await runAuthenticatedQuery(withPasscode, context)
 
     expect(
       context.publishPartnerListPublicationLoader
-    ).toHaveBeenCalledWith("list-abc", { password: "letmein" })
+    ).toHaveBeenCalledWith("list-abc", { passcode: "letmein" })
     expect(
       result.publishPartnerListPublication.partnerListPublicationOrError
-        .partnerListPublication.passwordProtected
+        .partnerListPublication.passcodeProtected
     ).toBe(true)
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication.passcode
+    ).toBe("letmein")
   })
 
-  it("passes an empty string through when clearing a password", async () => {
-    // Regression guard: `password: ""` must reach the loader as "" (not be
-    // dropped), since that's what signals "clear the password" — the query
+  it("passes an empty string through when clearing a passcode", async () => {
+    // Regression guard: `passcode: ""` must reach the loader as "" (not be
+    // dropped), since that's what signals "clear the passcode" — the query
     // string round trip further down in lib/apis/fetch.ts is what turns it
     // into a `null` on the wire, which is out of scope for this mutation to
     // guard against; this test only proves the mutation itself forwards it.
-    const clearPassword = gql`
+    const clearPasscode = gql`
       mutation {
         publishPartnerListPublication(
-          input: { partnerListID: "list-abc", password: "" }
+          input: { partnerListID: "list-abc", passcode: "" }
         ) {
           partnerListPublicationOrError {
             __typename
             ... on PublishPartnerListPublicationSuccess {
               partnerListPublication {
-                passwordProtected
+                passcodeProtected
               }
             }
           }
@@ -164,15 +170,15 @@ describe("PublishPartnerListPublicationMutation", () => {
     const context = {
       publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
         id: "pub-1",
-        password_protected: false,
+        passcode_protected: false,
       }),
     }
 
-    await runAuthenticatedQuery(clearPassword, context)
+    await runAuthenticatedQuery(clearPasscode, context)
 
     expect(
       context.publishPartnerListPublicationLoader
-    ).toHaveBeenCalledWith("list-abc", { password: "" })
+    ).toHaveBeenCalledWith("list-abc", { passcode: "" })
   })
 
   it("omits artwork_field_visibility entirely when not provided", async () => {

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
@@ -33,7 +33,7 @@ const ArtworkFieldVisibilityInputType = new GraphQLInputObjectType({
 
 interface PublishPartnerListPublicationMutationInputProps {
   partnerListID: string
-  password?: string
+  passcode?: string
   description?: string
   applyBrand?: boolean
   artworkFieldVisibility?: Record<string, boolean>
@@ -79,10 +79,10 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
       type: new GraphQLNonNull(GraphQLString),
       description: "The ID of the partner list to publish as a viewing room.",
     },
-    password: {
+    passcode: {
       type: GraphQLString,
       description:
-        "Password to gate the room. Pass an empty string to clear a previously set password.",
+        "Passcode to gate the room. Pass an empty string to clear a previously set passcode.",
     },
     description: {
       type: GraphQLString,
@@ -108,7 +108,7 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
   mutateAndGetPayload: async (
     {
       partnerListID,
-      password,
+      passcode,
       description,
       applyBrand,
       artworkFieldVisibility,
@@ -121,13 +121,13 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
 
     const gravityArgs: Record<string, unknown> = {}
 
-    // password: "" is intentional here, not a bug — it's how a client clears
-    // a previously-set password. The loader layer's query-string round trip
+    // passcode: "" is intentional here, not a bug — it's how a client clears
+    // a previously-set passcode. The loader layer's query-string round trip
     // (lib/apis/fetch.ts `constructUrlAndParams`) rewrites an empty string to
-    // `null` before it reaches Gravity, and Gravity's own `password=` setter
-    // treats `nil` (via `new_password.presence`) as "clear the digest" — so
-    // an empty string here and an explicit `null` arrive at the same place.
-    if (password !== undefined) gravityArgs.password = password
+    // `null` before it reaches Gravity, and Gravity's own `passcode=` setter
+    // treats `nil` (via `new_passcode.presence`) as "clear it" — so an empty
+    // string here and an explicit `null` arrive at the same place.
+    if (passcode !== undefined) gravityArgs.passcode = passcode
     if (description !== undefined) gravityArgs.description = description
     if (applyBrand !== undefined) gravityArgs.apply_brand = applyBrand
     if (artworkFieldVisibility !== undefined) {

--- a/src/schema/v2/partnerListPublication.ts
+++ b/src/schema/v2/partnerListPublication.ts
@@ -87,9 +87,13 @@ export const PartnerListPublicationType = new GraphQLObjectType<
       type: GraphQLBoolean,
       resolve: ({ apply_brand }) => apply_brand,
     },
-    passwordProtected: {
+    passcodeProtected: {
       type: GraphQLBoolean,
-      resolve: ({ password_protected }) => password_protected,
+      resolve: ({ passcode_protected }) => passcode_protected,
+    },
+    passcode: {
+      type: GraphQLString,
+      description: "Plain-text passcode gating this room, if one is set.",
     },
     createdAt: date(),
     updatedAt: date(),

--- a/src/schema/v2/privateViewingRoom.ts
+++ b/src/schema/v2/privateViewingRoom.ts
@@ -12,7 +12,7 @@ import { PrivateViewingRoomArtworkType } from "./privateViewingRoomArtwork"
 
 // Shared by PrivateViewingRoomType and PrivateViewingRoomContentsType — every
 // field Gravity's room_json actually returns, regardless of whether it's
-// reached via the plain GET (password_required: false branch) or via a
+// reached via the plain GET (passcode_required: false branch) or via a
 // successful authenticate. Kept as one field map so the two types can't
 // silently drift apart.
 const contentFields = () => ({
@@ -41,10 +41,10 @@ const contentFields = () => ({
 // endpoint (PartnerListPublication + PartnerListPublicationArtwork). Distinct
 // from the pre-existing, unrelated `ViewingRoom` type/model in this schema.
 //
-// Used only by the `privateViewingRoom` query below, where `passwordRequired`
+// Used only by the `privateViewingRoom` query below, where `passcodeRequired`
 // has one clear meaning: whether the room is gated at all. Gravity's GET
-// endpoint returns just `{password_required: true}` (no content fields) when
-// it's gated and unauthenticated, or `{password_required: false, ...content}`
+// endpoint returns just `{passcode_required: true}` (no content fields) when
+// it's gated and unauthenticated, or `{passcode_required: false, ...content}`
 // otherwise — so every content field here is nullable.
 export const PrivateViewingRoomType = new GraphQLObjectType<
   any,
@@ -52,25 +52,27 @@ export const PrivateViewingRoomType = new GraphQLObjectType<
 >({
   name: "PrivateViewingRoom",
   fields: () => ({
-    passwordRequired: {
+    passcodeRequired: {
       type: new GraphQLNonNull(GraphQLBoolean),
-      description: "Whether this room requires a password to view.",
+      description: "Whether this room requires a passcode to view.",
       // Coerced rather than passed straight through: if Gravity's GET ever
       // omitted this key on either branch, a bare `undefined` would violate
       // Boolean! and null the entire privateViewingRoom field — losing
       // gallery name/description/artworks along with it, not just this flag.
-      resolve: ({ password_required }) => !!password_required,
+      resolve: ({ passcode_required }) => !!passcode_required,
     },
     ...contentFields(),
   }),
 })
 
 // Returned by authenticatePrivateViewingRoomMutation on success. Deliberately
-// has no `passwordRequired` field: reaching a Success payload only ever
+// has no `passcodeRequired` field: reaching a Success payload only ever
 // happens after Gravity's authenticate endpoint has already confirmed the
-// password, so the field would always be `false` there and add nothing —
+// passcode, so the field would always be `false` there and add nothing —
 // see the PrivateViewingRoomType doc comment above for the query's version,
-// which does carry real signal.
+// which does carry real signal. Note this content is also never given a
+// plain-text passcode field — Gravity's authenticate endpoint doesn't return
+// one, matching the public/anonymous path's no-leak guarantee.
 export const PrivateViewingRoomContentsType = new GraphQLObjectType<
   any,
   ResolverContext
@@ -82,7 +84,7 @@ export const PrivateViewingRoomContentsType = new GraphQLObjectType<
 export const PrivateViewingRoom: GraphQLFieldConfig<void, ResolverContext> = {
   type: PrivateViewingRoomType,
   description:
-    "Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a password is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.",
+    "Find a private viewing room by slug. Returns null for an unknown/unpublished slug. Returns whether a passcode is required; artwork/gallery data is omitted until authenticated via the authenticatePrivateViewingRoom mutation.",
   args: {
     slug: {
       type: new GraphQLNonNull(GraphQLString),

--- a/src/schema/v2/privateViewingRoom/mutations/__tests__/authenticatePrivateViewingRoomMutation.test.ts
+++ b/src/schema/v2/privateViewingRoom/mutations/__tests__/authenticatePrivateViewingRoomMutation.test.ts
@@ -5,7 +5,7 @@ describe("AuthenticatePrivateViewingRoomMutation", () => {
   const mutation = gql`
     mutation {
       authenticatePrivateViewingRoom(
-        input: { slug: "some-gallery-for-anna", password: "letmein" }
+        input: { slug: "some-gallery-for-anna", passcode: "letmein" }
       ) {
         privateViewingRoomOrError {
           __typename
@@ -27,14 +27,15 @@ describe("AuthenticatePrivateViewingRoomMutation", () => {
     }
   `
 
-  it("returns the room contents on a correct password", async () => {
+  it("returns the room contents on a correct passcode", async () => {
     const context = {
       // Gravity's authenticate endpoint reuses room_json as-is and never
-      // includes a `password_required` key (unlike the plain GET) — omitted
+      // includes a `passcode_required` key (unlike the plain GET) — omitted
       // here deliberately to match the real response shape. There's no
       // corresponding field to assert on either: PrivateViewingRoomContentsType
-      // (this mutation's success payload) doesn't expose passwordRequired at
-      // all, since reaching Success already means the password check passed.
+      // (this mutation's success payload) doesn't expose passcodeRequired at
+      // all, since reaching Success already means the passcode check passed.
+      // Gravity also never includes the plaintext passcode itself here.
       authenticatePrivateViewingRoomLoader: jest.fn().mockResolvedValue({
         gallery_name: "Isabel Croxatto Galeria",
         artworks: [{ artwork_id: "artwork-1" }],
@@ -45,7 +46,7 @@ describe("AuthenticatePrivateViewingRoomMutation", () => {
 
     expect(
       context.authenticatePrivateViewingRoomLoader
-    ).toHaveBeenCalledWith("some-gallery-for-anna", { password: "letmein" })
+    ).toHaveBeenCalledWith("some-gallery-for-anna", { passcode: "letmein" })
 
     expect(result).toEqual({
       authenticatePrivateViewingRoom: {
@@ -60,11 +61,11 @@ describe("AuthenticatePrivateViewingRoomMutation", () => {
     })
   })
 
-  it("returns a mutation error on an incorrect password", async () => {
+  it("returns a mutation error on an incorrect passcode", async () => {
     const context = {
       authenticatePrivateViewingRoomLoader: jest
         .fn()
-        .mockRejectedValue({ body: { error: "Incorrect Password" } }),
+        .mockRejectedValue({ body: { error: "Incorrect Passcode" } }),
     }
 
     const result = await runQuery(mutation, context)
@@ -74,7 +75,7 @@ describe("AuthenticatePrivateViewingRoomMutation", () => {
         privateViewingRoomOrError: {
           __typename: "AuthenticatePrivateViewingRoomFailure",
           mutationError: {
-            message: "Incorrect Password",
+            message: "Incorrect Passcode",
           },
         },
       },

--- a/src/schema/v2/privateViewingRoom/mutations/authenticatePrivateViewingRoomMutation.ts
+++ b/src/schema/v2/privateViewingRoom/mutations/authenticatePrivateViewingRoomMutation.ts
@@ -14,7 +14,7 @@ import { PrivateViewingRoomContentsType } from "schema/v2/privateViewingRoom"
 
 interface AuthenticatePrivateViewingRoomMutationInputProps {
   slug: string
-  password: string
+  passcode: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -51,31 +51,31 @@ export const authenticatePrivateViewingRoomMutation = mutationWithClientMutation
 >({
   name: "AuthenticatePrivateViewingRoomMutation",
   description:
-    "Authenticates against a password-protected private viewing room, returning its contents on success.",
+    "Authenticates against a passcode-protected private viewing room, returning its contents on success.",
   inputFields: {
     slug: {
       type: new GraphQLNonNull(GraphQLString),
       description: "The slug of the private viewing room.",
     },
-    password: {
+    passcode: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "The room's password.",
+      description: "The room's passcode.",
     },
   },
   outputFields: {
     privateViewingRoomOrError: {
       type: ResponseOrErrorType,
       description:
-        "On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect password).",
+        "On success: the private viewing room's contents. On error: the error that occurred (e.g. an incorrect passcode).",
       resolve: (result) => result,
     },
   },
   mutateAndGetPayload: async (
-    { slug, password },
+    { slug, passcode },
     { authenticatePrivateViewingRoomLoader }
   ) => {
     try {
-      return await authenticatePrivateViewingRoomLoader(slug, { password })
+      return await authenticatePrivateViewingRoomLoader(slug, { passcode })
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {


### PR DESCRIPTION
Continue the work started on https://github.com/artsy/gravity/pull/20420

- Rename password to passcode (not encrypted anymore)
- Expose passcode on the graphql layer, so we can surface it in OS. Users should be able to see the passcode defined for previously published viewing rooms.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 