### PR TITLE
chore: Remove partner show references from mailchimp campaigns

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -15074,7 +15074,7 @@ type CreateMailchimpCampaignFailure {
 
 input CreateMailchimpCampaignInput {
   """
-  Artwork IDs to associate with the campaign for tracking (mutually exclusive with partnerShowId)
+  Artwork IDs to associate with the campaign for tracking
   """
   artworkIds: [String!]
   clientMutationId: String
@@ -15093,11 +15093,6 @@ input CreateMailchimpCampaignInput {
   The internal ID of the Mailchimp account to use
   """
   mailchimpAccountId: String!
-
-  """
-  Partner show ID to associate with the campaign for tracking (mutually exclusive with artworkIds)
-  """
-  partnerShowId: String
 
   """
   The email preview text
@@ -23212,11 +23207,6 @@ type MailchimpCampaign {
   """
   mailchimpUrl: String
   partnerId: String
-
-  """
-  The partner show associated with this campaign, if any
-  """
-  partnerShowId: String
 
   """
   The email preview text

--- a/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
+++ b/src/schema/v2/__tests__/createMailchimpCampaignMutation.test.ts
@@ -59,7 +59,6 @@ describe("createMailchimpCampaign", () => {
       subject_line: "New Artworks from Acme Gallery",
       list_id: "list-1",
       artwork_ids: undefined,
-      partner_show_id: undefined,
       html_content: "<html><body>Partner-authored content</body></html>",
       preview_text: undefined,
     })
@@ -111,71 +110,9 @@ describe("createMailchimpCampaign", () => {
         subject_line: "Custom Campaign",
         list_id: "list-1",
         artwork_ids: ["artwork-1", "artwork-2"],
-        partner_show_id: undefined,
         html_content: "<html><body>Partner-authored content</body></html>",
         preview_text: undefined,
       })
-    })
-  })
-
-  describe("with partnerShowId for tracking", () => {
-    const mutationWithShow = `
-      mutation {
-        createMailchimpCampaign(input: {
-          mailchimpAccountId: "mc-account-1"
-          subjectLine: "Gallery Show"
-          listId: "list-1"
-          htmlContent: "<html><body>Partner-authored content</body></html>"
-          partnerShowId: "show-1"
-        }) {
-          mailchimpCampaignOrError {
-            __typename
-          }
-        }
-      }
-    `
-
-    it("passes correct args to Gravity", async () => {
-      await runAuthenticatedQuery(mutationWithShow, context)
-
-      expect(
-        context.createMailchimpCampaignLoader as jest.Mock
-      ).toHaveBeenCalledWith({
-        mailchimp_account_id: "mc-account-1",
-        subject_line: "Gallery Show",
-        list_id: "list-1",
-        artwork_ids: undefined,
-        partner_show_id: "show-1",
-        html_content: "<html><body>Partner-authored content</body></html>",
-        preview_text: undefined,
-      })
-    })
-  })
-
-  describe("mutually exclusive fields", () => {
-    const mutationWithBoth = `
-      mutation {
-        createMailchimpCampaign(input: {
-          mailchimpAccountId: "mc-account-1"
-          subjectLine: "Test"
-          listId: "list-1"
-          htmlContent: "<html><body>Partner-authored content</body></html>"
-          artworkIds: ["artwork-1"]
-          partnerShowId: "show-1"
-        }) {
-          mailchimpCampaignOrError {
-            __typename
-          }
-        }
-      }
-    `
-
-    it("throws when both artworkIds and partnerShowId are provided", async () => {
-      await expect(
-        runAuthenticatedQuery(mutationWithBoth, context)
-      ).rejects.toThrow(
-        'The "artworkIds" and "partnerShowId" arguments are mutually exclusive.'
-      )
     })
   })
 

--- a/src/schema/v2/createMailchimpCampaignMutation.ts
+++ b/src/schema/v2/createMailchimpCampaignMutation.ts
@@ -16,7 +16,6 @@ import { MailchimpCampaignType } from "./mailchimpCampaign"
 interface Input {
   mailchimpAccountId: string
   artworkIds?: string[]
-  partnerShowId?: string
   htmlContent: string
   subjectLine: string
   previewText?: string
@@ -75,13 +74,7 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
     },
     artworkIds: {
       type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
-      description:
-        "Artwork IDs to associate with the campaign for tracking (mutually exclusive with partnerShowId)",
-    },
-    partnerShowId: {
-      type: GraphQLString,
-      description:
-        "Partner show ID to associate with the campaign for tracking (mutually exclusive with artworkIds)",
+      description: "Artwork IDs to associate with the campaign for tracking",
     },
     subjectLine: {
       type: new GraphQLNonNull(GraphQLString),
@@ -107,7 +100,6 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
     {
       mailchimpAccountId,
       artworkIds,
-      partnerShowId,
       htmlContent,
       subjectLine,
       previewText,
@@ -119,17 +111,10 @@ export const createMailchimpCampaignMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
-    if (artworkIds && partnerShowId) {
-      throw new Error(
-        'The "artworkIds" and "partnerShowId" arguments are mutually exclusive.'
-      )
-    }
-
     try {
       return await createMailchimpCampaignLoader({
         mailchimp_account_id: mailchimpAccountId,
         artwork_ids: artworkIds,
-        partner_show_id: partnerShowId,
         html_content: htmlContent,
         subject_line: subjectLine,
         preview_text: previewText,

--- a/src/schema/v2/mailchimpCampaign.ts
+++ b/src/schema/v2/mailchimpCampaign.ts
@@ -59,11 +59,6 @@ export const MailchimpCampaignType = new GraphQLObjectType<
       type: GraphQLString,
       resolve: ({ partner_id }) => partner_id,
     },
-    partnerShowId: {
-      type: GraphQLString,
-      description: "The partner show associated with this campaign, if any",
-      resolve: ({ partner_show_id }) => partner_show_id,
-    },
     webId: {
       type: GraphQLString,
       description: "The Mailchimp web ID for linking to the campaign",


### PR DESCRIPTION
Relates to: https://github.com/artsy/gravity/pull/20441

Mailchimp campaigns were initially built with partner shows in mind. This changed over time, we moved away from the concept of shows to collections (partners lists) in OS and this is currently dead code.

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 