### PR TITLE
feat: pass through agree to receive emails to mutation

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -39029,6 +39029,11 @@ type UpdateMyPasswordMutationPayload {
 
 input UpdateMyProfileInput {
   """
+  Whether the user consents to receiving marketing emails from Artsy. Sets agreed_to_receive_emails_at in Gravity (idempotent; never cleared).
+  """
+  agreedToReceiveEmails: Boolean
+
+  """
   Number of artworks purchased per year.
   """
   artworksPerYear: String

--- a/src/schema/v2/me/__tests__/update_me_mutation.test.js
+++ b/src/schema/v2/me/__tests__/update_me_mutation.test.js
@@ -263,6 +263,39 @@ describe("UpdateMeMutation", () => {
     expect(mockUpdateCollectorProfileIconLoader).not.toHaveBeenCalled()
   })
 
+  it("passes agreedToReceiveEmails through to the loader as snake_case", async () => {
+    const mutation = gql`
+      mutation {
+        updateMyUserProfile(input: { agreedToReceiveEmails: true }) {
+          me {
+            internalID
+          }
+        }
+      }
+    `
+
+    const mockUpdateMeLoader = jest.fn().mockReturnValue(
+      Promise.resolve({
+        id: "106",
+      })
+    )
+
+    const context = {
+      meLoader: () =>
+        Promise.resolve({
+          id: "106",
+        }),
+      updateMeLoader: mockUpdateMeLoader,
+      updateCollectorProfileIconLoader: jest.fn(),
+    }
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(mockUpdateMeLoader).toHaveBeenCalledWith({
+      agreed_to_receive_emails: true,
+    })
+  })
+
   it("updates phone number and returns correct region code", async () => {
     const mutation = gql`
       mutation {

--- a/src/schema/v2/me/update_me_mutation.ts
+++ b/src/schema/v2/me/update_me_mutation.ts
@@ -108,6 +108,12 @@ export default mutationWithClientMutationId<any, any, ResolverContext>({
   name: "UpdateMyProfile",
   description: "Update the current logged in user.",
   inputFields: {
+    agreedToReceiveEmails: {
+      description:
+        "Whether the user consents to receiving marketing emails from Artsy. " +
+        "Sets agreed_to_receive_emails_at in Gravity (idempotent; never cleared).",
+      type: GraphQLBoolean,
+    },
     artworksPerYear: {
       type: GraphQLString,
       description: "Number of artworks purchased per year.",


### PR DESCRIPTION

Passes through agreedToReceiveEmails to gravity to allow opting into emails after sign up.
This is specifically for Google One Tap use case which does have any opt in UX before sign up. 

```
mutation OptInToEmails {
  updateMyUserProfile(input: { agreedToReceiveEmails: true }) {
    me {
      internalID
    }
  }
}
```

Assisted-By: Claude <noreply@anthropic.com>