### PR TITLE
feat: Simplify interface, fetch article data from the Artist Node

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2848,14 +2848,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   last: String
 
   """
-  The most recent published article featuring this artist, optionally limited to those published since a given date.
+  The most recent editorial article featuring this artist, published in the last 12 months.
   """
-  latestArticle(
-    """
-    Only return articles published since this ISO 8601 date.
-    """
-    publishedSince: String
-  ): Article
+  latestArticle: ArtistLatestArticle
   location: String
   marketingCollections(
     after: String
@@ -3186,6 +3181,10 @@ type ArtistInstagramMedia {
   image: Image
   internalID: String
   permalink: String
+}
+
+type ArtistLatestArticle {
+  href: String
 }
 
 type ArtistMeta {

--- a/src/schema/v2/artist/__tests__/latestArticle.test.ts
+++ b/src/schema/v2/artist/__tests__/latestArticle.test.ts
@@ -7,125 +7,85 @@ const ARTIST_FIXTURE = {
   name: "Gerhard Richter",
 }
 
-const ARTICLE_FIXTURE = {
-  id: "some-article-id",
-  slug: "some-article",
-  title: "Gerhard Richter at the MoMA",
-  published_at: "2024-01-15T00:00:00.000Z",
-}
+const recentDate = new Date()
+recentDate.setMonth(recentDate.getMonth() - 1)
+const RECENT_DATE = recentDate.toISOString()
+
+const exactlyOneYearAgo = new Date()
+exactlyOneYearAgo.setFullYear(exactlyOneYearAgo.getFullYear() - 1)
+exactlyOneYearAgo.setDate(exactlyOneYearAgo.getDate() - 1)
+const JUST_EXPIRED_DATE = exactlyOneYearAgo.toISOString()
+
+const oldDate = new Date()
+oldDate.setFullYear(oldDate.getFullYear() - 2)
+const OLD_DATE = oldDate.toISOString()
+
+const query = gql`
+  {
+    artist(id: "gerhard-richter") {
+      latestArticle {
+        href
+      }
+    }
+  }
+`
 
 describe("Artist#latestArticle", () => {
-  it("returns the most recent published article featuring the artist", async () => {
-    const query = gql`
-      {
-        artist(id: "gerhard-richter") {
-          latestArticle {
-            slug
-            title
-          }
-        }
-      }
-    `
-
-    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
-    const articlesLoader = jest.fn().mockResolvedValue({
-      results: [ARTICLE_FIXTURE],
+  it("returns href when article was published within the last year", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      ...ARTIST_FIXTURE,
+      latest_article_href: "/article/gerhard-richter-moma",
+      latest_article_published_at: RECENT_DATE,
     })
 
-    const { artist } = await runQuery(query, { artistLoader, articlesLoader })
+    const { artist } = await runQuery(query, { artistLoader })
 
     expect(artist.latestArticle).toEqual({
-      slug: "some-article",
-      title: "Gerhard Richter at the MoMA",
+      href: "/article/gerhard-richter-moma",
     })
-
-    expect(articlesLoader).toBeCalledWith(
-      expect.objectContaining({
-        published: true,
-        artist_id: "artist-id",
-        sort: "-published_at",
-        limit: 1,
-      })
-    )
   })
 
-  it("returns null when no articles feature the artist", async () => {
-    const query = gql`
-      {
-        artist(id: "gerhard-richter") {
-          latestArticle {
-            slug
-          }
-        }
-      }
-    `
-
+  it("returns null when no article is stored", async () => {
     const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
-    const articlesLoader = jest.fn().mockResolvedValue({ results: [] })
 
-    const { artist } = await runQuery(query, { artistLoader, articlesLoader })
+    const { artist } = await runQuery(query, { artistLoader })
 
     expect(artist.latestArticle).toBeNull()
   })
 
-  it("does not call articlesLoader when latestArticle is not requested", async () => {
-    const query = gql`
-      {
-        artist(id: "gerhard-richter") {
-          name
-        }
-      }
-    `
+  it("returns null when latest_article_href is missing but published_at is present", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      ...ARTIST_FIXTURE,
+      latest_article_href: null,
+      latest_article_published_at: RECENT_DATE,
+    })
 
-    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
-    const articlesLoader = jest.fn()
+    const { artist } = await runQuery(query, { artistLoader })
 
-    await runQuery(query, { artistLoader, articlesLoader })
-
-    expect(articlesLoader).not.toHaveBeenCalled()
+    expect(artist.latestArticle).toBeNull()
   })
 
-  it("passes publishedSince as published_since to articlesLoader", async () => {
-    const query = gql`
-      {
-        artist(id: "gerhard-richter") {
-          latestArticle(publishedSince: "2024-01-01") {
-            slug
-          }
-        }
-      }
-    `
+  it("returns null when the article was published more than a year ago", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      ...ARTIST_FIXTURE,
+      latest_article_href: "/article/old-article",
+      latest_article_published_at: OLD_DATE,
+    })
 
-    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
-    const articlesLoader = jest.fn().mockResolvedValue({ results: [] })
+    const { artist } = await runQuery(query, { artistLoader })
 
-    await runQuery(query, { artistLoader, articlesLoader })
-
-    expect(articlesLoader).toBeCalledWith(
-      expect.objectContaining({
-        published_since: "2024-01-01",
-      })
-    )
+    expect(artist.latestArticle).toBeNull()
   })
 
-  it("does not pass published_since when publishedSince is not provided", async () => {
-    const query = gql`
-      {
-        artist(id: "gerhard-richter") {
-          latestArticle {
-            slug
-          }
-        }
-      }
-    `
+  it("returns null when the article is just over a year old", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      ...ARTIST_FIXTURE,
+      latest_article_href: "/article/just-expired",
+      latest_article_published_at: JUST_EXPIRED_DATE,
+    })
 
-    const artistLoader = jest.fn().mockResolvedValue(ARTIST_FIXTURE)
-    const articlesLoader = jest.fn().mockResolvedValue({ results: [] })
+    const { artist } = await runQuery(query, { artistLoader })
 
-    await runQuery(query, { artistLoader, articlesLoader })
-
-    expect(articlesLoader).toBeCalledWith(
-      expect.not.objectContaining({ published_since: expect.anything() })
-    )
+    expect(artist.latestArticle).toBeNull()
   })
 })

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -440,24 +440,23 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           }).then((articles) => first(articles.results)),
       },
       latestArticle: {
-        type: Article.type,
-        description:
-          "The most recent published article featuring this artist, optionally limited to those published since a given date.",
-        args: {
-          publishedSince: {
-            type: GraphQLString,
-            description:
-              "Only return articles published since this ISO 8601 date.",
+        type: new GraphQLObjectType<any, ResolverContext>({
+          name: "ArtistLatestArticle",
+          fields: {
+            href: { type: GraphQLString },
           },
+        }),
+        description:
+          "The most recent editorial article featuring this artist, published in the last 12 months. ",
+        resolve: ({ latest_article_href, latest_article_published_at }) => {
+          if (!latest_article_href || !latest_article_published_at) return null
+
+          const oneYearAgo = new Date()
+          oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+          if (new Date(latest_article_published_at) < oneYearAgo) return null
+
+          return { href: latest_article_href }
         },
-        resolve: ({ _id }, { publishedSince }, { articlesLoader }) =>
-          articlesLoader({
-            published: true,
-            artist_id: _id,
-            sort: "-published_at",
-            limit: 1,
-            ...(publishedSince && { published_since: publishedSince }),
-          }).then((articles) => first(articles.results)),
       },
       biographyBlurb: {
         args: {


### PR DESCRIPTION
feat: Update to now fetch article presence off of `Artist` node. This data is now accessible on the public JSON of artist coming from Gravity


Performance improvement with the new backend: https://github.com/artsy/gravity/pull/20480

We can now access article published at data and `href` from Gravity, no longer needing to use the `articleLoader` to make roundtrip calls to positron