### PR TITLE
chore: Expose lists and publication data for Private Viewing Rooms

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -30375,9 +30375,19 @@ type PartnerList {
   partnerShowID: String
 
   """
+  Whether this list's private viewing room publication is gated by a passcode. Null if no publication exists yet.
+  """
+  passcodeProtected: Boolean
+
+  """
   The private viewing room publication for this list, if one exists (only applies to private_viewing_room lists). Not resolvable through partnerListsConnection.
   """
   publication: PartnerListPublication
+
+  """
+  Whether this list's private viewing room publication is live. Null if no publication exists yet.
+  """
+  published: Boolean
   startAt(
     format: String
 

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -30468,6 +30468,11 @@ type PartnerListPublication {
   Per-field visibility toggles for artworks in the room. Any key the gallery hasn't set is null.
   """
   artworkFieldVisibility: ArtworkFieldVisibility
+
+  """
+  Number of artworks currently snapshotted into this publication.
+  """
+  artworksCount: Int!
   createdAt(
     format: String
 

--- a/src/schema/v2/__tests__/partnerListPublication.test.ts
+++ b/src/schema/v2/__tests__/partnerListPublication.test.ts
@@ -16,6 +16,7 @@ describe("PartnerList.publication", () => {
             description
             heading
             showGalleryName
+            artworksCount
           }
         }
       }
@@ -36,6 +37,7 @@ describe("PartnerList.publication", () => {
         description: "For Anna",
         heading: "For Anna",
         show_gallery_name: false,
+        artworks_count: 3,
       }),
     }
 
@@ -54,6 +56,7 @@ describe("PartnerList.publication", () => {
       description: "For Anna",
       heading: "For Anna",
       showGalleryName: false,
+      artworksCount: 3,
     })
   })
 

--- a/src/schema/v2/__tests__/partnerListPublication.test.ts
+++ b/src/schema/v2/__tests__/partnerListPublication.test.ts
@@ -169,3 +169,94 @@ describe("PartnerList.publication", () => {
     ).toEqual({ slug: "some-gallery-for-anna" })
   })
 })
+
+describe("PartnerList.published / PartnerList.passcodeProtected", () => {
+  it("reads inline from partner_list_publication on partnerListsConnection, with no per-node Gravity call", async () => {
+    const query = gql`
+      {
+        partner(id: "gallery-1") {
+          partnerListsConnection(first: 2) {
+            edges {
+              node {
+                internalID
+                published
+                passcodeProtected
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListsLoader: jest.fn().mockResolvedValue({
+        body: [
+          {
+            id: "list-published",
+            partner_list_publication: {
+              published: true,
+              passcode_protected: false,
+            },
+          },
+          { id: "list-unpublished", partner_list_publication: null },
+        ],
+        headers: { "x-total-count": "2" },
+      }),
+      // Batched inline on the index response — must not trigger a
+      // per-node lookup the way PartnerList.publication does.
+      partnerListPublicationLoader: jest
+        .fn()
+        .mockRejectedValue(new Error("should not be called")),
+    }
+
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(context.partnerListPublicationLoader).not.toHaveBeenCalled()
+    expect(
+      result.partner.partnerListsConnection.edges.map((edge) => edge.node)
+    ).toEqual([
+      {
+        internalID: "list-published",
+        published: true,
+        passcodeProtected: false,
+      },
+      {
+        internalID: "list-unpublished",
+        published: null,
+        passcodeProtected: null,
+      },
+    ])
+  })
+
+  it("also resolves on a single partnerList lookup, from the same inline key", async () => {
+    const query = gql`
+      {
+        partner(id: "gallery-1") {
+          partnerList(id: "list-abc") {
+            published
+            passcodeProtected
+          }
+        }
+      }
+    `
+
+    const context = {
+      partnerLoader: jest.fn().mockResolvedValue({ id: "gallery-1" }),
+      partnerListLoader: jest.fn().mockResolvedValue({
+        id: "list-abc",
+        partner_list_publication: {
+          published: false,
+          passcode_protected: true,
+        },
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(query, context)
+
+    expect(result.partner.partnerList).toEqual({
+      published: false,
+      passcodeProtected: true,
+    })
+  })
+})

--- a/src/schema/v2/partnerList.ts
+++ b/src/schema/v2/partnerList.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLBoolean,
   GraphQLEnumType,
   GraphQLInt,
   GraphQLNonNull,
@@ -74,6 +75,25 @@ export const PartnerListType = new GraphQLObjectType<any, ResolverContext>({
       distributedAt: date(({ distributed_at }) => distributed_at),
       createdAt: date(),
       updatedAt: date(),
+      // published/passcodeProtected read from the `partner_list_publication`
+      // key Gravity inlines on every PartnerList response (index, show,
+      // mutation payloads) — unlike `publication` below, this never issues a
+      // separate `partner_list/:id/publication` call, so it's safe to resolve
+      // per node inside partnerListsConnection with no N+1.
+      published: {
+        type: GraphQLBoolean,
+        description:
+          "Whether this list's private viewing room publication is live. Null if no publication exists yet.",
+        resolve: ({ partner_list_publication }) =>
+          partner_list_publication?.published ?? null,
+      },
+      passcodeProtected: {
+        type: GraphQLBoolean,
+        description:
+          "Whether this list's private viewing room publication is gated by a passcode. Null if no publication exists yet.",
+        resolve: ({ partner_list_publication }) =>
+          partner_list_publication?.passcode_protected ?? null,
+      },
       artworksConnection: {
         type: PartnerListArtworkConnection.connectionType,
         args: pageable({}),

--- a/src/schema/v2/partnerListPublication.ts
+++ b/src/schema/v2/partnerListPublication.ts
@@ -1,5 +1,11 @@
 import { camelCase } from "lodash"
-import { GraphQLBoolean, GraphQLObjectType, GraphQLString } from "graphql"
+import {
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
 import { ResolverContext } from "types/graphql"
 import { InternalIDFields } from "./object_identification"
 import { date } from "./fields/date"
@@ -88,6 +94,12 @@ export const PartnerListPublicationType = new GraphQLObjectType<
       type: GraphQLBoolean,
       description: "Whether the gallery name is shown on the public page.",
       resolve: ({ show_gallery_name }) => show_gallery_name,
+    },
+    artworksCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      description:
+        "Number of artworks currently snapshotted into this publication.",
+      resolve: ({ artworks_count }) => artworks_count,
     },
     slug: {
       type: GraphQLString,


### PR DESCRIPTION
Rely on https://github.com/artsy/gravity

### Expose the artworks count for partner list publications

Expose the number of artworks included within a publication so clients can fetch this directly in a single query.
Relates to https://github.com/artsy/volt/pull/11926

### Expose data essential data around publication on partner list level

Allow partner list to return data for published and password protected from partner list publications, so we can fetch it inline.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 