### PR TITLE
feat: agent remembers the artworks it showed

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -38,6 +38,7 @@ union AIAgentEvent =
   | AIAgentTurnComplete
 
 input AIAgentMessageInput {
+  artworkIDs: [String!]
   content: String!
   role: AIAgentRole!
 }

--- a/src/schema/v2/ai/agent/__tests__/index.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/index.test.ts
@@ -27,12 +27,7 @@ function callSubscribe(
   schema: GraphQLSchema = ({} as unknown) as GraphQLSchema
 ) {
   const info = ({ schema } as unknown) as GraphQLResolveInfo
-  return (AIAgentTurn.subscribe as any)(
-    undefined,
-    { input },
-    context,
-    info
-  )
+  return (AIAgentTurn.subscribe as any)(undefined, { input }, context, info)
 }
 
 describe("AIAgentTurn", () => {
@@ -114,6 +109,25 @@ describe("AIAgentTurn", () => {
 
   it("rejects an oversized history", () => {
     const history = [{ role: "user", content: "x".repeat(200_000) }]
+
+    expect(() =>
+      callSubscribe(
+        { conversationID: "c1", message: "hi", history },
+        { userID: "user-42", accessToken: "token" }
+      )
+    ).toThrow(/too large/)
+  })
+
+  it("counts replayed artwork ids against the byte cap", () => {
+    // They are client-supplied and reach the model like any other content, so
+    // a history that is small in prose but enormous in ids must not slip past.
+    const history = [
+      {
+        role: "assistant",
+        content: "Here you go.",
+        artworkIDs: Array.from({ length: 5000 }, () => "x".repeat(24)),
+      },
+    ]
 
     expect(() =>
       callSubscribe(

--- a/src/schema/v2/ai/agent/__tests__/runTurn.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/runTurn.test.ts
@@ -92,7 +92,15 @@ const ID_B = "6a6b6c6d6e6f707172737475"
 const ID_C = "7b7c7d7e7f80818283848586"
 
 async function collectEvents(
-  input: { conversationID: string; message: string },
+  input: {
+    conversationID: string
+    message: string
+    history?: Array<{
+      role: string
+      content: string
+      artworkIDs?: string[] | null
+    }>
+  },
   context: ResolverContext = fakeContext()
 ) {
   const events: any[] = []
@@ -630,6 +638,139 @@ describe("runTurn", () => {
     const signal = mockModel.doStreamCalls[0].abortSignal
     expect(signal?.aborted).toBe(true)
   })
+  describe("replayed history", () => {
+    // What the provider actually receives: the system prompt, then one entry
+    // per conversation message, each with its content as an array of parts.
+    const conversationSentToModel = () =>
+      mockModel.doStreamCalls[0].prompt
+        .filter((entry: any) => entry.role !== "system")
+        .map((entry: any) => ({
+          role: entry.role,
+          text: Array.isArray(entry.content)
+            ? entry.content.map((part: any) => part.text ?? "").join("")
+            : entry.content,
+        }))
+
+    beforeEach(() => {
+      mockModel = new MockLanguageModelV3({
+        doStream: {
+          stream: convertArrayToReadableStream([
+            { type: "stream-start", warnings: [] },
+            { type: "text-start", id: "1" },
+            {
+              type: "text-delta",
+              id: "1",
+              delta: JSON.stringify({ message: "Sure.", artworkIDs: [] }),
+            },
+            { type: "text-end", id: "1" },
+            {
+              type: "finish",
+              finishReason: { unified: "stop", raw: "end_turn" },
+              usage: FAKE_USAGE,
+            },
+          ]),
+        },
+      })
+    })
+
+    it("folds the cards a prior answer showed back into that assistant turn, in display order", async () => {
+      // The prose never names the works (the cards do), so this note is the
+      // only thing an ordinal follow-up like "the second one" can resolve
+      // against.
+      await collectEvents({
+        conversationID: "c1",
+        message: "How much is the second one?",
+        history: [
+          { role: "user", content: "Show me Warhol prints" },
+          {
+            role: "assistant",
+            content: "Here are a few.",
+            artworkIDs: [ID_A, ID_B],
+          },
+        ],
+      })
+
+      const conversation = conversationSentToModel()
+      expect(conversation).toHaveLength(3)
+      expect(conversation[1].role).toBe("assistant")
+      expect(conversation[1].text).toContain("Here are a few.")
+      expect(conversation[1].text).toContain(`1. ${ID_A} 2. ${ID_B}`)
+      expect(conversation[2]).toMatchObject({
+        role: "user",
+        text: "How much is the second one?",
+      })
+    })
+
+    it("leaves an assistant turn untouched when the client replays no ids", async () => {
+      await collectEvents({
+        conversationID: "c1",
+        message: "And in blue?",
+        history: [
+          { role: "user", content: "Tell me about Banksy" },
+          { role: "assistant", content: "He is a street artist." },
+        ],
+      })
+
+      expect(conversationSentToModel()[1]).toEqual({
+        role: "assistant",
+        text: "He is a street artist.",
+      })
+    })
+
+    it("ignores ids replayed on a user turn, which never rendered cards", async () => {
+      await collectEvents({
+        conversationID: "c1",
+        message: "And cheaper?",
+        history: [
+          { role: "user", content: "Show me Warhol", artworkIDs: [ID_A] },
+        ],
+      })
+
+      expect(conversationSentToModel()[0]).toEqual({
+        role: "user",
+        text: "Show me Warhol",
+      })
+    })
+
+    it("drops a replayed id that isn't an internalID", async () => {
+      // Same reasoning as the citation path: only the 24-char hex form ever
+      // resolved to a card, so anything else is context the model can't act on.
+      await collectEvents({
+        conversationID: "c1",
+        message: "The first one?",
+        history: [
+          {
+            role: "assistant",
+            content: "Here you go.",
+            artworkIDs: ["andy-warhol-flowers", ID_A],
+          },
+        ],
+      })
+
+      const text = conversationSentToModel()[0].text
+      expect(text).toContain(`1. ${ID_A}`)
+      expect(text).not.toContain("andy-warhol-flowers")
+    })
+
+    it("caps a replayed turn at the number of cards that can be shown", async () => {
+      const manyIDs = Array.from({ length: 25 }, (_, index) =>
+        index.toString(16).padStart(24, "0")
+      )
+
+      await collectEvents({
+        conversationID: "c1",
+        message: "More like these",
+        history: [
+          { role: "assistant", content: "Here you go.", artworkIDs: manyIDs },
+        ],
+      })
+
+      const text = conversationSentToModel()[0].text
+      expect(text).toContain(`20. ${manyIDs[19]}`)
+      expect(text).not.toContain(manyIDs[20])
+    })
+  })
+
   describe("per-user rate limiting", () => {
     it("checks the limit against the calling user before any model call", async () => {
       mockModel = new MockLanguageModelV3({

--- a/src/schema/v2/ai/agent/index.ts
+++ b/src/schema/v2/ai/agent/index.ts
@@ -3,17 +3,15 @@ import config from "config"
 import { ResolverContext } from "types/graphql"
 import { isFeatureFlagEnabled } from "lib/featureFlags"
 import { runTurn } from "./runTurn"
-import { AIAgentEventType, AIAgentTurnInputType } from "./types"
+import {
+  AIAgentEventType,
+  AIAgentHistoryEntry,
+  AIAgentTurnInputType,
+} from "./types"
 
 // Guardrail: reject a client-supplied history before it ever reaches the model.
 const MAX_HISTORY_MESSAGES = 40
 const MAX_HISTORY_BYTES = 100_000
-
-interface AIAgentHistoryEntry {
-  role: string
-  content: string
-  artworkIDs?: string[] | null
-}
 
 function assertInputWithinLimits(input: {
   message: string

--- a/src/schema/v2/ai/agent/index.ts
+++ b/src/schema/v2/ai/agent/index.ts
@@ -9,9 +9,15 @@ import { AIAgentEventType, AIAgentTurnInputType } from "./types"
 const MAX_HISTORY_MESSAGES = 40
 const MAX_HISTORY_BYTES = 100_000
 
+interface AIAgentHistoryEntry {
+  role: string
+  content: string
+  artworkIDs?: string[] | null
+}
+
 function assertInputWithinLimits(input: {
   message: string
-  history?: Array<{ role: string; content: string }> | null
+  history?: Array<AIAgentHistoryEntry> | null
 }) {
   const history = input.history ?? []
   if (history.length > MAX_HISTORY_MESSAGES) {
@@ -23,7 +29,13 @@ function assertInputWithinLimits(input: {
   const totalBytes =
     Buffer.byteLength(input.message, "utf8") +
     history.reduce(
-      (sum, entry) => sum + Buffer.byteLength(entry.content ?? "", "utf8"),
+      (sum, entry) =>
+        sum +
+        Buffer.byteLength(entry.content ?? "", "utf8") +
+        (entry.artworkIDs ?? []).reduce(
+          (bytes, id) => bytes + Buffer.byteLength(id ?? "", "utf8"),
+          0
+        ),
       0
     )
   if (totalBytes > MAX_HISTORY_BYTES) {
@@ -62,7 +74,7 @@ export const AIAgentTurn: GraphQLFieldConfig<void, ResolverContext> = {
     const input = args.input as {
       conversationID: string
       message: string
-      history?: Array<{ role: string; content: string }> | null
+      history?: Array<AIAgentHistoryEntry> | null
     }
 
     assertInputWithinLimits(input)

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -342,8 +342,8 @@ function annotateWithShownArtworks(
   artworkIDs: readonly string[]
 ): string {
   const shown = artworkIDs
-    .filter((id) => INTERNAL_ID.test(id))
     .slice(0, MAX_ARTWORK_IDS)
+    .filter((id) => INTERNAL_ID.test(id))
   if (shown.length === 0) return content
 
   const note =

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -81,6 +81,25 @@ a type this turn and aren't sure of its fields, introspect it once first:
 \`{ __type(name: "Artwork") { fields { name type { name kind ofType { name kind } } } } }\`.
 One introspection is cheaper than a retry loop.
 
+## Follow-ups
+
+A prior answer of yours may end with a bracketed note listing the ids of the
+cards it showed, in the order the collector sees them. That note is ours: they
+did not write it and cannot see it, so never quote it back or mention an id to
+them. It is the only record of what they are currently looking at, so read it
+before deciding what a follow-up refers to.
+
+"The second one", "the Warhol", "that one" resolve against that order. To say
+anything about one of those works, look it up
+(\`artwork(id: "<internalID>") { title artistNames saleMessage }\`) and cite its
+id again, so its card renders alongside the answer.
+
+A refinement — "cheaper", "only paintings", "something larger", "what about
+prints" — means re-running your previous search with that one constraint added,
+not starting over from a bare keyword. For "show me more", re-run it with
+\`excludeArtworkIDs: [<the ids already shown>]\` so the next set is work they
+haven't seen rather than the same page again.
+
 ## Recipes
 
 Artworks by a named artist, with price/size filters:
@@ -304,14 +323,55 @@ async function loadSystemPrompt(context: ResolverContext): Promise<string> {
   }
 }
 
+/**
+ * The client owns and replays history, and per AgentOutputSchema an answer's
+ * `message` deliberately never names the works it showed -- the cards do that.
+ * Replayed as prose alone, then, a prior turn reads as an answer about works
+ * that have since vanished: "the second one", "cheaper ones like those", "show
+ * me more" have nothing left to resolve against, so the model either re-derives
+ * the search from the user's words or answers about nothing.
+ *
+ * So fold the ids the client actually rendered back into the assistant turn, in
+ * card order, which is what makes an ordinal reference land. Ids are
+ * re-validated rather than trusted: they come back from the client, and only
+ * the internalID form resolves to a card (see resolveArtworks), so anything
+ * else is context the model cannot act on.
+ */
+function annotateWithShownArtworks(
+  content: string,
+  artworkIDs: readonly string[]
+): string {
+  const shown = artworkIDs
+    .filter((id) => INTERNAL_ID.test(id))
+    .slice(0, MAX_ARTWORK_IDS)
+  if (shown.length === 0) return content
+
+  const note =
+    "[Cards shown to the collector with this answer, in display order: " +
+    `${shown.map((id, index) => `${index + 1}. ${id}`).join(" ")} — they see ` +
+    "images, not these ids.]"
+
+  return content.length > 0 ? `${content}\n\n${note}` : note
+}
+
 function buildMessages(
-  history: Array<{ role: string; content: string }> | null | undefined,
+  history:
+    | Array<{ role: string; content: string; artworkIDs?: string[] | null }>
+    | null
+    | undefined,
   message: string
 ): ModelMessage[] {
-  const priorMessages: ModelMessage[] = (history ?? []).map((entry) => ({
-    role: entry.role as "user" | "assistant",
-    content: entry.content,
-  }))
+  const priorMessages: ModelMessage[] = (history ?? []).map((entry) =>
+    entry.role === "assistant"
+      ? {
+          role: "assistant",
+          content: annotateWithShownArtworks(
+            entry.content,
+            entry.artworkIDs ?? []
+          ),
+        }
+      : { role: "user", content: entry.content }
+  )
 
   return [...priorMessages, { role: "user", content: message }]
 }

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -324,20 +324,9 @@ async function loadSystemPrompt(context: ResolverContext): Promise<string> {
   }
 }
 
-/**
- * The client owns and replays history, and per AgentOutputSchema an answer's
- * `message` deliberately never names the works it showed -- the cards do that.
- * Replayed as prose alone, then, a prior turn reads as an answer about works
- * that have since vanished: "the second one", "cheaper ones like those", "show
- * me more" have nothing left to resolve against, so the model either re-derives
- * the search from the user's words or answers about nothing.
- *
- * So fold the ids the client actually rendered back into the assistant turn, in
- * card order, which is what makes an ordinal reference land. Ids are
- * re-validated rather than trusted: they come back from the client, and only
- * the internalID form resolves to a card (see resolveArtworks), so anything
- * else is context the model cannot act on.
- */
+// An answer's `message` never names the works it showed, so without this a
+// follow-up like "the second one" has nothing to resolve against. Capped then
+// filtered, matching resolveArtworks.
 function annotateWithShownArtworks(
   content: string,
   artworkIDs: readonly string[]

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -15,6 +15,7 @@ import {
 } from "./tools"
 import {
   AIAgentEventPayload,
+  AIAgentHistoryEntry,
   AIAgentTextDeltaPayload,
   AIAgentToolCallPayload,
   AIAgentToolResultPayload,
@@ -355,10 +356,7 @@ function annotateWithShownArtworks(
 }
 
 function buildMessages(
-  history:
-    | Array<{ role: string; content: string; artworkIDs?: string[] | null }>
-    | null
-    | undefined,
+  history: AIAgentHistoryEntry[] | null | undefined,
   message: string
 ): ModelMessage[] {
   const priorMessages: ModelMessage[] = (history ?? []).map((entry) =>
@@ -384,7 +382,11 @@ function buildMessages(
  * live SSE stream mid-flight.
  */
 export async function* runTurn(
-  input: { conversationID: string; message: string; history?: any },
+  input: {
+    conversationID: string
+    message: string
+    history?: AIAgentHistoryEntry[] | null
+  },
   schema: GraphQLSchema,
   context: ResolverContext
 ): AsyncGenerator<AIAgentEventPayload> {

--- a/src/schema/v2/ai/agent/types.ts
+++ b/src/schema/v2/ai/agent/types.ts
@@ -31,6 +31,12 @@ export const AIAgentMessageInputType = new GraphQLInputObjectType({
   },
 })
 
+export interface AIAgentHistoryEntry {
+  role: string
+  content: string
+  artworkIDs?: string[] | null
+}
+
 export const AIAgentTurnInputType = new GraphQLInputObjectType({
   name: "AIAgentTurnInput",
   fields: {

--- a/src/schema/v2/ai/agent/types.ts
+++ b/src/schema/v2/ai/agent/types.ts
@@ -25,6 +25,9 @@ export const AIAgentMessageInputType = new GraphQLInputObjectType({
   fields: {
     role: { type: new GraphQLNonNull(AIAgentRoleType) },
     content: { type: new GraphQLNonNull(GraphQLString) },
+    artworkIDs: {
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+    },
   },
 })
 
@@ -33,7 +36,8 @@ export const AIAgentTurnInputType = new GraphQLInputObjectType({
   fields: {
     conversationID: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "Client-generated; identifies which conversation a turn belongs to.",
+      description:
+        "Client-generated; identifies which conversation a turn belongs to.",
     },
     message: {
       type: new GraphQLNonNull(GraphQLString),
@@ -105,7 +109,7 @@ const AIAgentToolCallType = new GraphQLObjectType<
     toolName: { type: new GraphQLNonNull(GraphQLString) },
     summary: {
       type: GraphQLString,
-      description: "Human-readable label, e.g. \"Searching artists…\".",
+      description: 'Human-readable label, e.g. "Searching artists…".',
     },
   },
 })


### PR DESCRIPTION
Follow-ups like "the second one", "cheaper ones" or "show me more" currently reach the agent with nothing to resolve against: the client replays history as prose only, and an answer's message deliberately never names the works it showed — the cards do that.

So AIAgentMessageInput gains an optional artworkIDs, which the client replays from that turn's AIAgentTurnComplete.artworks. buildMessages folds them back into the assistant turn as a numbered note in card order, which is what makes an ordinal reference land. Ids are re-validated as internalIDs and capped, and they now count against the input byte budget since they reach the model like any other content.

A new ## Follow-ups prompt section tells the model the note is ours and invisible to the collector, that describing one of those works means looking it up and re-citing its id, and that a refinement means re-running the previous search with one constraint added — including excludeArtworkIDs for "show me more".

Before
<img width="1284" height="623" alt="Screenshot 2026-08-31 at 16 49 54" src="https://github.com/user-attachments/assets/9932daa3-ce70-48c4-b469-57ba24a2fc1b" />

After
<img width="1251" height="588" alt="Screenshot 2026-08-31 at 16 50 03" src="https://github.com/user-attachments/assets/50969d1a-427f-4362-8e7d-b9b92e28d77f" />
