### PR TITLE
feat(EMI-3382): expose artist instagram handle

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2732,6 +2732,11 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   ): [ArtistInsight!]!
 
   """
+  Artist's Instagram handle, without a leading @
+  """
+  instagramHandle: String
+
+  """
   Instagram media for display on an artist page.
   """
   instagramMedia(
@@ -37929,6 +37934,11 @@ input UpdateArtistMutationInput {
   groupIndicator: ArtistGroupIndicator
   hometown: String
   id: String!
+
+  """
+  Artist's Instagram handle. A leading @ or a profile URL is accepted.
+  """
+  instagramHandle: String
   last: String
   location: String
   middle: String

--- a/src/schema/v2/artist/__tests__/updateArtistMutation.test.ts
+++ b/src/schema/v2/artist/__tests__/updateArtistMutation.test.ts
@@ -50,6 +50,46 @@ describe("updateArtistMutation", () => {
     })
   })
 
+  it("updates the artist's Instagram handle", async () => {
+    const instagramMutation = gql`
+      mutation {
+        updateArtist(input: { id: "3", instagramHandle: "@artsy" }) {
+          artistOrError {
+            ... on UpdateArtistSuccess {
+              artist {
+                instagramHandle
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const mockUpdateArtistLoader = jest.fn(() =>
+      Promise.resolve({
+        id: "foo",
+        instagram_handle: "artsy",
+      })
+    )
+
+    const context = { updateArtistLoader: mockUpdateArtistLoader }
+    const result = await runAuthenticatedQuery(instagramMutation, context)
+
+    expect(mockUpdateArtistLoader).toBeCalledWith("3", {
+      instagram_handle: "@artsy",
+    })
+
+    expect(result).toEqual({
+      updateArtist: {
+        artistOrError: {
+          artist: {
+            instagramHandle: "artsy",
+          },
+        },
+      },
+    })
+  })
+
   it("throws error when data loader is missing", async () => {
     const errorResponse =
       "You need to pass a X-Access-Token header to perform this action"

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -835,6 +835,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       initials: initials("name"),
       insights: ArtistInsights,
+      instagramHandle: {
+        type: GraphQLString,
+        description: "Artist's Instagram handle, without a leading @",
+        resolve: ({ instagram_handle }) => instagram_handle,
+      },
       instagramMedia: InstagramMedia,
       isConsignable: {
         type: GraphQLBoolean,

--- a/src/schema/v2/artist/updateArtistMutation.ts
+++ b/src/schema/v2/artist/updateArtistMutation.ts
@@ -41,6 +41,7 @@ interface Input {
   groupIndicator?: ArtistGroupIndicator
   hometown?: string
   id: string
+  instagramHandle?: string
   last?: string
   location?: string
   middle?: string
@@ -70,6 +71,11 @@ const inputFields = {
   groupIndicator: { type: ArtistGroupIndicatorEnum },
   hometown: { type: GraphQLString },
   id: { type: new GraphQLNonNull(GraphQLString) },
+  instagramHandle: {
+    type: GraphQLString,
+    description:
+      "Artist's Instagram handle. A leading @ or a profile URL is accepted.",
+  },
   last: { type: GraphQLString },
   location: { type: GraphQLString },
   middle: { type: GraphQLString },
@@ -99,6 +105,7 @@ interface GravityInput {
   group_indicator?: string
   hometown?: string
   id: string
+  instagram_handle?: string
   last?: string
   location?: string
   middle?: string


### PR DESCRIPTION
Exposes Artist `instagramHandle`

Adds `instagramHandle` to `ArtistType` and to `UpdateArtistMutationInput`, so Volt
can read and update an artist's Instagram handle. Maps to Gravity's
`instagram_handle` field.

[Gravity PR](https://github.com/artsy/gravity/pull/20460)
