### PR TITLE
feat: add trending data to agent, modify voice

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -34146,6 +34146,11 @@ type Query {
     id: String!
   ): Tag
   targetSupply: TargetSupply
+
+  """
+  Artists and artworks trending on Artsy over a rolling window, ranked by search and view activity.
+  """
+  trendingSearches(period: TrendingSearchPeriod = ONE_DAY): TrendingSearches
   user(
     """
     Email to search for user by
@@ -35968,6 +35973,9 @@ type SearchCriteriaLabel {
 }
 
 type SearchDropdown {
+  """
+  Artists and artworks trending on Artsy over a rolling window, ranked by search and view activity.
+  """
   trending(period: TrendingSearchPeriod = ONE_DAY): TrendingSearches
 }
 
@@ -43698,6 +43706,11 @@ type Viewer {
     id: String!
   ): Tag
   targetSupply: TargetSupply
+
+  """
+  Artists and artworks trending on Artsy over a rolling window, ranked by search and view activity.
+  """
+  trendingSearches(period: TrendingSearchPeriod = ONE_DAY): TrendingSearches
   user(
     """
     Email to search for user by

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -123,6 +123,68 @@ describe("runQueryArtsyTool", () => {
     expect(result.ok).toBe(false)
   })
 
+  it("runs the trending recipe, through the depth and complexity caps", async () => {
+    const trendingSearchesLoader = jest.fn().mockResolvedValue({
+      data: {
+        artists: [{ entity_id: "4d8b92b34eb68a1b2c000452" }],
+        artworks: [
+          { entity_id: "5d3d7e6a1b8e4a0f2c1a2b3c" },
+          { entity_id: "5d3d7e6a1b8e4a0f2c1a2b3d" },
+        ],
+      },
+    })
+    const artworksLoader = jest.fn().mockResolvedValue([
+      // Returned out of rank order, as Gravity's batch endpoint may.
+      { _id: "5d3d7e6a1b8e4a0f2c1a2b3d", id: "second", title: "Second" },
+      { _id: "5d3d7e6a1b8e4a0f2c1a2b3c", id: "first", title: "First" },
+    ])
+    const context = ({
+      artworksLoader,
+      unauthenticatedLoaders: { trendingSearchesLoader },
+    } as unknown) as ResolverContext
+
+    const result = await runQueryArtsyTool(
+      {
+        query: `
+          {
+            searchDropdown {
+              trending(period: SEVEN_DAYS) {
+                label
+                artworks(first: 20) {
+                  rank
+                  artwork { internalID slug title }
+                }
+              }
+            }
+          }
+        `,
+      },
+      schema,
+      context
+    )
+
+    expect(result.ok).toBe(true)
+    const { artworks } = JSON.parse(result.content).searchDropdown.trending
+    expect(artworks).toEqual([
+      {
+        rank: 1,
+        artwork: {
+          internalID: "5d3d7e6a1b8e4a0f2c1a2b3c",
+          slug: "first",
+          title: "First",
+        },
+      },
+      {
+        rank: 2,
+        artwork: {
+          internalID: "5d3d7e6a1b8e4a0f2c1a2b3d",
+          slug: "second",
+          title: "Second",
+        },
+      },
+    ])
+  })
+
   it("rejects a query that exceeds the depth limit", async () => {
     // Artist -> artworksConnection -> node -> artist -> artworksConnection
     // -> node -> artist -> ... nested well past MAX_QUERY_DEPTH.
@@ -308,6 +370,15 @@ describe("summarizeToolCall", () => {
     expect(
       summarizeToolCall({ query: '{ artist(id: "andy-warhol") { name } }' })
     ).toBe("Querying Artsy: artist…")
+  })
+
+  it("labels a trending query by searchDropdown, not the artwork nested in it", () => {
+    expect(
+      summarizeToolCall({
+        query:
+          "{ searchDropdown { trending { artworks { artwork { slug } } } } }",
+      })
+    ).toBe("Querying Artsy: searchDropdown…")
   })
 
   it("falls back to a generic label when the root field can't be identified", () => {

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -147,13 +147,11 @@ describe("runQueryArtsyTool", () => {
       {
         query: `
           {
-            searchDropdown {
-              trending(period: SEVEN_DAYS) {
-                label
-                artworks(first: 20) {
-                  rank
-                  artwork { internalID slug title }
-                }
+            trendingSearches(period: SEVEN_DAYS) {
+              label
+              artworks(first: 20) {
+                rank
+                artwork { internalID slug title }
               }
             }
           }
@@ -164,7 +162,7 @@ describe("runQueryArtsyTool", () => {
     )
 
     expect(result.ok).toBe(true)
-    const { artworks } = JSON.parse(result.content).searchDropdown.trending
+    const { artworks } = JSON.parse(result.content).trendingSearches
     expect(artworks).toEqual([
       {
         rank: 1,
@@ -372,13 +370,12 @@ describe("summarizeToolCall", () => {
     ).toBe("Querying Artsy: artist…")
   })
 
-  it("labels a trending query by searchDropdown, not the artwork nested in it", () => {
+  it("labels a trending query by trendingSearches, not the artwork nested in it", () => {
     expect(
       summarizeToolCall({
-        query:
-          "{ searchDropdown { trending { artworks { artwork { slug } } } } }",
+        query: "{ trendingSearches { artworks { artwork { slug } } } }",
       })
-    ).toBe("Querying Artsy: searchDropdown…")
+    ).toBe("Querying Artsy: trendingSearches…")
   })
 
   it("falls back to a generic label when the root field can't be identified", () => {

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -46,6 +46,34 @@ Leave \`artworkIDs\` empty only when you found no artworks, or the question isn'
 about artworks at all. Mention an individual work in \`message\` only when the
 user asked about that one specific work.
 
+## Voice
+
+Write like a knowledgeable gallerist talking to a collector: warm, brief,
+concrete. One to three sentences.
+
+**You are Artsy.** Speak as the house, in the first person plural — "we", "our",
+"us" — and address the collector as "you". Never put Artsy in the third person:
+"we don't track that", never "Artsy doesn't track that"; "our trending list",
+never "Artsy's trending list". Naming Artsy as a place is fine ("on Artsy",
+"across Artsy"); handing it agency or knowledge, as though you were describing
+some company you don't work for, is not. Reserve "I" for the rare sentence
+genuinely about you rather than making it the frame for every answer.
+
+Never let the plumbing show. The collector doesn't know there's a schema behind
+this and must never learn it from you, so none of these words belong in
+\`message\`: API, endpoint, schema, field, argument, sort, filter, query,
+connection, tool, database, id. Don't narrate what you checked, introspected
+or tried, and don't describe what is or isn't "available", "exposed" or
+"supported". Talk about art and what people are doing with it, never about how
+you looked it up.
+
+When you can't answer exactly what was asked, don't explain the shortfall and
+stop. Say in plain words what we don't have, pivot in the same breath to the
+closest real thing, and actually *show* it — pulling it in this same turn, with
+the works attached. Offering to fetch something is a dead end: the collector
+has to ask twice and sees nothing in the meantime. Never end on "I can show you
+X if you like" when you could simply have shown X.
+
 ## Workflow
 
 Prefer a small number of well-formed queries over guessing. If you haven't used
@@ -69,6 +97,25 @@ Artist details by slug:
 Shows, searched by name or city and filtered by run status:
   \`showsConnection(term: "<name or city>", status: RUNNING, first: <=20) { edges { node { internalID slug name startAt endAt } } }\`
 
+Trending / most popular artworks or artists ("what's trending", "what's
+popular right now", "what are people looking at"):
+  \`searchDropdown { trending(period: SEVEN_DAYS) { label artworks(first: <=20) { rank artwork { internalID slug title artistNames saleMessage } } } }\`
+  For artists, select \`artists(first: <=20) { rank artist { internalID slug name } }\`
+  on that same \`trending\` field instead.
+
+## When a tool call fails
+
+A failed \`query_artsy\` call reports a category, not a cause: "Not authorized
+to read", "Upstream service error", "Upstream rate limit reached". These are
+*our* infrastructure talking to itself — they say nothing about the user, who
+is already signed in, and nothing about whether the data exists. So never
+repeat one to the user, never tell them they need to sign in or lack
+permission, and never conclude from one that Artsy doesn't have the data.
+
+Fix what you can: a validation error means rewrite the query. Otherwise say the
+specific thing is temporarily unavailable, in one clause, then answer as much
+of the question as your other tool calls did cover.
+
 ## Schema gotchas
 
 - \`priceMin\`, \`priceMax\`, \`listPrice\`, \`estimate\`, \`fee\`, and similar
@@ -89,7 +136,27 @@ Shows, searched by name or city and filtered by run status:
   to array args like \`artistIDs\`.
 - Available root fields are only:
   \`artworksConnection\`, \`artistsConnection\`, \`artist\`, \`artwork\`,
-  \`showsConnection\`, \`matchConnection\`. Anything else will fail validation.
+  \`showsConnection\`, \`matchConnection\`, \`searchDropdown\`. Anything else
+  will fail validation.
+- \`searchDropdown { trending }\` is the *only* popularity ranking in the
+  schema, and it is a real one — computed daily from what people actually
+  search for and view. \`artworksConnection\` has no trending/popular sort, so
+  never answer a "what's popular" question by sorting on recency and never say
+  Artsy has no trending data. \`period\` is \`ONE_DAY\`, \`SEVEN_DAYS\` or
+  \`THIRTY_DAYS\` (default \`ONE_DAY\`); prefer \`SEVEN_DAYS\` unless the user
+  asked specifically about today. The ranking is global — it takes no artist,
+  medium or price filter, so for "trending <something specific>" say the
+  ranking is site-wide before narrowing another way.
+- Saves: an artist's own \`artworksConnection\` takes a real sort enum,
+  including \`RECENT_SAVES_COUNT_DESC\` (most saved in the last 30 days), so
+  \`artist(id: "<slug>") { artworksConnection(sort: RECENT_SAVES_COUNT_DESC, first: <=20) { edges { node { internalID slug title recentSavesCount } } } }\`
+  answers "most saved works by <artist>". The site-wide \`artworksConnection\`
+  takes \`sort\` as a plain string with no saves ranking, so "most saved on
+  Artsy" overall is not answerable — offer trending, or the same question
+  scoped to an artist.
+- \`trending\` returns ranked wrappers, not artworks: the \`internalID\` you cite
+  must come from the nested \`artwork { internalID }\`, and results are already
+  in rank order, so keep that order in \`artworkIDs\`.
 - \`matchConnection\` requires \`term\`; \`entities\` is optional and defaults to
   every searchable type, so pass it (e.g. \`[ARTIST]\`, \`[ARTWORK]\`) to narrow
   the results. Do not pass \`mode: INTERNAL_AUTOSUGGEST\` — it requires a

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -99,9 +99,9 @@ Shows, searched by name or city and filtered by run status:
 
 Trending / most popular artworks or artists ("what's trending", "what's
 popular right now", "what are people looking at"):
-  \`searchDropdown { trending(period: SEVEN_DAYS) { label artworks(first: <=20) { rank artwork { internalID slug title artistNames saleMessage } } } }\`
+  \`trendingSearches(period: SEVEN_DAYS) { label artworks(first: <=20) { rank artwork { internalID slug title artistNames saleMessage } } }\`
   For artists, select \`artists(first: <=20) { rank artist { internalID slug name } }\`
-  on that same \`trending\` field instead.
+  on that same field instead.
 
 ## When a tool call fails
 
@@ -136,9 +136,9 @@ of the question as your other tool calls did cover.
   to array args like \`artistIDs\`.
 - Available root fields are only:
   \`artworksConnection\`, \`artistsConnection\`, \`artist\`, \`artwork\`,
-  \`showsConnection\`, \`matchConnection\`, \`searchDropdown\`. Anything else
+  \`showsConnection\`, \`matchConnection\`, \`trendingSearches\`. Anything else
   will fail validation.
-- \`searchDropdown { trending }\` is the *only* popularity ranking in the
+- \`trendingSearches\` is the *only* popularity ranking in the
   schema, and it is a real one — computed daily from what people actually
   search for and view. \`artworksConnection\` has no trending/popular sort, so
   never answer a "what's popular" question by sorting on recency and never say
@@ -154,7 +154,7 @@ of the question as your other tool calls did cover.
   takes \`sort\` as a plain string with no saves ranking, so "most saved on
   Artsy" overall is not answerable — offer trending, or the same question
   scoped to an artist.
-- \`trending\` returns ranked wrappers, not artworks: the \`internalID\` you cite
+- \`trendingSearches\` returns ranked wrappers, not artworks: the \`internalID\` you cite
   must come from the nested \`artwork { internalID }\`, and results are already
   in rank order, so keep that order in \`artworkIDs\`.
 - \`matchConnection\` requires \`term\`; \`entities\` is optional and defaults to

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -46,7 +46,7 @@ const ALLOWED_ROOT_FIELDS = new Set([
   "artwork",
   "showsConnection",
   "matchConnection",
-  "searchDropdown",
+  "trendingSearches",
 ])
 
 const rootFieldFilter: RootFieldFilter = (operation, rootFieldName) =>
@@ -342,7 +342,7 @@ export function buildAgentTools(
         "Run a read-only GraphQL query to search and look up artists, " +
         "artworks, shows, and fairs. Available root fields: " +
         "artworksConnection, artistsConnection, artist, artwork, " +
-        "showsConnection, matchConnection, searchDropdown (the last one for " +
+        "showsConnection, matchConnection, trendingSearches (the last one for " +
         "trending/most-popular rankings). Use GraphQL introspection (e.g. " +
         '`{ __type(name: "Artwork") { fields { name description } } }`) to ' +
         "discover the fields and args available on any type — one type at a " +
@@ -380,7 +380,7 @@ export function summarizeToolCall(input: unknown): string {
   if (typeof query !== "string") return "Querying Artsy…"
 
   const match = query.match(
-    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|searchDropdown)\b/
+    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|trendingSearches)\b/
   )
   return match ? `Querying Artsy: ${match[1]}…` : "Querying Artsy…"
 }

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -46,6 +46,7 @@ const ALLOWED_ROOT_FIELDS = new Set([
   "artwork",
   "showsConnection",
   "matchConnection",
+  "searchDropdown",
 ])
 
 const rootFieldFilter: RootFieldFilter = (operation, rootFieldName) =>
@@ -341,7 +342,8 @@ export function buildAgentTools(
         "Run a read-only GraphQL query to search and look up artists, " +
         "artworks, shows, and fairs. Available root fields: " +
         "artworksConnection, artistsConnection, artist, artwork, " +
-        "showsConnection, matchConnection. Use GraphQL introspection (e.g. " +
+        "showsConnection, matchConnection, searchDropdown (the last one for " +
+        "trending/most-popular rankings). Use GraphQL introspection (e.g. " +
         '`{ __type(name: "Artwork") { fields { name description } } }`) to ' +
         "discover the fields and args available on any type — one type at a " +
         "time, as `__schema` is not available. Always " +
@@ -378,7 +380,7 @@ export function summarizeToolCall(input: unknown): string {
   if (typeof query !== "string") return "Querying Artsy…"
 
   const match = query.match(
-    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection)\b/
+    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|searchDropdown)\b/
   )
   return match ? `Querying Artsy: ${match[1]}…` : "Querying Artsy…"
 }

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -132,7 +132,7 @@ import { SaleArtworksConnectionField } from "./sale_artworks"
 import { SalesConnectionField } from "./sales"
 import { Search } from "./search"
 import { SearchableItem } from "./SearchableItem"
-import { SearchDropdown } from "./searchDropdown"
+import { SearchDropdown, TrendingSearches } from "./searchDropdown"
 import { sendFeedbackMutation } from "./sendFeedbackMutation"
 import Show from "./show"
 import ShippingPreset from "./shippingPreset"
@@ -584,6 +584,7 @@ const rootFields = {
   system: System,
   tag: TagField,
   targetSupply: TargetSupply,
+  trendingSearches: TrendingSearches,
   user: UserField,
   usersConnection: Users,
   vanityURLEntity: VanityURLEntity,

--- a/src/schema/v2/searchDropdown/index.ts
+++ b/src/schema/v2/searchDropdown/index.ts
@@ -165,18 +165,22 @@ const TrendingSearchesType = new GraphQLObjectType<
   }),
 })
 
+const trendingSearchesField: GraphQLFieldConfig<any, ResolverContext> = {
+  // Nullable so a Vortex failure nulls this field rather than the query.
+  type: TrendingSearchesType,
+  description:
+    "Artists and artworks trending on Artsy over a rolling window, ranked by " +
+    "search and view activity.",
+  args: {
+    period: { type: TrendingSearchPeriodEnum, defaultValue: "1d" },
+  },
+  resolve: (_parent, { period }, context) => trendingWindowFor(period, context),
+}
+
 const SearchDropdownType = new GraphQLObjectType<void, ResolverContext>({
   name: "SearchDropdown",
   fields: () => ({
-    trending: {
-      // Nullable so a Vortex failure nulls this field rather than the query.
-      type: TrendingSearchesType,
-      args: {
-        period: { type: TrendingSearchPeriodEnum, defaultValue: "1d" },
-      },
-      resolve: (_parent, { period }, context) =>
-        trendingWindowFor(period, context),
-    },
+    trending: trendingSearchesField,
   }),
 })
 
@@ -184,3 +188,5 @@ export const SearchDropdown: GraphQLFieldConfig<void, ResolverContext> = {
   type: new GraphQLNonNull(SearchDropdownType),
   resolve: () => ({}),
 }
+
+export const TrendingSearches = trendingSearchesField


### PR DESCRIPTION
Add trending artwork/artist data to agent. Modify voice to improve message quality, avoiding technical language, showing the internal plumbing or treating Artsy as a 3rd party.

<img width="1316" height="758" alt="Screenshot 2026-08-28 at 11 24 29" src="https://github.com/user-attachments/assets/3406ca8b-d7a3-4dcb-b037-1553ec0e1dd2" />
<img width="1401" height="742" alt="Screenshot 2026-08-28 at 11 38 13" src="https://github.com/user-attachments/assets/884a0b31-7d46-43d4-8b39-7a4bbea80116" />


