### PR TITLE
chore: Retire legacy artwork missing metadata arguments and query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -28731,22 +28731,12 @@ type Partner implements Node {
     """
     includeUnpublished: Boolean
     last: Int
-
-    """
-    Return artworks that are missing priority metadata
-    """
-    missingPriorityMetadata: Boolean
     page: Int
 
     """
     Only return artworks that are partner-offerable
     """
     partnerOfferable: Boolean
-
-    """
-    Return artworks published less than x seconds ago.
-    """
-    publishedWithin: Int
 
     """
     Only allowed for authorized admin/partner requests. When false fetch :all properties on an artwork, when true or not present fetch artwork :short properties

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -131,17 +131,9 @@ const artworksArgs: GraphQLFieldConfigArgumentMap = {
     description:
       "If true return both published and unpublished artworks, requires auth",
   },
-  missingPriorityMetadata: {
-    type: GraphQLBoolean,
-    description: "Return artworks that are missing priority metadata",
-  },
   partnerOfferable: {
     type: GraphQLBoolean,
     description: "Only return artworks that are partner-offerable",
-  },
-  publishedWithin: {
-    type: GraphQLInt,
-    description: "Return artworks published less than x seconds ago.",
   },
   shallow: {
     type: GraphQLBoolean,
@@ -680,11 +672,9 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             exclude_ids?: string[]
             for_sale: boolean
             include_non_artsy_listed?: boolean
-            missing_priority_metadata?: boolean
             partner_offerable?: boolean
             page: number
             published?: boolean
-            published_within?: number
             size: number
             sort: string
             total_count: boolean
@@ -693,12 +683,10 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           const gravityArgs: GravityArgs = {
             for_sale: args.forSale,
-            missing_priority_metadata: args.missingPriorityMetadata,
             artist_id: args.artistID || undefined,
             partner_offerable: args.partnerOfferable,
             page,
             published: true,
-            published_within: args.publishedWithin,
             size,
             sort: args.sort,
             total_count: true,


### PR DESCRIPTION
This PR resolves [TOPAZ-399](https://artsyproduct.atlassian.net/browse/TOP-399)

### Description

Now that listing scores are the drivers for the items in Homepage checklist in Volt, we not longer need to support these unused legacy code paths

Retiring ✨

Associated PRs:
- https://github.com/artsy/volt/pull/11986
- https://github.com/artsy/gravity/pull/20462