### PR TITLE
fix: always request accurate count from gravity

### DIFF
--- a/src/schema/v2/sale/__tests__/index.test.ts
+++ b/src/schema/v2/sale/__tests__/index.test.ts
@@ -298,6 +298,68 @@ describe("Sale type", () => {
       expect(data).toMatchSnapshot()
     })
 
+    it("requests an accurate total_count from gravity", async () => {
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            saleArtworksConnection(first: 10) {
+              pageInfo {
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+      const saleArtworksLoaderMock = jest.fn().mockResolvedValue({
+        body: fill(Array(10), { id: "some-id" }),
+        headers: {},
+      })
+
+      await runAuthenticatedQuery(query, {
+        saleLoader: () => Promise.resolve(sale),
+        saleArtworksLoader: saleArtworksLoaderMock,
+      })
+
+      expect(saleArtworksLoaderMock.mock.calls[0][1].total_count).toBe(true)
+    })
+
+    it("computes hasNextPage from the returnable count, not the stale eligible counter, at the tail", async () => {
+      // eligible_sale_artworks_count is stale/inflated (200) while gravity
+      // reports the true returnable count via x-total-count (199). Paging past
+      // the last artwork must return hasNextPage: false rather than looping.
+      sale.eligible_sale_artworks_count = 200
+      const after = Buffer.from("arrayconnection:198").toString("base64")
+      const query = `
+        {
+          sale(id: "foo-foo") {
+            saleArtworksConnection(first: 100, after: "${after}") {
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+              edges {
+                node {
+                  slug
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const context = {
+        saleLoader: () => Promise.resolve(sale),
+        saleArtworksLoader: jest.fn().mockResolvedValue({
+          body: [],
+          headers: { "x-total-count": "199" },
+        }),
+      }
+
+      const data = await runAuthenticatedQuery(query, context)
+      expect(data.sale.saleArtworksConnection.edges).toEqual([])
+      expect(data.sale.saleArtworksConnection.pageInfo.hasNextPage).toBe(false)
+    })
+
     it("accepts the internalIDs argument", async () => {
       const query = `
         {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -532,11 +532,19 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               path: sale.id,
             }).then((body) => connectionFromArray(body, {}))
           } else {
+            // Always ask Gravity for an accurate total_count to drive the
+            // pagination math. The denormalized `sale.eligible_sale_artworks_count`
+            // fallback can drift above the number of artworks actually
+            // returnable (e.g. lots withdrawn/unpublished mid-sale), which pins
+            // `hasNextPage` to `true` past the real end of the connection and
+            // breaks cursor pagination for exhaustive consumers. When filtering
+            // by `ids` the count comes from the response body, so it's not needed.
             const gravityArgs = {
               size,
               offset,
               ids,
-              ...(status && { status, total_count: true }),
+              ...(!ids && { total_count: true }),
+              ...(status && { status }),
             }
             return saleArtworksLoader(sale.id, gravityArgs).then(
               ({ body, headers }) => {

--- a/src/schema/v2/sale/index.ts
+++ b/src/schema/v2/sale/index.ts
@@ -532,13 +532,6 @@ export const SaleType = new GraphQLObjectType<any, ResolverContext>({
               path: sale.id,
             }).then((body) => connectionFromArray(body, {}))
           } else {
-            // Always ask Gravity for an accurate total_count to drive the
-            // pagination math. The denormalized `sale.eligible_sale_artworks_count`
-            // fallback can drift above the number of artworks actually
-            // returnable (e.g. lots withdrawn/unpublished mid-sale), which pins
-            // `hasNextPage` to `true` past the real end of the connection and
-            // breaks cursor pagination for exhaustive consumers. When filtering
-            // by `ids` the count comes from the response body, so it's not needed.
             const gravityArgs = {
               size,
               offset,


### PR DESCRIPTION
the pagination for saleArtworks connection relies on sale.eligibleArtworks, if this for any reason drifts from the returned artwork count from gravity we can get an infinite loading issue.

This always requests the accurate total count from gravity. 

~~key question: do we not do this for performance reasons? any other way to keep this accurate if so?~~

We do this in most other paginated connections and in the standalone saleArtworks connection: https://github.com/artsy/metaphysics/blob/bba6ed482d0c5eb95e72408c3ab5a401a12fc7b2/src/schema/v2/sale_artworks.ts#L165 should be fine