### PR TITLE
fix: Allow clients to filter articles only published within a given timeframe

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2767,9 +2767,14 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   last: String
 
   """
-  The most recent published article featuring this artist
+  The most recent published article featuring this artist, optionally limited to those published since a given date.
   """
-  latestArticle: Article
+  latestArticle(
+    """
+    Only return articles published since this ISO 8601 date.
+    """
+    publishedSince: String
+  ): Article
   location: String
   marketingCollections(
     after: String

--- a/src/schema/v2/artist/__tests__/latestArticle.test.ts
+++ b/src/schema/v2/artist/__tests__/latestArticle.test.ts
@@ -39,12 +39,14 @@ describe("Artist#latestArticle", () => {
       title: "Gerhard Richter at the MoMA",
     })
 
-    expect(articlesLoader).toBeCalledWith({
-      published: true,
-      artist_id: "artist-id",
-      sort: "-published_at",
-      limit: 1,
-    })
+    expect(articlesLoader).toBeCalledWith(
+      expect.objectContaining({
+        published: true,
+        artist_id: "artist-id",
+        sort: "-published_at",
+        limit: 1,
+      })
+    )
   })
 
   it("returns null when no articles feature the artist", async () => {
@@ -81,5 +83,49 @@ describe("Artist#latestArticle", () => {
     await runQuery(query, { artistLoader, articlesLoader })
 
     expect(articlesLoader).not.toHaveBeenCalled()
+  })
+
+  it("passes publishedSince as published_since to articlesLoader", async () => {
+    const query = gql`
+      {
+        artist(id: "gerhard-richter") {
+          latestArticle(publishedSince: "2024-01-01") {
+            slug
+          }
+        }
+      }
+    `
+
+    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
+    const articlesLoader = jest.fn().mockResolvedValue({ results: [] })
+
+    await runQuery(query, { artistLoader, articlesLoader })
+
+    expect(articlesLoader).toBeCalledWith(
+      expect.objectContaining({
+        published_since: "2024-01-01",
+      })
+    )
+  })
+
+  it("does not pass published_since when publishedSince is not provided", async () => {
+    const query = gql`
+      {
+        artist(id: "gerhard-richter") {
+          latestArticle {
+            slug
+          }
+        }
+      }
+    `
+
+    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
+    const articlesLoader = jest.fn().mockResolvedValue({ results: [] })
+
+    await runQuery(query, { artistLoader, articlesLoader })
+
+    expect(articlesLoader).toBeCalledWith(
+      expect.not.objectContaining({ published_since: expect.anything() })
+    )
   })
 })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -441,13 +441,22 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
       },
       latestArticle: {
         type: Article.type,
-        description: "The most recent published article featuring this artist",
-        resolve: ({ _id }, _options, { articlesLoader }) =>
+        description:
+          "The most recent published article featuring this artist, optionally limited to those published since a given date.",
+        args: {
+          publishedSince: {
+            type: GraphQLString,
+            description:
+              "Only return articles published since this ISO 8601 date.",
+          },
+        },
+        resolve: ({ _id }, { publishedSince }, { articlesLoader }) =>
           articlesLoader({
             published: true,
             artist_id: _id,
             sort: "-published_at",
             limit: 1,
+            ...(publishedSince && { published_since: publishedSince }),
           }).then((articles) => first(articles.results)),
       },
       biographyBlurb: {


### PR DESCRIPTION
fix: Filter to articles only published within a given timeframe

While testing the Proof of Concept on staging we noticed A LOT of articles from a looong time ago which is not the best user experience

https://github.com/user-attachments/assets/2f1228ef-b5eb-4d3b-bdc7-9d8396f3040c








This PR adds filtering support to allow clients to filter for articles published within a certain date


Associated PRs:
- https://github.com/artsy/positron/pull/3318
- https://github.com/artsy/positron/pull/3320

