### PR TITLE
chore: add artnet artwork schema for OS

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3825,6 +3825,105 @@ type ArtistsWithAlertCountsEdge {
   totalAlertCount: Int
 }
 
+"""
+Artnet record of an artwork.
+"""
+type ArtnetArtwork {
+  artnetEditionSets: [ArtnetEditionSet]
+  artnetId: String
+
+  """
+  Artnet availability vocabulary, e.g. For Sale or Price on Request.
+  """
+  availability: String
+  createdAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  A type-specific ID likely used as a database ID.
+  """
+  internalID: ID!
+
+  """
+  Medium names + materials for this artwork, e.g. Paintings, Oil.
+  """
+  mediums: [String]
+  priceCurrency: String
+  priceFrom: Money
+  priceTo: Money
+
+  """
+  Whether the artwork is published on Artnet.
+  """
+  published: Boolean
+  updatedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+}
+
+"""
+An Artnet edition set.
+"""
+type ArtnetEditionSet {
+  artnetId: String
+
+  """
+  Artnet availability vocabulary, e.g. For Sale or Price on Request.
+  """
+  availability: String
+
+  """
+  The corresponding CatalogEditionSet, if this edition set has been matched to one.
+  """
+  catalogEditionSetId: String
+  createdAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  A type-specific ID likely used as a database ID.
+  """
+  internalID: ID!
+  label: String
+  priceCurrency: String
+  priceFrom: Money
+  priceTo: Money
+  updatedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+}
+
 type ArtsyShippingOptInMutationFailure {
   mutationError: GravityMutationError
 }
@@ -8293,6 +8392,10 @@ type CareerHighlight implements Node {
 }
 
 type CatalogArtwork {
+  """
+  Artnet record of this catalog artwork.
+  """
+  artnetArtwork: ArtnetArtwork
   artworkId: String
   availability: String
 

--- a/src/schema/v2/artnet/artnetArtwork.ts
+++ b/src/schema/v2/artnet/artnetArtwork.ts
@@ -1,0 +1,75 @@
+import {
+  GraphQLBoolean,
+  GraphQLList,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "../object_identification"
+import { date } from "../fields/date"
+import { moneyFieldFromMinor } from "../fields/money"
+import {
+  ArtnetEditionSetGravityResponse,
+  ArtnetEditionSetType,
+} from "./artnetEditionSet"
+
+export interface ArtnetArtworkGravityResponse {
+  id: string
+  catalog_artwork_id: string
+  artnet_id: string | null
+  mediums: string[]
+  availability: string | null
+  price_currency: string | null
+  price_from_minor: number | null
+  price_to_minor: number | null
+  published: boolean
+  artnet_edition_sets: ArtnetEditionSetGravityResponse[]
+  created_at: string
+  updated_at: string
+}
+
+export const ArtnetArtworkType = new GraphQLObjectType<
+  ArtnetArtworkGravityResponse,
+  ResolverContext
+>({
+  name: "ArtnetArtwork",
+  description: "Artnet record of an artwork.",
+  fields: {
+    ...InternalIDFields,
+    artnetId: {
+      type: GraphQLString,
+      resolve: ({ artnet_id }) => artnet_id,
+    },
+    mediums: {
+      type: new GraphQLList(GraphQLString),
+      description:
+        "Medium names + materials for this artwork, e.g. Paintings, Oil.",
+      resolve: ({ mediums }) => mediums ?? [],
+    },
+    availability: {
+      type: GraphQLString,
+      description:
+        "Artnet availability vocabulary, e.g. For Sale or Price on Request.",
+    },
+    priceCurrency: {
+      type: GraphQLString,
+      resolve: ({ price_currency }) => price_currency,
+    },
+    priceFrom: moneyFieldFromMinor<ArtnetArtworkGravityResponse>(
+      "price_from_minor"
+    ),
+    priceTo: moneyFieldFromMinor<ArtnetArtworkGravityResponse>(
+      "price_to_minor"
+    ),
+    published: {
+      type: GraphQLBoolean,
+      description: "Whether the artwork is published on Artnet.",
+    },
+    artnetEditionSets: {
+      type: new GraphQLList(ArtnetEditionSetType),
+      resolve: ({ artnet_edition_sets }) => artnet_edition_sets ?? [],
+    },
+    createdAt: date(),
+    updatedAt: date(),
+  },
+})

--- a/src/schema/v2/artnet/artnetEditionSet.ts
+++ b/src/schema/v2/artnet/artnetEditionSet.ts
@@ -1,0 +1,57 @@
+import { GraphQLObjectType, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { InternalIDFields } from "../object_identification"
+import { date } from "../fields/date"
+import { moneyFieldFromMinor } from "../fields/money"
+
+export interface ArtnetEditionSetGravityResponse {
+  id: string
+  catalog_edition_set_id: string | null
+  artnet_id: number | null // Artnet's numeric editionId.
+  label: string | null
+  price_from_minor: number | null
+  price_to_minor: number | null
+  price_currency: string | null
+  availability: string | null
+  created_at: string
+  updated_at: string
+}
+
+export const ArtnetEditionSetType = new GraphQLObjectType<
+  ArtnetEditionSetGravityResponse,
+  ResolverContext
+>({
+  name: "ArtnetEditionSet",
+  description: "An Artnet edition set.",
+  fields: {
+    ...InternalIDFields,
+    catalogEditionSetId: {
+      type: GraphQLString,
+      description:
+        "The corresponding CatalogEditionSet, if this edition set has been matched to one.",
+      resolve: ({ catalog_edition_set_id }) => catalog_edition_set_id,
+    },
+    artnetId: {
+      type: GraphQLString,
+      resolve: ({ artnet_id }) => artnet_id?.toString(),
+    },
+    label: { type: GraphQLString },
+    priceCurrency: {
+      type: GraphQLString,
+      resolve: ({ price_currency }) => price_currency,
+    },
+    priceFrom: moneyFieldFromMinor<ArtnetEditionSetGravityResponse>(
+      "price_from_minor"
+    ),
+    priceTo: moneyFieldFromMinor<ArtnetEditionSetGravityResponse>(
+      "price_to_minor"
+    ),
+    availability: {
+      type: GraphQLString,
+      description:
+        "Artnet availability vocabulary, e.g. For Sale or Price on Request.",
+    },
+    createdAt: date(),
+    updatedAt: date(),
+  },
+})

--- a/src/schema/v2/artwork/__tests__/artnetArtwork.test.ts
+++ b/src/schema/v2/artwork/__tests__/artnetArtwork.test.ts
@@ -1,0 +1,308 @@
+import { runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("CatalogArtwork.artnetArtwork", () => {
+  const mockArtworkWithArtnetArtwork = (artnetArtwork) => () =>
+    Promise.resolve({
+      id: "some-artwork",
+      _id: "artwork-internal-id",
+      title: "Some Artwork",
+      catalog_artwork: {
+        id: "catalog-artwork-id",
+        artnet_artwork: artnetArtwork,
+      },
+    })
+
+  it("returns null when artnet_artwork is not present", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              internalID
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork(null),
+    })
+
+    expect(data).toEqual({
+      artwork: { catalogArtwork: { artnetArtwork: null } },
+    })
+  })
+
+  it("returns scalar fields", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              internalID
+              artnetId
+              availability
+              published
+              priceCurrency
+              mediums
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+        artnet_id: "12345",
+        availability: "Price on Request",
+        published: true,
+        price_currency: "USD",
+        mediums: ["Paintings", "Works on paper"],
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: {
+          artnetArtwork: {
+            internalID: "artnet-artwork-id",
+            artnetId: "12345",
+            availability: "Price on Request",
+            published: true,
+            priceCurrency: "USD",
+            mediums: ["Paintings", "Works on paper"],
+          },
+        },
+      },
+    })
+  })
+
+  it("returns an empty list when mediums is not present", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              mediums
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: { catalogArtwork: { artnetArtwork: { mediums: [] } } },
+    })
+  })
+
+  it("returns priceFrom as a Money type and priceTo as null when absent", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              priceFrom {
+                major
+                minor
+                currencyCode
+                display
+              }
+              priceTo {
+                major
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+        price_from_minor: 250000,
+        price_currency: "USD",
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: {
+          artnetArtwork: {
+            priceFrom: {
+              major: 2500,
+              minor: 250000,
+              currencyCode: "USD",
+              display: "US$2,500",
+            },
+            priceTo: null,
+          },
+        },
+      },
+    })
+  })
+
+  it("returns null for priceFrom when price_currency is missing, without throwing", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              priceFrom {
+                major
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+        price_from_minor: 250000,
+        price_currency: null,
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: { artnetArtwork: { priceFrom: null } },
+      },
+    })
+  })
+
+  it("returns nested artnetEditionSets", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              artnetEditionSets {
+                internalID
+                catalogEditionSetId
+                artnetId
+                label
+                availability
+                priceFrom {
+                  major
+                }
+                priceTo {
+                  major
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+        artnet_edition_sets: [
+          {
+            id: "artnet-edition-set-1",
+            catalog_edition_set_id: "catalog-edition-set-1",
+            artnet_id: 1000,
+            label: "Edition of 10",
+            availability: "For Sale",
+            price_from_minor: 100000,
+            price_to_minor: 200000,
+            price_currency: "USD",
+          },
+        ],
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: {
+          artnetArtwork: {
+            artnetEditionSets: [
+              {
+                internalID: "artnet-edition-set-1",
+                catalogEditionSetId: "catalog-edition-set-1",
+                artnetId: "1000",
+                label: "Edition of 10",
+                availability: "For Sale",
+                priceFrom: { major: 1000 },
+                priceTo: { major: 2000 },
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it("returns an empty list when artnet_edition_sets is not present", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              artnetEditionSets {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: { artnetArtwork: { artnetEditionSets: [] } },
+      },
+    })
+  })
+
+  it("returns createdAt and updatedAt dates", async () => {
+    const query = gql`
+      {
+        artwork(id: "some-artwork") {
+          catalogArtwork {
+            artnetArtwork {
+              createdAt
+              updatedAt
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      artworkLoader: mockArtworkWithArtnetArtwork({
+        id: "artnet-artwork-id",
+        created_at: "2024-01-15T10:30:00Z",
+        updated_at: "2024-06-20T14:45:00Z",
+      }),
+    })
+
+    expect(data).toEqual({
+      artwork: {
+        catalogArtwork: {
+          artnetArtwork: {
+            createdAt: "2024-01-15T10:30:00Z",
+            updatedAt: "2024-06-20T14:45:00Z",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/catalogArtwork.ts
+++ b/src/schema/v2/catalogArtwork.ts
@@ -10,6 +10,7 @@ import { Money, resolveMinorAndCurrencyFieldsToMoney } from "./fields/money"
 import { date } from "./fields/date"
 import { CatalogArtworkDocumentType } from "./catalogArtworkDocument"
 import { CatalogEditionSetType } from "./catalogEditionSet"
+import { ArtnetArtworkType } from "./artnet/artnetArtwork"
 
 export const CatalogArtworkType = new GraphQLObjectType<any, ResolverContext>({
   name: "CatalogArtwork",
@@ -72,6 +73,11 @@ export const CatalogArtworkType = new GraphQLObjectType<any, ResolverContext>({
       type: new GraphQLList(CatalogEditionSetType),
       description: "Edition sets associated with this catalog artwork.",
       resolve: ({ catalog_edition_sets }) => catalog_edition_sets ?? [],
+    },
+    artnetArtwork: {
+      type: ArtnetArtworkType,
+      description: "Artnet record of this catalog artwork.",
+      resolve: ({ artnet_artwork }) => artnet_artwork,
     },
   },
 })

--- a/src/schema/v2/fields/money.ts
+++ b/src/schema/v2/fields/money.ts
@@ -283,6 +283,29 @@ export const resolveMinorAndCurrencyFieldsToMoney = async (
   }
 }
 
+/**
+ * Money field factory for a source object with a minor-units field and a
+ * `price_currency` field. Returns null when either is missing.
+ */
+export const moneyFieldFromMinor = <
+  TSource extends { price_currency: string | null }
+>(
+  minorKey: keyof TSource
+) => ({
+  type: Money,
+  resolve: (source: TSource, args, context, info) => {
+    const minor = (source[minorKey] as unknown) as number | null
+    const currencyCode = source.price_currency
+    if (minor == null || currencyCode == null) return null
+    return resolveMinorAndCurrencyFieldsToMoney(
+      { minor, currencyCode },
+      args,
+      context,
+      info
+    )
+  },
+})
+
 export const resolveLotCentsFieldToMoney = (centsField) => {
   return async (parent, _args, context, _info) => {
     const { internalID, [centsField]: cents } = parent


### PR DESCRIPTION
Fairly straightforward/boilerplate (for now!) exposing the artnet artwork more or less one-to-one from Gravity.