### PR TITLE
chore: Support edition set on Private Viewing Rooms

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -4824,7 +4824,10 @@ type ArtworkFieldVisibility {
   availability: Boolean
   certificateOfAuthenticity: Boolean
   dimensions: Boolean
-  editionInfo: Boolean
+  editionAvailability: Boolean
+  editionInventoryCount: Boolean
+  editionPrice: Boolean
+  editionSize: Boolean
   location: Boolean
   medium: Boolean
   price: Boolean
@@ -4837,7 +4840,10 @@ input ArtworkFieldVisibilityInput {
   availability: Boolean
   certificateOfAuthenticity: Boolean
   dimensions: Boolean
-  editionInfo: Boolean
+  editionAvailability: Boolean
+  editionInventoryCount: Boolean
+  editionPrice: Boolean
+  editionSize: Boolean
   location: Boolean
   medium: Boolean
   price: Boolean
@@ -31387,7 +31393,11 @@ type PrivateViewingRoomArtwork {
   coaByAuthenticatingBody: Boolean
   coaByGallery: Boolean
   dimensions: String
-  editionInfo: String
+
+  """
+  One entry per edition set on this artwork, each independently visibility-gated. Null/empty when the artwork has no edition sets.
+  """
+  editionInfo: [PrivateViewingRoomArtworkEditionInfo!]
   imageURL: String
 
   """
@@ -31403,6 +31413,20 @@ type PrivateViewingRoomArtwork {
   priceCents: Int
   priceCurrency: String
   year: String
+}
+
+type PrivateViewingRoomArtworkEditionInfo {
+  availability: String
+  editionSetID: String!
+  editionSize: String
+  inventoryCount: Int
+
+  """
+  The pinned price for this edition set as a formatted Money object. Null when there's no pinned price or currency (resolveMinorAndCurrencyFieldsToMoney returns null rather than throwing).
+  """
+  price: Money
+  priceCents: Int
+  priceCurrency: String
 }
 
 type PrivateViewingRoomContents {

--- a/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
+++ b/src/schema/v2/__tests__/privateViewingRoomArtwork.test.ts
@@ -100,6 +100,136 @@ describe("PrivateViewingRoomArtwork.price", () => {
   })
 })
 
+describe("PrivateViewingRoomArtwork.editionInfo", () => {
+  const query = gql`
+    {
+      privateViewingRoom(slug: "some-gallery-for-anna") {
+        artworks {
+          editionInfo {
+            editionSetID
+            priceCents
+            priceCurrency
+            price {
+              minor
+              major
+              currencyCode
+              display
+            }
+            availability
+            editionSize
+            inventoryCount
+          }
+        }
+      }
+    }
+  `
+
+  it("returns one entry per edition set, each with its own pinned data", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            edition_info: [
+              {
+                edition_set_id: "edition-set-a",
+                price_cents: 100000,
+                price_currency: "USD",
+                availability: "for sale",
+                edition_size: "10",
+                inventory_count: 3,
+              },
+              {
+                edition_set_id: "edition-set-b",
+                price_cents: 200000,
+                price_currency: "USD",
+                availability: "sold",
+                edition_size: "25",
+                inventory_count: 7,
+              },
+            ],
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0].editionInfo).toEqual([
+      {
+        editionSetID: "edition-set-a",
+        priceCents: 100000,
+        priceCurrency: "USD",
+        price: {
+          minor: 100000,
+          major: 1000,
+          currencyCode: "USD",
+          display: "US$1,000",
+        },
+        availability: "for sale",
+        editionSize: "10",
+        inventoryCount: 3,
+      },
+      {
+        editionSetID: "edition-set-b",
+        priceCents: 200000,
+        priceCurrency: "USD",
+        price: {
+          minor: 200000,
+          major: 2000,
+          currencyCode: "USD",
+          display: "US$2,000",
+        },
+        availability: "sold",
+        editionSize: "25",
+        inventoryCount: 7,
+      },
+    ])
+  })
+
+  it("returns an empty list when the artwork has no edition sets", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [{ artwork_id: "artwork-1", edition_info: [] }],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0].editionInfo).toEqual([])
+  })
+
+  it("returns null price/availability/size/inventory on an entry when those sub-fields aren't visible, but keeps editionSetID", async () => {
+    const context = {
+      privateViewingRoomLoader: jest.fn().mockResolvedValue({
+        passcode_required: false,
+        artworks: [
+          {
+            artwork_id: "artwork-1",
+            edition_info: [{ edition_set_id: "edition-set-a" }],
+          },
+        ],
+      }),
+    }
+
+    const result = await runQuery(query, context)
+
+    expect(result.privateViewingRoom.artworks[0].editionInfo).toEqual([
+      {
+        editionSetID: "edition-set-a",
+        priceCents: null,
+        priceCurrency: null,
+        price: null,
+        availability: null,
+        editionSize: null,
+        inventoryCount: null,
+      },
+    ])
+  })
+})
+
 describe("PrivateViewingRoomArtwork.location / coa fields", () => {
   const query = gql`
     {

--- a/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/PartnerListPublication/__tests__/publishPartnerListPublicationMutation.test.ts
@@ -280,6 +280,74 @@ describe("PublishPartnerListPublicationMutation", () => {
     ).toEqual({ location: true, certificateOfAuthenticity: true })
   })
 
+  it("accepts the 4 per-edition-set visibility keys (Gravity PR #20428)", async () => {
+    const withEditionVisibilityKeys = gql`
+      mutation {
+        publishPartnerListPublication(
+          input: {
+            partnerListID: "list-abc"
+            artworkFieldVisibility: {
+              editionPrice: true
+              editionAvailability: true
+              editionSize: false
+              editionInventoryCount: false
+            }
+          }
+        ) {
+          partnerListPublicationOrError {
+            ... on PublishPartnerListPublicationSuccess {
+              partnerListPublication {
+                artworkFieldVisibility {
+                  editionPrice
+                  editionAvailability
+                  editionSize
+                  editionInventoryCount
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+    const context = {
+      publishPartnerListPublicationLoader: jest.fn().mockResolvedValue({
+        id: "pub-1",
+        artwork_field_visibility: {
+          edition_price: true,
+          edition_availability: true,
+          edition_size: false,
+          edition_inventory_count: false,
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(
+      withEditionVisibilityKeys,
+      context
+    )
+
+    expect(context.publishPartnerListPublicationLoader).toHaveBeenCalledWith(
+      "list-abc",
+      {
+        artwork_field_visibility: {
+          edition_price: true,
+          edition_availability: true,
+          edition_size: false,
+          edition_inventory_count: false,
+        },
+      }
+    )
+    expect(
+      result.publishPartnerListPublication.partnerListPublicationOrError
+        .partnerListPublication.artworkFieldVisibility
+    ).toEqual({
+      editionPrice: true,
+      editionAvailability: true,
+      editionSize: false,
+      editionInventoryCount: false,
+    })
+  })
+
   it("omits artwork_field_visibility entirely when not provided", async () => {
     const withoutVisibility = gql`
       mutation {

--- a/src/schema/v2/partnerListPublication.ts
+++ b/src/schema/v2/partnerListPublication.ts
@@ -4,12 +4,18 @@ import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
 import { date } from "./fields/date"
 
-// Single source of truth for the 10 keys Gravity's
+// Single source of truth for the 13 keys Gravity's
 // VALID_ARTWORK_FIELD_VISIBILITY_KEYS allowlist accepts (snake_case, as
 // stored). Both ArtworkFieldVisibilityType below (read) and
 // ArtworkFieldVisibilityInputType (write, in
 // publishPartnerListPublicationMutation) are generated from this list. Keep
 // it in sync with Gravity's PartnerListPublicationsEndpoint.
+//
+// `edition_info` (Gravity PR #20428) was replaced by 4 per-edition-set toggles
+// — edition_price, edition_availability, edition_size, edition_inventory_count
+// — since edition_info is no longer a single display string but an array of
+// per-edition-set snapshots, each gated independently. See
+// PrivateViewingRoomArtworkType's editionInfo field for the read-side shape.
 export const ARTWORK_FIELD_VISIBILITY_KEYS = [
   "artist_name",
   "artwork_title",
@@ -18,9 +24,12 @@ export const ARTWORK_FIELD_VISIBILITY_KEYS = [
   "dimensions",
   "price",
   "availability",
-  "edition_info",
   "location",
   "certificate_of_authenticity",
+  "edition_price",
+  "edition_availability",
+  "edition_size",
+  "edition_inventory_count",
 ] as const
 
 // Gravity stores each value as either a real boolean or the literal string

--- a/src/schema/v2/privateViewingRoomArtwork.ts
+++ b/src/schema/v2/privateViewingRoomArtwork.ts
@@ -1,6 +1,8 @@
 import {
   GraphQLBoolean,
   GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
 } from "graphql"
@@ -9,6 +11,67 @@ import {
   Money,
   resolveMinorAndCurrencyFieldsToMoney,
 } from "schema/v2/fields/money"
+
+// One entry per artwork.edition_sets, as pinned by Gravity's
+// PartnerListPublicationArtwork#edition_info_snapshots_from (Gravity PR
+// #20428) — replaces the old single formatted-string edition_info. Each
+// sub-field is independently visibility-gated (edition_price,
+// edition_availability, edition_size, edition_inventory_count — see
+// ARTWORK_FIELD_VISIBILITY_KEYS in partnerListPublication.ts), so any of them
+// may be null on a given entry regardless of the others. editionSetID is
+// always present — it's a stable identifier, not gallery-toggleable data.
+const PrivateViewingRoomArtworkEditionInfoType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PrivateViewingRoomArtworkEditionInfo",
+  fields: () => ({
+    editionSetID: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ edition_set_id }) => edition_set_id,
+    },
+    priceCents: {
+      type: GraphQLInt,
+      resolve: ({ price_cents }) => price_cents,
+    },
+    priceCurrency: {
+      type: GraphQLString,
+      resolve: ({ price_currency }) => price_currency,
+    },
+    price: {
+      type: Money,
+      description:
+        "The pinned price for this edition set as a formatted Money object. Null when there's no pinned price " +
+        "or currency (resolveMinorAndCurrencyFieldsToMoney returns null rather than throwing).",
+      resolve: (
+        { price_cents: minor, price_currency: currencyCode },
+        args,
+        context,
+        info
+      ) => {
+        if (minor == null || !currencyCode) return null
+
+        return resolveMinorAndCurrencyFieldsToMoney(
+          { minor, currencyCode },
+          args,
+          context,
+          info
+        )
+      },
+    },
+    availability: {
+      type: GraphQLString,
+    },
+    editionSize: {
+      type: GraphQLString,
+      resolve: ({ edition_size }) => edition_size,
+    },
+    inventoryCount: {
+      type: GraphQLInt,
+      resolve: ({ inventory_count }) => inventory_count,
+    },
+  }),
+})
 
 // A point-in-time snapshot of an artwork as included in a published private
 // viewing room (Gravity's PartnerListPublicationArtwork#visible_json) — not
@@ -78,7 +141,12 @@ export const PrivateViewingRoomArtworkType = new GraphQLObjectType<
       type: GraphQLString,
     },
     editionInfo: {
-      type: GraphQLString,
+      type: new GraphQLList(
+        new GraphQLNonNull(PrivateViewingRoomArtworkEditionInfoType)
+      ),
+      description:
+        "One entry per edition set on this artwork, each independently visibility-gated. " +
+        "Null/empty when the artwork has no edition sets.",
       resolve: ({ edition_info }) => edition_info,
     },
     location: {


### PR DESCRIPTION
[notion card](https://app.notion.com/p/artsy/Edition-Sets-handling-3b5cab0764a080f2b9c4e6475bb1582d)
Rely on https://github.com/artsy/gravity/pull/20428

Capture and expose edition set nested info within the Viewing Room query and the publishing mutation

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 