### PR TITLE
feat(TOP-375): unstitch inquiry creation from submitOfferOrderWithConversation and submitOrderMutation

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -13,6 +13,7 @@ const FEATURE_FLAGS_LIST = [
   "diamond_artwork-title-experiment",
   "onyx_nwfy-gravity",
   "onyx_nwfy-refresh-eigen",
+  "topaz_remove-inquiry-creation-from-order-mutation",
 ] as const
 
 export type FeatureFlag = typeof FEATURE_FLAGS_LIST[number]

--- a/src/lib/stitching/exchange/__tests__/stitching.test.ts
+++ b/src/lib/stitching/exchange/__tests__/stitching.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./testingUtils"
 import schema from "schema/v2/schema"
 import { addMocksToSchema } from "@graphql-tools/mock"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 it("extends the Order objects", async () => {
   const mergedSchema = await getExchangeMergedSchema()
@@ -505,6 +506,24 @@ describe("submitOfferOrderWithConversation", () => {
       message: "test note",
       order_id: "order-id",
     })
+  })
+
+  it("does not call submitArtworkInquiryRequestLoader when Gravity handles inquiry creation", async () => {
+    ;(isFeatureFlagEnabled as jest.Mock).mockReturnValue(true)
+
+    const { resolvers } = await getExchangeStitchedSchema()
+    const resolver = resolvers.Mutation.submitOfferOrderWithConversation.resolve
+    const args = {
+      input: {
+        offerId: "offer-id",
+      },
+    }
+    mergeInfo.delegateToSchema.mockResolvedValue(validOrderResult)
+
+    const result = await resolver({}, args, context, { mergeInfo })
+
+    expect(result).toEqual(validOrderResult)
+    expect(context.submitArtworkInquiryRequestLoader).not.toHaveBeenCalled()
   })
 
   it("does not call submitArtworkInquiryRequestLoader given inquiry offer", async () => {

--- a/src/lib/stitching/exchange/v2/stitching.ts
+++ b/src/lib/stitching/exchange/v2/stitching.ts
@@ -13,6 +13,7 @@ import { toGlobalId } from "graphql-relay"
 import gql from "lib/gql"
 import { ArtworkVersionType } from "schema/v2/artwork_version"
 import { amount, amountSDL } from "schema/v2/fields/money"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 const orderTotals = [
   "itemsTotal",
@@ -935,7 +936,13 @@ export const exchangeStitchingEnvironment = ({
 
             const { orderOrError } = submitOrderWithOffer
 
+            const inquiryCreationHandledByGravity = isFeatureFlagEnabled(
+              "topaz_remove-inquiry-creation-from-order-mutation",
+              { userId: context.userID }
+            )
+
             if (
+              inquiryCreationHandledByGravity ||
               orderOrError.error ||
               !orderOrError.order ||
               orderOrError.order.source === "inquiry" ||

--- a/src/schema/v2/order/__tests__/submitOrderMutation.test.ts
+++ b/src/schema/v2/order/__tests__/submitOrderMutation.test.ts
@@ -1,5 +1,8 @@
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 import { runAuthenticatedQuery } from "schema/v2/test/utils"
 import { baseArtwork, baseOrderJson } from "./support"
+
+const mockIsFeatureFlagEnabled = isFeatureFlagEnabled as jest.Mock
 
 const mockMutation = `
   mutation {
@@ -295,6 +298,11 @@ describe("submitOrderMutation", () => {
       context.submitArtworkInquiryRequestLoader = jest
         .fn()
         .mockResolvedValue({})
+      mockIsFeatureFlagEnabled.mockReturnValue(false)
+    })
+
+    afterEach(() => {
+      mockIsFeatureFlagEnabled.mockReset()
     })
 
     it("creates an inquiry when submitting an offer order with a note", async () => {
@@ -391,6 +399,34 @@ describe("submitOrderMutation", () => {
         message: "I sent an offer for £750",
         order_id: "order-id",
       })
+    })
+
+    it("does not create inquiry when Gravity handles it", async () => {
+      mockIsFeatureFlagEnabled.mockReturnValue(true)
+
+      context.meOrderSubmitLoader = jest.fn().mockResolvedValue({
+        ...baseOrderJson,
+        id: "order-id",
+        source: "artwork_page",
+        mode: "offer",
+        last_submitted_offer: {
+          note: "I love this piece!",
+          amount_cents: 100000,
+          currency_code: "USD",
+        },
+        line_items: [{ artwork_id: "artwork-id" }],
+      })
+
+      const result = await runAuthenticatedQuery(mockMutation, context)
+
+      expect(result.errors).toBeUndefined()
+      expect(
+        mockIsFeatureFlagEnabled
+      ).toHaveBeenCalledWith(
+        "topaz_remove-inquiry-creation-from-order-mutation",
+        { userId: "user-42" }
+      )
+      expect(context.submitArtworkInquiryRequestLoader).not.toHaveBeenCalled()
     })
 
     it("does not create inquiry for buy orders", async () => {

--- a/src/schema/v2/order/submitOrderMutation.ts
+++ b/src/schema/v2/order/submitOrderMutation.ts
@@ -12,6 +12,7 @@ import { mutationWithClientMutationId } from "graphql-relay"
 import { ResolverContext } from "types/graphql"
 import { handleExchangeError } from "./exchangeErrorHandling"
 import { getOfferMessage } from "./utils/getOfferMessage"
+import { isFeatureFlagEnabled } from "lib/featureFlags"
 
 interface Input {
   id: string
@@ -68,9 +69,15 @@ export const submitOrderMutation = mutationWithClientMutationId<
       }
       const submittedOrder = await meOrderSubmitLoader(input.id, payload)
 
+      const inquiryCreationHandledByGravity = isFeatureFlagEnabled(
+        "topaz_remove-inquiry-creation-from-order-mutation",
+        { userId: context.userID }
+      )
+
       // If this offer is not from inquiry page and is not held for review,
       // create an inquiry. Reviewed offers processed after review passed event.
       if (
+        !inquiryCreationHandledByGravity &&
         submittedOrder.mode === "offer" &&
         submittedOrder.source !== "inquiry" &&
         submittedOrder.state !== "in_review" &&


### PR DESCRIPTION
Unstitch inquiry creation from 2 mutations; make inquiry creation event-oriented in Gravity.

cc @artsy/topaz-devs 