### PR TITLE
feat: agent query user's saves

### DIFF
--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -402,6 +402,29 @@ describe("the Me field allowlist", () => {
     )
   })
 
+  it("keeps the never-throws contract when the allowlist stops matching", () => {
+    // The guard above throws, but `runQueryArtsyTool` is documented never to
+    // -- a caller adding a second call site shouldn't have to know that
+    // building the narrowed schema is the one step that can reject.
+    const renamed = mapSchema(schema, {
+      [MapperKind.OBJECT_TYPE]: (type) =>
+        type.name === "FollowsAndSaves"
+          ? new GraphQLObjectType({ ...type.toConfig(), name: "FollowsSaves" })
+          : type,
+    })
+
+    return expect(
+      runQueryArtsyTool(
+        {
+          query:
+            "{ me { basedOnUserSaves(first: 1) { edges { node { internalID } } } } }",
+        },
+        renamed,
+        {} as ResolverContext
+      )
+    ).resolves.toEqual({ ok: false, content: "The query could not be run." })
+  })
+
   it("keeps `id`, so the filtered Me still satisfies the Node interface", async () => {
     // Dropping it would leave `Me implements Node` without `id` — an invalid
     // schema, which would break every query, not just this one.

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -113,9 +113,9 @@ describe("runQueryArtsyTool", () => {
     expect(data.artwork.attributionClass).toMatchObject({ name: "Unique" })
   })
 
-  it("rejects a disallowed root field (e.g. me)", async () => {
+  it("rejects a disallowed root field (e.g. sale)", async () => {
     const result = await runQueryArtsyTool(
-      { query: "{ me { name } }" },
+      { query: '{ sale(id: "some-sale") { name } }' },
       schema,
       {} as ResolverContext
     )
@@ -241,6 +241,141 @@ describe("runQueryArtsyTool", () => {
     expect(result.ok).toBe(false)
     expect(typeof result.content).toBe("string")
     expect(result.content.length).toBeGreaterThan(0)
+  })
+})
+
+describe("the Me field allowlist", () => {
+  // `me` is the one root field whose *fields* are gated too: it resolves the
+  // signed-in collector's own record, so root-field filtering alone would put
+  // their orders, messages and payment details inside a model-authored query.
+  it("reaches the personalization connections", async () => {
+    const meLoader = jest.fn()
+    const savedArtworksLoader = jest.fn().mockResolvedValue({
+      body: [{ _id: "5d8b92b34eb68a1b2c000111" }],
+    })
+    const similarArtworksLoader = jest.fn().mockResolvedValue([
+      {
+        _id: "5d8b92b34eb68a1b2c000222",
+        id: "similar-work",
+        title: "Similar Work",
+      },
+    ])
+    const context = ({
+      userID: "user-42",
+      meLoader,
+      savedArtworksLoader,
+      similarArtworksLoader,
+    } as unknown) as ResolverContext
+
+    const result = await runQueryArtsyTool(
+      {
+        query: `
+          {
+            me {
+              basedOnUserSaves(first: 5) {
+                edges { node { internalID slug title } }
+              }
+            }
+          }
+        `,
+      },
+      schema,
+      context
+    )
+
+    expect(result.ok).toBe(true)
+    const data = JSON.parse(result.content)
+    expect(data.me.basedOnUserSaves.edges).toEqual([
+      {
+        node: {
+          internalID: "5d8b92b34eb68a1b2c000222",
+          slug: "similar-work",
+          title: "Similar Work",
+        },
+      },
+    ])
+    // Anchored on the collector's most recent saves, per basedOnUserSaves.
+    expect(savedArtworksLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "user-42", sort: "-position" })
+    )
+    expect(similarArtworksLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ artwork_id: ["5d8b92b34eb68a1b2c000111"] })
+    )
+  })
+
+  it("reaches the collector's own saved works and followed artists", async () => {
+    const result = await runQueryArtsyTool(
+      {
+        query: `
+          {
+            me {
+              followsAndSaves {
+                artworksConnection(first: 5) { edges { node { internalID } } }
+                artistsConnection(first: 5) { edges { node { internalID } } }
+              }
+            }
+          }
+        `,
+      },
+      schema,
+      ({ userID: "user-42" } as unknown) as ResolverContext
+    )
+
+    // No loaders on the context, so this stops at resolution rather than
+    // returning data — the point is that it passed *validation*.
+    expect(result.content).not.toMatch(/Cannot query field/i)
+  })
+
+  it("hides the rest of the collector's record, including their identity", async () => {
+    const privateFields = [
+      "name",
+      "email",
+      "phone",
+      "creditCards { internalID }",
+      "bankAccounts(first: 1) { edges { node { internalID } } }",
+      "conversationsConnection(first: 1) { edges { node { internalID } } }",
+      "addressConnection(first: 1) { edges { node { internalID } } }",
+      "identityVerification { internalID }",
+    ]
+
+    for (const field of privateFields) {
+      const result = await runQueryArtsyTool(
+        { query: `{ me { ${field} } }` },
+        schema,
+        {} as ResolverContext
+      )
+
+      expect(result.ok).toBe(false)
+      expect(result.content).toMatch(/Cannot query field/i)
+    }
+  })
+
+  it("keeps `id`, so the filtered Me still satisfies the Node interface", async () => {
+    // Dropping it would leave `Me implements Node` without `id` — an invalid
+    // schema, which would break every query, not just this one.
+    const result = await runQueryArtsyTool(
+      { query: "{ me { id } }" },
+      schema,
+      {} as ResolverContext
+    )
+
+    expect(result.content).not.toMatch(/Cannot query field/i)
+  })
+
+  it("leaves field access on other types alone", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      _id: "4d8b92b34eb68a1b2c000452",
+      id: "andy-warhol",
+      name: "Andy Warhol",
+    })
+
+    const result = await runQueryArtsyTool(
+      { query: '{ artist(id: "andy-warhol") { name birthday nationality } }' },
+      schema,
+      ({ artistLoader } as unknown) as ResolverContext
+    )
+
+    expect(result.ok).toBe(true)
   })
 })
 
@@ -378,6 +513,24 @@ describe("summarizeToolCall", () => {
     ).toBe("Querying Artsy: trendingSearches…")
   })
 
+  it("labels a personalized query by its field, not by the `me` wrapping it", () => {
+    expect(
+      summarizeToolCall({
+        query:
+          "{ me { basedOnUserSaves(first: 10) { edges { node { slug } } } } }",
+      })
+    ).toBe("Querying Artsy: basedOnUserSaves…")
+
+    // The outer field wins over the `artworksConnection` nested inside it,
+    // because the match is on the earliest position, not the listed order.
+    expect(
+      summarizeToolCall({
+        query:
+          "{ me { followsAndSaves { artworksConnection(first: 10) { edges { node { slug } } } } } }",
+      })
+    ).toBe("Querying Artsy: followsAndSaves…")
+  })
+
   it("falls back to a generic label when the root field can't be identified", () => {
     expect(summarizeToolCall({ query: "not graphql" })).toBe("Querying Artsy…")
     expect(summarizeToolCall({})).toBe("Querying Artsy…")
@@ -450,6 +603,14 @@ describe("query complexity budget", () => {
     [
       "shows",
       `{ showsConnection(term: "London", status: RUNNING, first: 20) { edges { node { internalID slug name startAt endAt } } } }`,
+    ],
+    [
+      "based on saves",
+      `{ me { basedOnUserSaves(first: 20) { edges { node { internalID slug title artistNames saleMessage } } } } }`,
+    ],
+    [
+      "own saves",
+      `{ me { followsAndSaves { artworksConnection(first: 20) { edges { node { internalID slug title artistNames saleMessage } } } } } }`,
     ],
   ])("stays within budget for the %s recipe", async (_name, query) => {
     const result = await runQueryArtsyTool({ query }, schema, context)

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -1,6 +1,13 @@
 import { schema } from "schema/v2"
 import { ResolverContext } from "types/graphql"
-import { buildAgentTools, runQueryArtsyTool, summarizeToolCall } from "../tools"
+import {
+  buildAgentTools,
+  narrowSchemaFor,
+  runQueryArtsyTool,
+  summarizeToolCall,
+} from "../tools"
+import { mapSchema, MapperKind } from "@graphql-tools/utils"
+import { GraphQLObjectType } from "graphql"
 import { HTTPError } from "lib/HTTPError"
 
 describe("buildAgentTools", () => {
@@ -348,6 +355,50 @@ describe("the Me field allowlist", () => {
       expect(result.ok).toBe(false)
       expect(result.content).toMatch(/Cannot query field/i)
     }
+  })
+
+  it("blocks the follows connections it doesn't allowlist", async () => {
+    // `followsAndSaves` is allowlisted down to two of its eight connections.
+    // Without this, a rename of the inline `FollowsAndSaves` type would make
+    // all of the collector's follows reachable again and nothing would fail.
+    const blocked = [
+      "showsConnection",
+      "fairsConnection",
+      "galleriesConnection",
+      "genesConnection",
+      "profilesConnection",
+      "bundledArtworksByArtistConnection",
+    ]
+
+    for (const field of blocked) {
+      const result = await runQueryArtsyTool(
+        {
+          query: `{ me { followsAndSaves { ${field}(first: 1) { edges { node { internalID } } } } } }`,
+        },
+        schema,
+        {} as ResolverContext
+      )
+
+      expect(result.ok).toBe(false)
+      expect(result.content).toMatch(/Cannot query field/i)
+    }
+  })
+
+  it("refuses to build the narrowed schema if an allowlisted type is renamed", () => {
+    // The allowlist keys on a type name, which is the one way it fails open.
+    // Every other test in this file exercises the same guard implicitly --
+    // rename `Me` and they all go red on this message rather than quietly
+    // passing against an unrestricted `Me`.
+    const renamed = mapSchema(schema, {
+      [MapperKind.OBJECT_TYPE]: (type) =>
+        type.name === "FollowsAndSaves"
+          ? new GraphQLObjectType({ ...type.toConfig(), name: "FollowsSaves" })
+          : type,
+    })
+
+    expect(() => narrowSchemaFor(renamed)).toThrow(
+      /unknown type\(s\).*FollowsAndSaves/s
+    )
   })
 
   it("keeps `id`, so the filtered Me still satisfies the Node interface", async () => {

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -335,6 +335,7 @@ describe("the Me field allowlist", () => {
 
   it("hides the rest of the collector's record, including their identity", async () => {
     const privateFields = [
+      "internalID",
       "name",
       "email",
       "phone",

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -97,6 +97,17 @@ Artist details by slug:
 Shows, searched by name or city and filtered by run status:
   \`showsConnection(term: "<name or city>", status: RUNNING, first: <=20) { edges { node { internalID slug name startAt endAt } } }\`
 
+Recommendations from the collector's own saves ("works similar to my saves",
+"recommend me something", "more like what I've saved", "based on my taste"):
+  \`me { basedOnUserSaves(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } }\`
+  This is a real recommendation ranking computed from their most recent saves —
+  the same one behind the "Inspired by Your Saved Artworks" rail — so use it
+  directly rather than reading their saves and searching by hand.
+
+The collector's own saved works ("what have I saved", "my saves"):
+  \`me { followsAndSaves { artworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } } }\`
+  For the artists they follow, use \`artistsConnection\` on that same field.
+
 Trending / most popular artworks or artists ("what's trending", "what's
 popular right now", "what are people looking at"):
   \`trendingSearches(period: SEVEN_DAYS) { label artworks(first: <=20) { rank artwork { internalID slug title artistNames saleMessage } } }\`
@@ -136,8 +147,26 @@ of the question as your other tool calls did cover.
   to array args like \`artistIDs\`.
 - Available root fields are only:
   \`artworksConnection\`, \`artistsConnection\`, \`artist\`, \`artwork\`,
-  \`showsConnection\`, \`matchConnection\`, \`trendingSearches\`. Anything else
-  will fail validation.
+  \`showsConnection\`, \`matchConnection\`, \`trendingSearches\`, \`me\`.
+  Anything else will fail validation.
+- \`me\` is the signed-in collector, and only their personalization fields are
+  reachable: \`basedOnUserSaves\`, \`artworkRecommendations\`,
+  \`artistRecommendations\`, and \`followsAndSaves\` (which has
+  \`artworksConnection\` for saved works and \`artistsConnection\` for followed
+  artists). Nothing else about them — name, email, orders, messages — is
+  readable, so don't try. \`me\` comes back null when the collector isn't
+  signed in; in that case say the recommendations are tied to a signed-in
+  account, and show trending works in the same breath rather than stopping
+  there.
+- \`basedOnUserSaves\` and \`artworkRecommendations\` are both artwork
+  connections but answer different questions: the first is anchored on their
+  most recent saves ("more like what I saved"), the second is their broader
+  recommendation feed ("recommend me something"). Both return an empty
+  connection when there's nothing to work from — treat that as "you haven't
+  saved much yet", and pivot to trending or to works by an artist they follow.
+- These are already ranked by relevance, so keep their order in
+  \`artworkIDs\`, and don't re-sort or filter them by price or medium unless
+  the collector asked.
 - \`trendingSearches\` is the *only* popularity ranking in the
   schema, and it is a real one — computed daily from what people actually
   search for and view. \`artworksConnection\` has no trending/popular sort, so

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -313,7 +313,8 @@ export interface AIAgentToolRunResult {
 /**
  * Runs one model-authored query against the schema, restricted to
  * `ALLOWED_ROOT_FIELDS`. Never throws — every failure mode (bad syntax,
- * validation, execution errors) becomes `{ ok: false, content }`.
+ * validation, execution errors, and a field allowlist that no longer matches
+ * the schema) becomes `{ ok: false, content }`.
  */
 export async function runQueryArtsyTool(
   input: unknown,
@@ -329,7 +330,18 @@ export async function runQueryArtsyTool(
     return { ok: false, content: "A non-empty `query` string is required." }
   }
 
-  const narrowSchema = narrowSchemaFor(schema)
+  let narrowSchema: GraphQLSchema
+  try {
+    narrowSchema = narrowSchemaFor(schema)
+  } catch (error) {
+    // `assertFieldAllowlistsResolve` rejected the schema, so there is no
+    // safely-narrowed one to run against and the tool is unavailable for this
+    // turn. Reported rather than surfaced: the message names internal types,
+    // and like the upstream errors below it describes our own configuration,
+    // which the model has no use for and no way to act on.
+    Sentry.captureException(error)
+    return { ok: false, content: "The query could not be run." }
+  }
 
   let document: DocumentNode
   try {

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -37,6 +37,10 @@ import { ResolverContext } from "types/graphql"
  * (an unauthorized/unauthenticated caller gets null, not a leak), so this
  * only needs to gate *which entry points* are reachable at all, not which
  * fields within them.
+ *
+ * `Me` is the exception — its fields are allowlisted too, because there
+ * resolver-level auth is what creates the problem rather than solving it.
+ * See ALLOWED_FIELDS_BY_TYPE below.
  */
 
 const ALLOWED_ROOT_FIELDS = new Set([

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -17,7 +17,7 @@ import depthLimit from "graphql-depth-limit"
 import { createComplexityRule, simpleEstimator } from "graphql-query-complexity"
 import type { ComplexityEstimator } from "graphql-query-complexity"
 import { filterSchema, pruneSchema } from "@graphql-tools/utils"
-import type { RootFieldFilter } from "@graphql-tools/utils"
+import type { FieldFilter, RootFieldFilter } from "@graphql-tools/utils"
 import * as Sentry from "@sentry/node"
 import {
   flattenErrors,
@@ -47,10 +47,44 @@ const ALLOWED_ROOT_FIELDS = new Set([
   "showsConnection",
   "matchConnection",
   "trendingSearches",
+  "me",
 ])
 
 const rootFieldFilter: RootFieldFilter = (operation, rootFieldName) =>
   operation === "Query" && ALLOWED_ROOT_FIELDS.has(rootFieldName)
+
+/**
+ * `me` is the exception to the comment above: for every other root field,
+ * gating the entry point is enough, because what hangs off it is public
+ * catalogue data. `Me` is the signed-in collector's own record, and almost
+ * all of it is personal — orders, credit cards, bank accounts, conversations,
+ * addresses, identity verification, inquiries. Metaphysics' resolvers do
+ * authorize those (they return this user's data, not someone else's), which
+ * is exactly the problem: a model-authored query would be *correctly*
+ * authorized to read the user's payment details into the model's context.
+ *
+ * So `Me` is the one type whose fields are allowlisted too, down to the
+ * personalization connections that answer "what should I look at next" —
+ * they return artworks and artists, the same shape the rest of the tool
+ * already returns. `id` is not optional here: `Me` implements `Node`, so
+ * dropping it would leave the filtered schema invalid.
+ */
+const ALLOWED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
+  Me: new Set([
+    "id",
+    "internalID",
+    "basedOnUserSaves",
+    "artworkRecommendations",
+    "artistRecommendations",
+    "followsAndSaves",
+  ]),
+  FollowsAndSaves: new Set(["artworksConnection", "artistsConnection"]),
+}
+
+const objectFieldFilter: FieldFilter = (typeName, fieldName) => {
+  const allowed = ALLOWED_FIELDS_BY_TYPE[typeName]
+  return !allowed || allowed.has(fieldName)
+}
 
 // Memoized rather than rebuilt per request — pruning a schema isn't free,
 // and `schema` is the same instance across requests except on a dev
@@ -63,7 +97,11 @@ function narrowSchemaFor(realSchema: GraphQLSchema): GraphQLSchema {
     return cachedNarrowSchema
   }
 
-  const filtered = filterSchema({ schema: realSchema, rootFieldFilter })
+  const filtered = filterSchema({
+    schema: realSchema,
+    rootFieldFilter,
+    objectFieldFilter,
+  })
   const pruned = pruneSchema(filtered)
 
   cachedRealSchema = realSchema
@@ -342,8 +380,11 @@ export function buildAgentTools(
         "Run a read-only GraphQL query to search and look up artists, " +
         "artworks, shows, and fairs. Available root fields: " +
         "artworksConnection, artistsConnection, artist, artwork, " +
-        "showsConnection, matchConnection, trendingSearches (the last one for " +
-        "trending/most-popular rankings). Use GraphQL introspection (e.g. " +
+        "showsConnection, matchConnection, trendingSearches (for " +
+        "trending/most-popular rankings), and me (the signed-in collector's " +
+        "own saves, follows and recommendations — `me` is null when signed " +
+        "out, and only its personalization fields are reachable). Use " +
+        "GraphQL introspection (e.g. " +
         '`{ __type(name: "Artwork") { fields { name description } } }`) to ' +
         "discover the fields and args available on any type — one type at a " +
         "time, as `__schema` is not available. Always " +
@@ -380,7 +421,7 @@ export function summarizeToolCall(input: unknown): string {
   if (typeof query !== "string") return "Querying Artsy…"
 
   const match = query.match(
-    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|trendingSearches)\b/
+    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|trendingSearches|basedOnUserSaves|artworkRecommendations|artistRecommendations|followsAndSaves)\b/
   )
   return match ? `Querying Artsy: ${match[1]}…` : "Querying Artsy…"
 }

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -76,7 +76,6 @@ const rootFieldFilter: RootFieldFilter = (operation, rootFieldName) =>
 const ALLOWED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
   Me: new Set([
     "id",
-    "internalID",
     "basedOnUserSaves",
     "artworkRecommendations",
     "artistRecommendations",

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -86,16 +86,47 @@ const objectFieldFilter: FieldFilter = (typeName, fieldName) => {
   return !allowed || allowed.has(fieldName)
 }
 
+/**
+ * The one way the allowlist above fails *open*: it keys on a type's name, so
+ * renaming `Me` or `FollowsAndSaves` upstream stops the lookup matching, and
+ * `objectFieldFilter` then waves through every field on the type it was
+ * written to restrict. Nothing about a rename looks like a privacy change at
+ * the call site, and the gate it disables lives in a different directory.
+ *
+ * So resolve the names against the real schema while narrowing it, and refuse
+ * to build the schema if one has gone missing. Failing here costs the agent
+ * its `query_artsy` tool — it surfaces as a tool error and a Sentry report —
+ * which is the right trade against silently widening what a model-authored
+ * query can read about the signed-in collector.
+ *
+ * Only missing *types* throw. A missing field name fails closed on its own
+ * (the field just stays unreachable), so it isn't worth taking the tool down.
+ */
+function assertFieldAllowlistsResolve(schema: GraphQLSchema): void {
+  const missing = Object.keys(ALLOWED_FIELDS_BY_TYPE).filter(
+    (typeName) => !schema.getType(typeName)
+  )
+  if (missing.length === 0) return
+
+  throw new Error(
+    `AI agent field allowlist names unknown type(s): ${missing.join(", ")}. ` +
+      "They were most likely renamed — update ALLOWED_FIELDS_BY_TYPE to match, " +
+      "or every field on them becomes readable by a model-authored query."
+  )
+}
+
 // Memoized rather than rebuilt per request — pruning a schema isn't free,
 // and `schema` is the same instance across requests except on a dev
 // hot-reload.
 let cachedRealSchema: GraphQLSchema | undefined
 let cachedNarrowSchema: GraphQLSchema | undefined
 
-function narrowSchemaFor(realSchema: GraphQLSchema): GraphQLSchema {
+export function narrowSchemaFor(realSchema: GraphQLSchema): GraphQLSchema {
   if (cachedRealSchema === realSchema && cachedNarrowSchema) {
     return cachedNarrowSchema
   }
+
+  assertFieldAllowlistsResolve(realSchema)
 
   const filtered = filterSchema({
     schema: realSchema,


### PR DESCRIPTION
Allow the agent to query a user's saves to give recommendations.

<img width="1289" height="685" alt="Screenshot 2026-08-31 at 10 38 04" src="https://github.com/user-attachments/assets/023fe64c-deb7-4f89-b6a4-0f30197e068f" />
