### PR TITLE
fix(agent): artwork ids over slugs

### DIFF
--- a/src/schema/v2/ai/agent/__tests__/runTurn.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/runTurn.test.ts
@@ -85,6 +85,12 @@ function fakeContext(
   } as unknown) as ResolverContext
 }
 
+// Real Gravity internalIDs are 24-char hex; that shape is what routes a cited
+// id to the batch endpoint rather than the per-slug fallback.
+const ID_A = "5f5a5b5c5d5e5f6061626364"
+const ID_B = "6a6b6c6d6e6f707172737475"
+const ID_C = "7b7c7d7e7f80818283848586"
+
 async function collectEvents(
   input: { conversationID: string; message: string },
   context: ResolverContext = fakeContext()
@@ -118,12 +124,12 @@ describe("runTurn", () => {
     // whatever the loader returns, not what the model claimed.
     const finalJson = JSON.stringify({
       message: "Found Andy Warhol.",
-      artworkIDs: ["andy-warhol-flowers"],
+      artworkIDs: [ID_A],
     })
     const artworksLoader = jest
       .fn()
       .mockResolvedValue([
-        { _id: "abc123", id: "andy-warhol-flowers", title: "Flowers" },
+        { _id: ID_A, id: "andy-warhol-flowers", title: "Flowers" },
       ])
     mockModel = new MockLanguageModelV3({
       doStream: stepsWithOffset([
@@ -180,13 +186,9 @@ describe("runTurn", () => {
       stopReason: "stop",
       toolCallCount: 1,
       message: "Found Andy Warhol.",
-      artworks: [
-        { _id: "abc123", id: "andy-warhol-flowers", title: "Flowers" },
-      ],
+      artworks: [{ _id: ID_A, id: "andy-warhol-flowers", title: "Flowers" }],
     })
-    expect(artworksLoader).toHaveBeenCalledWith({
-      ids: ["andy-warhol-flowers"],
-    })
+    expect(artworksLoader).toHaveBeenCalledWith({ ids: [ID_A] })
     expect(mockModel.doStreamCalls).toHaveLength(2)
   })
 
@@ -341,9 +343,11 @@ describe("runTurn", () => {
         },
       })
 
-    const cardsFor = async (artworkIDs: string[], gravityReturns: any[]) => {
+    // `batch` is what /artworks?ids[]= returns: internalID matches only, in
+    // Gravity's own order.
+    const cardsFor = async (artworkIDs: string[], batch: any[] = []) => {
       mockModel = modelCiting(artworkIDs)
-      const artworksLoader = jest.fn().mockResolvedValue(gravityReturns)
+      const artworksLoader = jest.fn().mockResolvedValue(batch)
       const events = await collectEvents(
         { conversationID: "c1", message: "Find artworks" },
         fakeContext({ artworksLoader })
@@ -351,53 +355,63 @@ describe("runTurn", () => {
       const complete = events.find(
         (e) => e.__typename === "AIAgentTurnComplete"
       )
-      return complete.artworks
+      return { artworks: complete.artworks, artworksLoader }
     }
 
     it("renders cards in the model's order, not Gravity's", async () => {
       // Gravity's /artworks?ids[]= doesn't promise to echo the request order.
-      const artworks = await cardsFor(
-        ["id-c", "id-a", "id-b"],
+      const { artworks } = await cardsFor(
+        [ID_C, ID_A, ID_B],
         [
-          { _id: "id-a", id: "slug-a" },
-          { _id: "id-b", id: "slug-b" },
-          { _id: "id-c", id: "slug-c" },
+          { _id: ID_A, id: "slug-a" },
+          { _id: ID_B, id: "slug-b" },
+          { _id: ID_C, id: "slug-c" },
         ]
       )
 
-      expect(artworks.map((a) => a._id)).toEqual(["id-c", "id-a", "id-b"])
+      expect(artworks.map((a) => a._id)).toEqual([ID_C, ID_A, ID_B])
     })
 
-    it("matches a citation by slug, which AgentOutputSchema also allows", async () => {
-      const artworks = await cardsFor(
-        ["slug-b", "id-a"],
-        [
-          { _id: "id-a", id: "slug-a" },
-          { _id: "id-b", id: "slug-b" },
-        ]
+    it("never asks Gravity for a citation that isn't an internalID", async () => {
+      // The batch endpoint matches on internalID only, so a slug would come
+      // back empty; sending it would just waste the lookup.
+      const { artworks, artworksLoader } = await cardsFor(
+        ["andy-warhol-flowers", ID_A],
+        [{ _id: ID_A, id: "slug-a" }]
       )
 
-      expect(artworks.map((a) => a._id)).toEqual(["id-b", "id-a"])
+      expect(artworksLoader).toHaveBeenCalledWith({ ids: [ID_A] })
+      expect(artworks.map((a) => a._id)).toEqual([ID_A])
+    })
+
+    it("skips Gravity entirely when no citation is an internalID", async () => {
+      const { artworks, artworksLoader } = await cardsFor([
+        "andy-warhol-flowers",
+        "Happy Birthday",
+      ])
+
+      expect(artworksLoader).not.toHaveBeenCalled()
+      expect(artworks).toEqual([])
     })
 
     it("leaves no hole for an id Gravity drops (deleted, unpublished, hallucinated)", async () => {
-      const artworks = await cardsFor(
-        ["id-a", "id-missing", "id-b"],
+      const { artworks } = await cardsFor(
+        [ID_A, ID_C, ID_B],
         [
-          { _id: "id-a", id: "slug-a" },
-          { _id: "id-b", id: "slug-b" },
+          { _id: ID_A, id: "slug-a" },
+          { _id: ID_B, id: "slug-b" },
         ]
       )
 
       expect(artworks).toHaveLength(2)
       expect(artworks).not.toContain(undefined)
-      expect(artworks.map((a) => a._id)).toEqual(["id-a", "id-b"])
+      expect(artworks.map((a) => a._id)).toEqual([ID_A, ID_B])
     })
 
     it("renders one card per work, however many times the model cites it", async () => {
-      const artworks = await cardsFor(
-        ["id-a", "slug-a", "id-a"],
-        [{ _id: "id-a", id: "slug-a" }]
+      const { artworks } = await cardsFor(
+        [ID_A, ID_A, ID_A],
+        [{ _id: ID_A, id: "slug-a" }]
       )
 
       expect(artworks).toHaveLength(1)

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -6,6 +6,7 @@ import config from "config"
 import { z } from "zod"
 import { anthropicProvider } from "lib/apis/anthropic"
 import { rateLimitByUser } from "lib/rateLimitByUser"
+import { warn } from "lib/loggers"
 import { ResolverContext } from "types/graphql"
 import {
   buildAgentTools,
@@ -26,13 +27,24 @@ and fairs using the provided tools. Only state facts returned by a tool call —
 never invent artist names, prices, or availability. If a tool call fails or
 returns nothing useful, say so plainly rather than guessing.
 
-When your answer references specific artworks, populate \`artworkIDs\` with their
-exact internalID or slug from the tool results — never invented. The client
-renders those as image cards, so do NOT list, number, or describe the individual
-artworks in \`message\` — that would duplicate the cards. Keep \`message\` to one or
-two sentences that frame the result set: what you searched for and what filters
-you applied. Mention an individual work only when the user asked about that one
-specific work.
+\`artworkIDs\` and \`message\` are two halves of one answer: \`artworkIDs\` *is* the
+result set — the client renders each id as an image card — and \`message\` is the
+one or two sentences framing it: what you searched for and what filters you
+applied.
+
+So whenever a tool call surfaced artworks that answer the question, populate
+\`artworkIDs\` with their exact \`internalID\` from those results — the
+24-character hex id, copied verbatim. It must be the \`internalID\` and nothing
+else: a slug, a title, or an invented id renders no card at all, so always
+select \`internalID\` on any artwork you might cite. Do NOT list, number, or describe the individual artworks in
+\`message\`; the cards already show them. That deliberate omission is not a
+reason to leave \`artworkIDs\` empty — a \`message\` that describes having found
+works, paired with an empty \`artworkIDs\`, renders as text with no images, which
+is a broken answer.
+
+Leave \`artworkIDs\` empty only when you found no artworks, or the question isn't
+about artworks at all. Mention an individual work in \`message\` only when the
+user asked about that one specific work.
 
 ## Workflow
 
@@ -104,9 +116,13 @@ const AgentOutputSchema = z.object({
   artworkIDs: z
     .array(z.string())
     .describe(
-      "internalID or slug of each artwork referenced in the answer, copied " +
-        "exactly from query_artsy tool results. Empty if the answer doesn't " +
-        "reference specific artworks."
+      "The 24-character hex `internalID` of every artwork this answer is " +
+        "based on, copied exactly from query_artsy tool results. Must be the " +
+        "internalID -- a slug or title renders nothing. These become image " +
+        "cards and are the only way the user sees the works, so populate " +
+        "this whenever a tool call surfaced artworks that answer the " +
+        "question -- `message` deliberately does not name them. Empty only " +
+        "when no artworks were found, or the question isn't about artworks."
     ),
 })
 
@@ -115,33 +131,35 @@ const AgentOutputSchema = z.object({
  * placeholder for an id it can't resolve, so what comes back is a set, not a
  * sequence -- see recentlySoldArtworks, which re-joins on `_id` for the same
  * reason. Restore the model's ordering, which is the only relevance signal the
- * cards carry, and index on both `_id` and `id` because AgentOutputSchema lets
- * the model cite either an internalID or a slug.
+ * cards carry.
  *
  * Ids that resolve to nothing (deleted, unpublished, or hallucinated) just
  * don't get a card: per AgentOutputSchema the model supplies identifiers and
  * never display data, so a bad one fails as a missing card, never a wrong one.
  */
 function orderArtworksByCitedIDs(artworks: any[], citedIDs: string[]) {
-  const byIdentifier = new Map<string, any>()
+  const byInternalID = new Map<string, any>()
   artworks.forEach((artwork) => {
-    if (artwork?._id) byIdentifier.set(artwork._id, artwork)
-    if (artwork?.id) byIdentifier.set(artwork.id, artwork)
+    if (artwork?._id) byInternalID.set(artwork._id, artwork)
   })
 
   const ordered: any[] = []
-  // Deduped on the resolved artwork rather than the id, which also collapses a
-  // work the model happened to cite twice, once by internalID and once by slug.
-  const seen = new Set<any>()
+  const seen = new Set<string>()
   citedIDs.forEach((id) => {
-    const artwork = byIdentifier.get(id)
-    if (!artwork || seen.has(artwork)) return
-    seen.add(artwork)
+    const artwork = byInternalID.get(id)
+    // `seen` guards the model citing the same work twice.
+    if (!artwork || seen.has(id)) return
+    seen.add(id)
     ordered.push(artwork)
   })
 
   return ordered
 }
+
+/**
+ * Gravity's batch endpoint (/artworks?ids[]=) matches on internalID only
+ */
+const INTERNAL_ID = /^[0-9a-f]{24}$/i
 
 async function resolveArtworks(
   ids: string[],
@@ -149,9 +167,24 @@ async function resolveArtworks(
 ): Promise<unknown[]> {
   if (ids.length === 0) return []
   const citedIDs = ids.slice(0, MAX_ARTWORK_IDS)
+  const internalIDs = citedIDs.filter((id) => INTERNAL_ID.test(id))
+
+  // Logged rather than passed through: a non-internalID citation resolves to
+  // nothing, and a card that never renders is invisible from the outside --
+  // which is how a slug-citing answer previously read as a working turn with
+  // an empty `artworks`. If this line stays quiet, the prompt is holding.
+  if (internalIDs.length < citedIDs.length) {
+    const dropped = citedIDs.filter((id) => !INTERNAL_ID.test(id))
+    warn(
+      `[aiAgentTurn] dropped ${dropped.length} of ${citedIDs.length} artwork ` +
+        `citation(s), not internalIDs: ${JSON.stringify(dropped.slice(0, 3))}`
+    )
+  }
+  if (internalIDs.length === 0) return []
+
   try {
-    const artworks = await context.artworksLoader({ ids: citedIDs })
-    return orderArtworksByCitedIDs(artworks, citedIDs)
+    const artworks = await context.artworksLoader({ ids: internalIDs })
+    return orderArtworksByCitedIDs(artworks, internalIDs)
   } catch (error) {
     Sentry.captureException(error)
     return []


### PR DESCRIPTION
Fixes scenarios where the model was talking about artworks yet no artwork cards were loading.

`artworksLoader` hits Gravity's `/artworks?ids[]=`, which only matches on `internalID` — pass it slugs and you get an empty array back (checked against staging). We were telling the model it could cite either, so any answer that happened to use slugs came back as prose describing artworks with zero cards under it.

internalID is now required in both the prompt and the output schema, citations get filtered to the 24-char hex shape before we hit Gravity, and anything dropped gets logged so we notice rather than silently losing cards.