### PR TITLE
chore: add mutation to trigger an Artnet import

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -14254,6 +14254,36 @@ type CreateArtistSuccess {
 
 union CreateArtistSuccessOrErrorType = CreateArtistFailure | CreateArtistSuccess
 
+type CreateArtnetImportFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateArtnetImportMutationInput {
+  clientMutationId: String
+
+  """
+  The ID of the partner whose Artnet inventory to import.
+  """
+  partnerID: String!
+}
+
+type CreateArtnetImportMutationPayload {
+  """
+  On success: the queued import details. On error: the error that occurred.
+  """
+  artnetImportOrError: CreateArtnetImportResponseOrError
+  clientMutationId: String
+}
+
+union CreateArtnetImportResponseOrError =
+    CreateArtnetImportFailure
+  | CreateArtnetImportSuccess
+
+type CreateArtnetImportSuccess {
+  artnetImportID: String
+  queued: Boolean
+}
+
 type CreateArtworkFailure {
   mutationError: GravityMutationError
 }
@@ -25678,6 +25708,13 @@ type Mutation {
   Create an artist, used for MyCollection. use CreateCanonicalArtistMutation for all other cases
   """
   createArtist(input: CreateArtistMutationInput!): CreateArtistMutationPayload
+
+  """
+  Kicks off a background job to pull a gallery's Artnet inventory and create corresponding Artsy artwork records.
+  """
+  createArtnetImport(
+    input: CreateArtnetImportMutationInput!
+  ): CreateArtnetImportMutationPayload
 
   """
   Creates a new artwork, optionally with associated images.

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -252,6 +252,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createArtnetImportLoader: gravityLoader(
+      "artnet_import",
+      {},
+      { method: "POST" }
+    ),
     createArtworkImportLoader: gravityLoader(
       "artwork_import",
       {},

--- a/src/schema/v2/artnet/__tests__/artnetImportMutation.test.ts
+++ b/src/schema/v2/artnet/__tests__/artnetImportMutation.test.ts
@@ -1,0 +1,62 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("createArtnetImport mutation", () => {
+  const query = `
+    mutation {
+      createArtnetImport(input: { partnerID: "some-gallery" }) {
+        artnetImportOrError {
+          ... on CreateArtnetImportSuccess {
+            queued
+            artnetImportID
+          }
+          ... on CreateArtnetImportFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("returns queued and artnetImportID on success", async () => {
+    const context = {
+      createArtnetImportLoader: () =>
+        Promise.resolve({ queued: true, artnet_import_id: "abc123" }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      createArtnetImport: {
+        artnetImportOrError: {
+          queued: true,
+          artnetImportID: "abc123",
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error on failure", async () => {
+    const context = {
+      createArtnetImportLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/artnet_import - {"type":"error","message":"Unauthorized"}`
+          )
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      createArtnetImport: {
+        artnetImportOrError: {
+          mutationError: {
+            type: "error",
+            message: "Unauthorized",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/artnet/artnetImportMutation.ts
+++ b/src/schema/v2/artnet/artnetImportMutation.ts
@@ -1,0 +1,88 @@
+import {
+  GraphQLBoolean,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+interface CreateArtnetImportMutationInputProps {
+  partnerID: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtnetImportSuccess",
+  isTypeOf: ({ queued }) => queued === true,
+  fields: () => ({
+    queued: {
+      type: GraphQLBoolean,
+      resolve: ({ queued }) => queued,
+    },
+    artnetImportID: {
+      type: GraphQLString,
+      resolve: ({ artnet_import_id }) => artnet_import_id,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtnetImportFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateArtnetImportResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const createArtnetImportMutation = mutationWithClientMutationId<
+  CreateArtnetImportMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "CreateArtnetImportMutation",
+  description:
+    "Kicks off a background job to pull a gallery's Artnet inventory and create corresponding Artsy artwork records.",
+  inputFields: {
+    partnerID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the partner whose Artnet inventory to import.",
+    },
+  },
+  outputFields: {
+    artnetImportOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the queued import details. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ partnerID }, { createArtnetImportLoader }) => {
+    if (!createArtnetImportLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const result = await createArtnetImportLoader({ partner_id: partnerID })
+      return result
+    } catch (error) {
+      const formatted = formatGravityError(error)
+      if (formatted) {
+        return { ...formatted, _type: "GravityMutationError" }
+      }
+      throw error
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -155,6 +155,7 @@ import { channel } from "./article/channel"
 import { createArtistMutation } from "./artist/createArtistMutation"
 import { createCanonicalArtistMutation } from "./artist/createCanonicalArtistMutation"
 import { deleteArtistMutation } from "./artist/deleteArtistMutation"
+import { createArtnetImportMutation } from "./artnet/artnetImportMutation"
 import { createArtworkMutation } from "./artwork/createArtworkMutation"
 import { deleteArtworkMutation } from "./artwork/deleteArtworkMutation"
 import { updateCatalogArtworkMutation } from "./artwork/updateCatalogArtworkMutation"
@@ -640,6 +641,7 @@ export default new GraphQLSchema({
       commerceOptInReport: commerceOptInReportMutation,
       createAccountRequest: createAccountRequestMutation,
       createAlert: createAlertMutation,
+      createArtnetImport: createArtnetImportMutation,
       createArtwork: createArtworkMutation,
       createAndSendBackupSecondFactor: createAndSendBackupSecondFactorMutation,
       createAppSecondFactor: createAppSecondFactorMutation,


### PR DESCRIPTION
Simple mutation to trigger the import via the POST endpoint added in https://github.com/artsy/gravity/pull/20449 . 

The Artnet headers (token and user id) are already setup to be propagated (thanks!).