### PR TITLE
chore: Expose remaining fields to Private Viewing Rooms

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4822,8 +4822,10 @@ type ArtworkFieldVisibility {
   artistName: Boolean
   artworkTitle: Boolean
   availability: Boolean
+  certificateOfAuthenticity: Boolean
   dimensions: Boolean
   editionInfo: Boolean
+  location: Boolean
   medium: Boolean
   price: Boolean
   year: Boolean
@@ -4833,8 +4835,10 @@ input ArtworkFieldVisibilityInput {
   artistName: Boolean
   artworkTitle: Boolean
   availability: Boolean
+  certificateOfAuthenticity: Boolean
   dimensions: Boolean
   editionInfo: Boolean
+  location: Boolean
   medium: Boolean
   price: Boolean
   year: Boolean
@@ -30469,6 +30473,11 @@ type PartnerListPublication {
   description: String
 
   """
+  Optional heading shown on the published room.
+  """
+  heading: String
+
+  """
   Public-facing path for this private viewing room.
   """
   href: String
@@ -30506,6 +30515,11 @@ type PartnerListPublication {
     """
     timezone: String
   ): String
+
+  """
+  Whether the gallery name is shown on the public page.
+  """
+  showGalleryName: Boolean
   slug: String
   updatedAt(
     format: String
@@ -31352,7 +31366,12 @@ type PrivateViewingRoom {
   artworks: [PrivateViewingRoomArtwork!]
   brandKit: BrandKit
   description: String
+
+  """
+  The gallery's name, omitted when the gallery has chosen to hide it (show_gallery_name).
+  """
   galleryName: String
+  heading: String
 
   """
   Whether this room requires a passcode to view.
@@ -31365,9 +31384,16 @@ type PrivateViewingRoomArtwork {
   artworkID: String
   artworkTitle: String
   availability: String
+  coaByAuthenticatingBody: Boolean
+  coaByGallery: Boolean
   dimensions: String
   editionInfo: String
   imageURL: String
+
+  """
+  The artwork's public location (city/state/country/postal code), pinned as of the room's last publish.
+  """
+  location: String
   medium: String
 
   """
@@ -31384,7 +31410,12 @@ type PrivateViewingRoomContents {
   artworks: [PrivateViewingRoomArtwork!]
   brandKit: BrandKit
   description: String
+
+  """
+  The gallery's name, omitted when the gallery has chosen to hide it (show_gallery_name).
+  """
   galleryName: String
+  heading: String
 }
 
 type Profile {
@@ -31520,6 +31551,11 @@ input PublishPartnerListPublicationMutationInput {
   description: String
 
   """
+  Optional heading shown on the published room.
+  """
+  heading: String
+
+  """
   The ID of the partner list to publish as a viewing room.
   """
   partnerListID: String!
@@ -31528,6 +31564,11 @@ input PublishPartnerListPublicationMutationInput {
   Passcode to gate the room. Pass an empty string to clear a previously set passcode.
   """
   passcode: String
+
+  """
+  Whether to show the gallery name on the public page.
+  """
+  showGalleryName: Boolean
 }
 
 type PublishPartnerListPublicationMutationPayload {

--- a/src/schema/v2/__tests__/partnerListPublication.test.ts
+++ b/src/schema/v2/__tests__/partnerListPublication.test.ts
@@ -14,6 +14,8 @@ describe("PartnerList.publication", () => {
             slug
             href
             description
+            heading
+            showGalleryName
           }
         }
       }
@@ -32,6 +34,8 @@ describe("PartnerList.publication", () => {
         passcode: "letmein",
         slug: "some-gallery-for-anna",
         description: "For Anna",
+        heading: "For Anna",
+        show_gallery_name: false,
       }),
     }
 
@@ -48,6 +52,8 @@ describe("PartnerList.publication", () => {
       slug: "some-gallery-for-anna",
       href: "/private-viewing-room/some-gallery-for-anna",
       description: "For Anna",
+      heading: "For Anna",
+      showGalleryName: false,
     })
   })
 

--- a/src/schema/v2/__tests__/privateViewingRoom.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoom.test.ts
@@ -7,6 +7,7 @@ describe("PrivateViewingRoom", () => {
       privateViewingRoom(slug: "some-gallery-for-anna") {
         passcodeRequired
         galleryName
+        heading
         description
         applyBrand
         brandKit {
@@ -36,6 +37,7 @@ describe("PrivateViewingRoom", () => {
     expect(result.privateViewingRoom).toEqual({
       passcodeRequired: true,
       galleryName: null,
+      heading: null,
       description: null,
       applyBrand: null,
       brandKit: null,
@@ -48,6 +50,7 @@ describe("PrivateViewingRoom", () => {
       privateViewingRoomLoader: jest.fn().mockResolvedValue({
         passcode_required: false,
         gallery_name: "Isabel Croxatto Galeria",
+        heading: "For Anna",
         description: "For Anna",
         apply_brand: true,
         brand_kit: { text_color: "#111111" },
@@ -66,6 +69,7 @@ describe("PrivateViewingRoom", () => {
     expect(result.privateViewingRoom).toEqual({
       passcodeRequired: false,
       galleryName: "Isabel Croxatto Galeria",
+      heading: "For Anna",
       description: "For Anna",
       applyBrand: true,
       brandKit: { textColor: "#111111" },
@@ -77,6 +81,19 @@ describe("PrivateViewingRoom", () => {
         },
       ],
     })
+  })
+
+  it("omits galleryName when the gallery has chosen to hide it", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.galleryName).toBeNull()
   })
 
   it("returns null for an unknown or unpublished slug instead of a GraphQL error", async () => {

--- a/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
@@ -99,3 +99,58 @@ describe("PrivateViewingRoomArtwork.price", () => {
     )
   })
 })
+
+describe("PrivateViewingRoomArtwork.location / coa fields", () => {
+  const query = gql`
+    {
+      privateViewingRoom(slug: "some-gallery-for-anna") {
+        artworks {
+          location
+          coaByGallery
+          coaByAuthenticatingBody
+        }
+      }
+    }
+  `
+
+  it("returns the pinned location and coa fields when visible", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            location: "Buffalo, Indiana, US, 38203",
+            coa_by_gallery: true,
+            coa_by_authenticating_body: false,
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0]).toEqual({
+      location: "Buffalo, Indiana, US, 38203",
+      coaByGallery: true,
+      coaByAuthenticatingBody: false,
+    })
+  })
+
+  it("returns null for location/coa fields when not visible", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [{ artwork_id: "artwork-1" }],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0]).toEqual({
+      location: null,
+      coaByGallery: null,
+      coaByAuthenticatingBody: null,
+    })
+  })
+})

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
@@ -181,6 +181,105 @@ describe("PublishPartnerListPublicationMutation", () => {
     ).toHaveBeenCalledWith("list-abc", { passcode: "" })
   })
 
+  it("sets heading and showGalleryName", async () => {
+    const withHeadingAndGalleryName = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: {
+            partnerListID: "list-abc"
+            heading: "For Anna"
+            showGalleryName: false
+          }
+        ) {
+          partnerListPublicationOrError {
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                heading
+                showGalleryName
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        heading: "For Anna",
+        show_gallery_name: false,
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(
+      withHeadingAndGalleryName,
+      context
+    )
+
+    expect(context.publishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        heading: "For Anna",
+        show_gallery_name: false,
+      }
+    )
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication
+    ).toEqual({ heading: "For Anna", showGalleryName: false })
+  })
+
+  it("accepts location and certificateOfAuthenticity visibility keys", async () => {
+    const withNewVisibilityKeys = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: {
+            partnerListID: "list-abc"
+            artworkFieldVisibility: {
+              location: true
+              certificateOfAuthenticity: true
+            }
+          }
+        ) {
+          partnerListPublicationOrError {
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                artworkFieldVisibility {
+                  location
+                  certificateOfAuthenticity
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        artwork_field_visibility: {
+          location: true,
+          certificate_of_authenticity: true,
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(withNewVisibilityKeys, context)
+
+    expect(context.publishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        artwork_field_visibility: {
+          location: true,
+          certificate_of_authenticity: true,
+        },
+      }
+    )
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication.artworkFieldVisibility
+    ).toEqual({ location: true, certificateOfAuthenticity: true })
+  })
+
   it("omits artwork_field_visibility entirely when not provided", async () => {
     const withoutVisibility = gql`
       mutation {

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/publishPartnerListPublicationMutation.ts
@@ -35,7 +35,9 @@ interface PublishPartnerListPublicationMutationInputProps {
   partnerListID: string
   passcode?: string
   description?: string
+  heading?: string
   applyBrand?: boolean
+  showGalleryName?: boolean
   artworkFieldVisibility?: Record<string, boolean>
 }
 
@@ -88,9 +90,17 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
       type: GraphQLString,
       description: "Plain-text description shown on the published room.",
     },
+    heading: {
+      type: GraphQLString,
+      description: "Optional heading shown on the published room.",
+    },
     applyBrand: {
       type: GraphQLBoolean,
       description: "Whether to apply the gallery's brand kit to the room.",
+    },
+    showGalleryName: {
+      type: GraphQLBoolean,
+      description: "Whether to show the gallery name on the public page.",
     },
     artworkFieldVisibility: {
       type: ArtworkFieldVisibilityInputType,
@@ -110,7 +120,9 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
       partnerListID,
       passcode,
       description,
+      heading,
       applyBrand,
+      showGalleryName,
       artworkFieldVisibility,
     },
     { publishPartnerListPublicationLoader }
@@ -129,7 +141,10 @@ export const publishPartnerListPublicationMutation = mutationWithClientMutationI
     // string here and an explicit `null` arrive at the same place.
     if (passcode !== undefined) gravityArgs.passcode = passcode
     if (description !== undefined) gravityArgs.description = description
+    if (heading !== undefined) gravityArgs.heading = heading
     if (applyBrand !== undefined) gravityArgs.apply_brand = applyBrand
+    if (showGalleryName !== undefined)
+      gravityArgs.show_gallery_name = showGalleryName
     if (artworkFieldVisibility !== undefined) {
       const visibility: Record<string, boolean> = {}
 

--- a/src/schema/v2/partnerListPublication.ts
+++ b/src/schema/v2/partnerListPublication.ts
@@ -4,7 +4,7 @@ import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
 import { date } from "./fields/date"
 
-// Single source of truth for the 8 keys Gravity's
+// Single source of truth for the 10 keys Gravity's
 // VALID_ARTWORK_FIELD_VISIBILITY_KEYS allowlist accepts (snake_case, as
 // stored). Both ArtworkFieldVisibilityType below (read) and
 // ArtworkFieldVisibilityInputType (write, in
@@ -19,6 +19,8 @@ export const ARTWORK_FIELD_VISIBILITY_KEYS = [
   "price",
   "availability",
   "edition_info",
+  "location",
+  "certificate_of_authenticity",
 ] as const
 
 // Gravity stores each value as either a real boolean or the literal string
@@ -68,6 +70,15 @@ export const PartnerListPublicationType = new GraphQLObjectType<
     lastPublishedAt: date(({ last_published_at }) => last_published_at),
     description: {
       type: GraphQLString,
+    },
+    heading: {
+      type: GraphQLString,
+      description: "Optional heading shown on the published room.",
+    },
+    showGalleryName: {
+      type: GraphQLBoolean,
+      description: "Whether the gallery name is shown on the public page.",
+      resolve: ({ show_gallery_name }) => show_gallery_name,
     },
     slug: {
       type: GraphQLString,

--- a/src/schema/v2/privateViewingRoom.ts
+++ b/src/schema/v2/privateViewingRoom.ts
@@ -18,7 +18,12 @@ import { PrivateViewingRoomArtworkType } from "./privateViewingRoomArtwork"
 const contentFields = () => ({
   galleryName: {
     type: GraphQLString,
+    description:
+      "The gallery's name, omitted when the gallery has chosen to hide it (show_gallery_name).",
     resolve: ({ gallery_name }) => gallery_name,
+  },
+  heading: {
+    type: GraphQLString,
   },
   description: {
     type: GraphQLString,

--- a/src/schema/v2/privateViewingRoomArtwork.ts
+++ b/src/schema/v2/privateViewingRoomArtwork.ts
@@ -1,4 +1,9 @@
-import { GraphQLInt, GraphQLObjectType, GraphQLString } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import {
   Money,
@@ -75,6 +80,19 @@ export const PrivateViewingRoomArtworkType = new GraphQLObjectType<
     editionInfo: {
       type: GraphQLString,
       resolve: ({ edition_info }) => edition_info,
+    },
+    location: {
+      type: GraphQLString,
+      description:
+        "The artwork's public location (city/state/country/postal code), pinned as of the room's last publish.",
+    },
+    coaByGallery: {
+      type: GraphQLBoolean,
+      resolve: ({ coa_by_gallery }) => coa_by_gallery,
+    },
+    coaByAuthenticatingBody: {
+      type: GraphQLBoolean,
+      resolve: ({ coa_by_authenticating_body }) => coa_by_authenticating_body,
     },
   }),
 })


### PR DESCRIPTION
Relates to https://github.com/artsy/gravity/pull/20426

Expose Viewing Room heading, gallery name display preference, artworks location and CoA details on the graphql queries and mutations.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 