### PR TITLE
feat(ArtworkFilter): add increasedInterest and curatorsPick

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -580,6 +580,11 @@ type Alert {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -623,6 +628,11 @@ type Alert {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -2549,6 +2559,11 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -2592,6 +2607,11 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -3194,6 +3214,11 @@ type ArtistPartnerEdge {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -3237,6 +3262,11 @@ type ArtistPartnerEdge {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -3446,6 +3476,11 @@ type ArtistSeries implements Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -3489,6 +3524,11 @@ type ArtistSeries implements Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -4897,6 +4937,11 @@ type ArtworkFilterNode {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -4940,6 +4985,11 @@ type ArtworkFilterNode {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -18302,6 +18352,11 @@ interface EntityWithFilterArtworksConnectionInterface {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -18345,6 +18400,11 @@ interface EntityWithFilterArtworksConnectionInterface {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     inquireableOnly: Boolean
     keyword: String
 
@@ -18777,6 +18837,11 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -18820,6 +18885,11 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -19572,6 +19642,11 @@ input FilterArtworksInput {
   Filter by artwork completeness tiers. Accepts multiple values.
   """
   completenessTier: [String]
+
+  """
+  When true, will only return artworks carrying the Curators' Pick collector signal.
+  """
+  curatorsPick: Boolean
   dimensionRange: String
 
   """
@@ -19615,6 +19690,11 @@ input FilterArtworksInput {
   """
   includeNonArtsyListed: Boolean
   includeUnpublished: Boolean
+
+  """
+  When true, will only return artworks carrying the Increased Interest collector signal.
+  """
+  increasedInterest: Boolean
   inquireableOnly: Boolean
   keyword: String
 
@@ -20368,6 +20448,11 @@ type Gene implements Node & Searchable {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -20411,6 +20496,11 @@ type Gene implements Node & Searchable {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -23525,6 +23615,11 @@ type MarketingCollection implements Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -23568,6 +23663,11 @@ type MarketingCollection implements Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -28917,6 +29017,11 @@ type Partner implements Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -28960,6 +29065,11 @@ type Partner implements Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -29487,6 +29597,11 @@ type PartnerArtist {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -29530,6 +29645,11 @@ type PartnerArtist {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -29786,6 +29906,11 @@ type PartnerArtistEdge {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -29829,6 +29954,11 @@ type PartnerArtistEdge {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -32164,6 +32294,11 @@ type Query {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -32207,6 +32342,11 @@ type Query {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -32774,6 +32914,11 @@ type Query {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -32822,6 +32967,11 @@ type Query {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -36573,6 +36723,11 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -36616,6 +36771,11 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -37440,6 +37600,11 @@ type Tag implements Node {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -37483,6 +37648,11 @@ type Tag implements Node {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -42065,6 +42235,11 @@ type Viewer {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -42108,6 +42283,11 @@ type Viewer {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String
@@ -42464,6 +42644,11 @@ type Viewer {
     Filter by artwork completeness tiers. Accepts multiple values.
     """
     completenessTier: [String]
+
+    """
+    When true, will only return artworks carrying the Curators' Pick collector signal.
+    """
+    curatorsPick: Boolean
     dimensionRange: String
 
     """
@@ -42512,6 +42697,11 @@ type Viewer {
     """
     includeNonArtsyListed: Boolean
     includeUnpublished: Boolean
+
+    """
+    When true, will only return artworks carrying the Increased Interest collector signal.
+    """
+    increasedInterest: Boolean
     input: FilterArtworksInput
     inquireableOnly: Boolean
     keyword: String

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -582,7 +582,7 @@ type Alert {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -2561,7 +2561,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -3216,7 +3216,7 @@ type ArtistPartnerEdge {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -3478,7 +3478,7 @@ type ArtistSeries implements Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -4939,7 +4939,7 @@ type ArtworkFilterNode {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -18354,7 +18354,7 @@ interface EntityWithFilterArtworksConnectionInterface {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -18839,7 +18839,7 @@ type Fair implements EntityWithFilterArtworksConnectionInterface & Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -19644,7 +19644,7 @@ input FilterArtworksInput {
   completenessTier: [String]
 
   """
-  When true, will only return artworks carrying the Curators' Pick collector signal.
+  When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
   """
   curatorsPick: Boolean
   dimensionRange: String
@@ -20450,7 +20450,7 @@ type Gene implements Node & Searchable {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -23617,7 +23617,7 @@ type MarketingCollection implements Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -29019,7 +29019,7 @@ type Partner implements Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -29599,7 +29599,7 @@ type PartnerArtist {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -29908,7 +29908,7 @@ type PartnerArtistEdge {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -32296,7 +32296,7 @@ type Query {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -32916,7 +32916,7 @@ type Query {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -36725,7 +36725,7 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -37602,7 +37602,7 @@ type Tag implements Node {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -42237,7 +42237,7 @@ type Viewer {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String
@@ -42646,7 +42646,7 @@ type Viewer {
     completenessTier: [String]
 
     """
-    When true, will only return artworks carrying the Curators' Pick collector signal.
+    When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.
     """
     curatorsPick: Boolean
     dimensionRange: String

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1709,6 +1709,98 @@ describe("artworksConnection", () => {
     })
   })
 
+  describe("collector signal filters", () => {
+    const buildContext = () => {
+      const filterArtworksLoader = jest.fn(() =>
+        Promise.resolve({
+          hits: [{ id: "artwork1", title: "Artwork 1" }],
+          aggregations: { total: { value: 1 } },
+        })
+      )
+
+      return {
+        filterArtworksLoader,
+        context: {
+          authenticatedLoaders: {},
+          unauthenticatedLoaders: { filterArtworksLoader },
+        },
+      }
+    }
+
+    const queryWithInput = (input) => gql`
+        {
+          artworksConnection(input: { ${input} aggregations: [TOTAL], first: 10 }) {
+            edges {
+              node {
+                slug
+              }
+            }
+          }
+        }
+      `
+
+    it("translates curatorsPick into marketing_collection_id", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(queryWithInput("curatorsPick: true"), context)
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketing_collection_id: "curators-picks-emerging-artists",
+        })
+      )
+    })
+
+    it("does not leak curators_pick through to the loader", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(queryWithInput("curatorsPick: true"), context)
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({ curators_pick: expect.anything() })
+      )
+    })
+
+    it("passes increased_interest_signal to the loader", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(queryWithInput("increasedInterest: true"), context)
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({ increased_interest_signal: true })
+      )
+    })
+
+    it("passes both signals independently", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(
+        queryWithInput("curatorsPick: true, increasedInterest: true"),
+        context
+      )
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          marketing_collection_id: "curators-picks-emerging-artists",
+          increased_interest_signal: true,
+        })
+      )
+    })
+
+    it("omits both when not provided", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(queryWithInput(""), context)
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          marketing_collection_id: expect.anything(),
+          increased_interest_signal: expect.anything(),
+        })
+      )
+    })
+  })
+
   describe(`completenessTier filter`, () => {
     let context
 

--- a/src/schema/v2/__tests__/filterArtworksConnection.test.ts
+++ b/src/schema/v2/__tests__/filterArtworksConnection.test.ts
@@ -1761,6 +1761,53 @@ describe("artworksConnection", () => {
       )
     })
 
+    it("strips curators_pick when explicitly false", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(queryWithInput("curatorsPick: false"), context)
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({ curators_pick: expect.anything() })
+      )
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          marketing_collection_id: expect.anything(),
+        })
+      )
+    })
+
+    it("leaves a client-provided marketingCollectionID alone when curatorsPick is false", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await runQuery(
+        queryWithInput(
+          'curatorsPick: false, marketingCollectionID: "trending"'
+        ),
+        context
+      )
+
+      expect(filterArtworksLoader).toHaveBeenCalledWith(
+        expect.objectContaining({ marketing_collection_id: "trending" })
+      )
+    })
+
+    it("errors rather than overwriting a client-provided marketingCollectionID", async () => {
+      const { filterArtworksLoader, context } = buildContext()
+
+      await expect(
+        runQuery(
+          queryWithInput(
+            'curatorsPick: true, marketingCollectionID: "trending"'
+          ),
+          context
+        )
+      ).rejects.toThrow(
+        "`curatorsPick` cannot be combined with `marketingCollectionID`"
+      )
+
+      expect(filterArtworksLoader).not.toHaveBeenCalled()
+    })
+
     it("passes increased_interest_signal to the loader", async () => {
       const { filterArtworksLoader, context } = buildContext()
 

--- a/src/schema/v2/artwork/collectorSignals.ts
+++ b/src/schema/v2/artwork/collectorSignals.ts
@@ -252,9 +252,11 @@ const getActivePartnerOffer = async (artwork, ctx) => {
   return partnerOffers.body?.find((po) => po.active)
 }
 
-const getIsCuratorsPick = async (artwork, ctx) => {
-  const CURATED_COLLECTION_SLUGS = ["curators-picks-emerging-artists"]
+export const CURATORS_PICK_COLLECTION_SLUG = "curators-picks-emerging-artists"
 
+const CURATED_COLLECTION_SLUGS = [CURATORS_PICK_COLLECTION_SLUG]
+
+const getIsCuratorsPick = async (artwork, ctx) => {
   const checks = await Promise.all(
     CURATED_COLLECTION_SLUGS.map(async (slug) => {
       const collection = await ctx.marketingCollectionLoader(slug)

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -157,7 +157,7 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   curatorsPick: {
     type: GraphQLBoolean,
     description:
-      "When true, will only return artworks carrying the Curators' Pick collector signal.",
+      "When true, will only return artworks carrying the Curators' Pick collector signal. Cannot be combined with `marketingCollectionID`.",
   },
   dimensionRange: {
     type: GraphQLString,
@@ -577,8 +577,6 @@ const convertFilterArgs = ({
     attribution_class: attributionClass,
     certificate_of_authenticity: certificateOfAuthenticity,
     completeness_tier: completenessTier,
-    // Translated into `marketing_collection_id` by the resolver; Gravity has no
-    // `curators_pick` param of its own.
     curators_pick: curatorsPick,
     dimension_range: dimensionRange,
     exclude_artwork_ids: excludeArtworkIDs,
@@ -650,8 +648,16 @@ const filterArtworksConnectionTypeFactory = (
       ...argsProvidedInInput,
     }
 
-    if (options.curators_pick) {
-      delete options.curators_pick
+    const curatorsPick = options.curators_pick
+    delete options.curators_pick
+
+    if (curatorsPick) {
+      if (options.marketing_collection_id) {
+        throw new Error(
+          "`curatorsPick` cannot be combined with `marketingCollectionID` — both resolve to the same Gravity filter."
+        )
+      }
+
       options.marketing_collection_id = CURATORS_PICK_COLLECTION_SLUG
     }
 

--- a/src/schema/v2/filterArtworksConnection.ts
+++ b/src/schema/v2/filterArtworksConnection.ts
@@ -36,6 +36,7 @@ import {
 import { ResolverContext } from "types/graphql"
 
 import { deprecate } from "lib/deprecation"
+import { CURATORS_PICK_COLLECTION_SLUG } from "schema/v2/artwork/collectorSignals"
 import { keys, map, omit } from "lodash"
 import {
   ArtworksAggregation,
@@ -153,6 +154,11 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   colors: {
     type: new GraphQLList(GraphQLString),
   },
+  curatorsPick: {
+    type: GraphQLBoolean,
+    description:
+      "When true, will only return artworks carrying the Curators' Pick collector signal.",
+  },
   dimensionRange: {
     type: GraphQLString,
   },
@@ -201,6 +207,11 @@ export const filterArtworksArgs: GraphQLFieldConfigArgumentMap = {
   },
   includeUnpublished: {
     type: GraphQLBoolean,
+  },
+  increasedInterest: {
+    type: GraphQLBoolean,
+    description:
+      "When true, will only return artworks carrying the Increased Interest collector signal.",
   },
   inquireableOnly: {
     type: GraphQLBoolean,
@@ -514,6 +525,7 @@ const convertFilterArgs = ({
   attributionClass,
   certificateOfAuthenticity,
   completenessTier,
+  curatorsPick,
   dimensionRange,
   excludeArtworkIDs,
   extraAggregationGeneIDs,
@@ -526,6 +538,7 @@ const convertFilterArgs = ({
   includeMediumFilterInAggregation,
   includeNonArtsyListed,
   includeUnpublished,
+  increasedInterest,
   inquireableOnly,
   keywordMatchExact,
   keywordTypoTolerance,
@@ -564,6 +577,9 @@ const convertFilterArgs = ({
     attribution_class: attributionClass,
     certificate_of_authenticity: certificateOfAuthenticity,
     completeness_tier: completenessTier,
+    // Translated into `marketing_collection_id` by the resolver; Gravity has no
+    // `curators_pick` param of its own.
+    curators_pick: curatorsPick,
     dimension_range: dimensionRange,
     exclude_artwork_ids: excludeArtworkIDs,
     extra_aggregation_gene_ids: extraAggregationGeneIDs,
@@ -577,6 +593,7 @@ const convertFilterArgs = ({
     include_medium_filter_in_aggregation: includeMediumFilterInAggregation,
     include_non_artsy_listed: includeNonArtsyListed,
     include_unpublished: includeUnpublished,
+    increased_interest_signal: increasedInterest,
     inquireable_only: inquireableOnly,
     keyword_match_exact: keywordMatchExact,
     keyword_typo_tolerance: keywordTypoTolerance,
@@ -631,6 +648,11 @@ const filterArtworksConnectionTypeFactory = (
     const options: any = {
       ...argsProvidedAtRoot,
       ...argsProvidedInInput,
+    }
+
+    if (options.curators_pick) {
+      delete options.curators_pick
+      options.marketing_collection_id = CURATORS_PICK_COLLECTION_SLUG
     }
 
     const {


### PR DESCRIPTION
Related to https://github.com/artsy/gravity/pull/20470

Wires `curatorsPick` and `increasedInterest` to the artwork filters.