### PR TITLE
fix: typescript errors after upgrade

### DIFF
--- a/src/lib/__tests__/cache.test.ts
+++ b/src/lib/__tests__/cache.test.ts
@@ -16,7 +16,9 @@ function parseCacheResponse(data, cacheCompressionDisabled) {
   if (cacheCompressionDisabled) {
     return JSON.parse(data)
   } else {
-    return JSON.parse(zlib.inflateSync(Buffer.from(data, "base64")).toString())
+    return JSON.parse(
+      zlib.inflateSync(new Uint8Array(Buffer.from(data, "base64"))).toString()
+    )
   }
 }
 

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -110,13 +110,16 @@ function _get<T>(key) {
         if (CACHE_COMPRESSION_DISABLED) {
           resolve(JSON.parse(data.toString()))
         } else {
-          zlib.inflate(Buffer.from(data, "base64"), (er, inflatedData) => {
-            if (er) {
-              reject(er)
-            } else {
-              resolve(JSON.parse(inflatedData.toString()))
+          zlib.inflate(
+            new Uint8Array(Buffer.from(data, "base64")),
+            (er, inflatedData) => {
+              if (er) {
+                reject(er)
+              } else {
+                resolve(JSON.parse(inflatedData.toString()))
+              }
             }
-          })
+          )
         }
       } else {
         reject()


### PR DESCRIPTION
Fixes `yarn tsc` in main:

```
src/lib/__tests__/cache.test.ts:19:40 - error TS2345: Argument of type 'Buffer' is not assignable to parameter of type 'InputType'.
  Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike> | DataView<ArrayBufferLike>'.
    Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
      The types of 'slice(...).buffer' are incompatible between these types.
        Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
          Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
            Types of property '[Symbol.toStringTag]' are incompatible.
              Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.

19     return JSON.parse(zlib.inflateSync(Buffer.from(data, "base64")).toString())
                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~

src/lib/cache.ts:113:24 - error TS2345: Argument of type 'Buffer' is not assignable to parameter of type 'InputType'.
  Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike> | DataView<ArrayBufferLike>'.
    Type 'Buffer' is not assignable to type 'Uint8Array<ArrayBufferLike>'.
      The types of 'slice(...).buffer' are incompatible between these types.
        Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
          Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
            Types of property '[Symbol.toStringTag]' are incompatible.
              Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.

113           zlib.inflate(Buffer.from(data, "base64"), (er, inflatedData) => {
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors in 2 files.

Errors  Files
     1  src/lib/__tests__/cache.test.ts:19
     1  src/lib/cache.ts:113
```