### PR TITLE
chore(artwork): close title tag experiment and adopt winning variant

### DIFF
--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -9,7 +9,6 @@ const { UNLEASH_API, UNLEASH_APP_NAME, UNLEASH_SERVER_KEY } = config
  * @see https://tools.artsy.net/feature-flags
  */
 const FEATURE_FLAGS_LIST = [
-  "diamond_artwork-title-experiment",
   "onyx_ai_agent-turn",
   "onyx_nwfy-gravity",
   "onyx_nwfy-refresh-eigen",

--- a/src/schema/v2/artwork/__tests__/meta.test.ts
+++ b/src/schema/v2/artwork/__tests__/meta.test.ts
@@ -1,9 +1,4 @@
 import { runQuery } from "schema/v2/test/utils"
-import * as featureFlags from "lib/featureFlags"
-
-jest.mock("lib/featureFlags", () => ({
-  getExperimentVariant: jest.fn(),
-}))
 
 describe("Meta", () => {
   const artworkData = {
@@ -49,8 +44,7 @@ describe("Meta", () => {
       expect(data).toEqual({
         artwork: {
           meta: {
-            title:
-              "Hans Hartung | P. 25-1975-H-8 (1975) | Available for Sale | Artsy",
+            title: "P. 25-1975-H-8 (1975) by Hans Hartung - For Sale | Artsy",
             description:
               "Available for sale from Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
           },
@@ -66,7 +60,7 @@ describe("Meta", () => {
       expect(data).toEqual({
         artwork: {
           meta: {
-            title: "Hans Hartung | P. 25-1975-H-8 (1975) | Artsy",
+            title: "P. 25-1975-H-8 (1975) by Hans Hartung | Artsy",
             description:
               "From Galerie Michel Descours, Hans Hartung, P. 25-1975-H-8 (1975), Acrylic on baryte card, 58 × 78 cm",
           },
@@ -100,7 +94,7 @@ describe("Meta", () => {
     })
   })
 
-  describe("title experiment", () => {
+  describe("title", () => {
     beforeEach(() => {
       artworkData.sale_message = "Price on request"
     })
@@ -115,85 +109,63 @@ describe("Meta", () => {
       }
     `
 
-    test("control renders current title", async () => {
-      jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-        enabled: true,
-        name: "control",
-      } as any)
-
+    it("displays title, date, artist name, then availability", async () => {
       const data = await runQuery(query, context as any)
 
       expect(data.artwork.meta.title).toBe(
-        "Hans Hartung | P. 25-1975-H-8 (1975) | Available for Sale | Artsy"
+        "P. 25-1975-H-8 (1975) by Hans Hartung - For Sale | Artsy"
       )
     })
 
-    describe("variant-a", () => {
-      beforeEach(() => {
-        jest.mocked(featureFlags.getExperimentVariant).mockReturnValue({
-          enabled: true,
-          name: "variant-a",
-        } as any)
-      })
+    describe("with a non for-sale work", () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({ ...artworkData, forsale: false }),
+      }
 
-      it("changes order and shortens availability", async () => {
+      it("omits availability", async () => {
         const data = await runQuery(query, context as any)
 
         expect(data.artwork.meta.title).toBe(
-          "P. 25-1975-H-8 (1975) by Hans Hartung - For Sale | Artsy"
+          "P. 25-1975-H-8 (1975) by Hans Hartung | Artsy"
         )
       })
+    })
 
-      describe("with a non for-sale work", () => {
-        const context = {
-          artworkLoader: () =>
-            Promise.resolve({ ...artworkData, forsale: false }),
-        }
+    describe("with a null title", () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            ...artworkData,
+            title: null,
+          }),
+      }
 
-        it("omits availability", async () => {
-          const data = await runQuery(query, context as any)
+      it("defaults to 'Untitled'", async () => {
+        const data = await runQuery(query, context as any)
 
-          expect(data.artwork.meta.title).toBe(
-            "P. 25-1975-H-8 (1975) by Hans Hartung | Artsy"
-          )
-        })
+        expect(data.artwork.meta.title).toBe(
+          "Untitled (1975) by Hans Hartung - For Sale | Artsy"
+        )
       })
+    })
 
-      describe("with a null title", () => {
-        const context = {
-          artworkLoader: () =>
-            Promise.resolve({
-              ...artworkData,
-              title: null,
-            }),
-        }
+    describe("with a long title", () => {
+      const context = {
+        artworkLoader: () =>
+          Promise.resolve({
+            ...artworkData,
+            title:
+              "This title is very very very very very very very very very long",
+          }),
+      }
 
-        it("defaults to 'Untitled'", async () => {
-          const data = await runQuery(query, context as any)
+      it("truncates title", async () => {
+        const data = await runQuery(query, context as any)
 
-          expect(data.artwork.meta.title).toBe(
-            "Untitled (1975) by Hans Hartung - For Sale | Artsy"
-          )
-        })
-      })
-
-      describe("with a long title", () => {
-        const context = {
-          artworkLoader: () =>
-            Promise.resolve({
-              ...artworkData,
-              title:
-                "This title is very very very very very very very very very long",
-            }),
-        }
-
-        it("truncates title", async () => {
-          const data = await runQuery(query, context as any)
-
-          expect(data.artwork.meta.title).toBe(
-            "This title is very very very very very very very ver… (1975) by Hans Hartung - For Sale | Artsy"
-          )
-        })
+        expect(data.artwork.meta.title).toBe(
+          "This title is very very very very very very very ver… (1975) by Hans Hartung - For Sale | Artsy"
+        )
       })
     })
   })

--- a/src/schema/v2/artwork/meta.ts
+++ b/src/schema/v2/artwork/meta.ts
@@ -9,9 +9,7 @@ import {
   GraphQLFieldConfig,
 } from "graphql"
 import { ResolverContext } from "types/graphql"
-import { getExperimentVariant } from "lib/featureFlags"
 
-const EXPERIMENT_NAME = "diamond_artwork-title-experiment"
 const TITLE_MAX_LENGTH = 52 // p95
 
 const isInquireAboutAvailability = (saleMessage) =>
@@ -20,7 +18,7 @@ const isInquireAboutAvailability = (saleMessage) =>
 const titleWithDate = ({ title, date }) =>
   join(" ", [title || "Untitled", date ? `(${date})` : undefined])
 
-const titleWithDateV2 = ({ title, date }) =>
+const truncatedTitleWithDate = ({ title, date }) =>
   join(" ", [
     truncate(title || "Untitled", TITLE_MAX_LENGTH),
     date ? `(${date})` : undefined,
@@ -30,11 +28,6 @@ export const artistNames = (artwork) =>
   artwork.cultural_maker || map(artwork.artists, "name").join(", ")
 
 const forSaleIndication = (artwork) =>
-  artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
-    ? "Available for Sale"
-    : undefined
-
-const forSaleIndicationV2 = (artwork) =>
   artwork.forsale && !isInquireAboutAvailability(artwork.sale_message)
     ? "For Sale"
     : undefined
@@ -95,14 +88,17 @@ const ArtworkMetaType = new GraphQLObjectType<any, ResolverContext>({
     },
     title: {
       type: GraphQLString,
-      resolve: (artwork) => {
-        const variant = getExperimentVariant(EXPERIMENT_NAME, {
-          artworkId: artwork._id,
-        })
-        const variantName =
-          variant && variant.enabled ? variant.name : undefined
-        return generateTitle(artwork, variantName)
-      },
+      resolve: (artwork) =>
+        join(" | ", [
+          join(" - ", [
+            join(" by ", [
+              truncatedTitleWithDate(artwork),
+              artistNames(artwork),
+            ]),
+            forSaleIndication(artwork),
+          ]),
+          "Artsy",
+        ]),
     },
   },
 })
@@ -113,32 +109,3 @@ const Meta: GraphQLFieldConfig<any, ResolverContext> = {
 }
 
 export default Meta
-
-/**
- * Generates a title for the artwork based on its properties and the
- * experiment variant, resulting in different formats/lengths.
- *
- * ```
- * control   ➡︎ Mevlana Lipp | Cups (2021) | Available for Sale | Artsy
- * variant-a ➡︎ Cups (2021) by Mevlana Lipp - For Sale | Artsy
- * ```
- */
-function generateTitle(artwork, variant) {
-  switch (variant) {
-    case "variant-a":
-      return join(" | ", [
-        join(" - ", [
-          join(" by ", [titleWithDateV2(artwork), artistNames(artwork)]),
-          forSaleIndicationV2(artwork),
-        ]),
-        "Artsy",
-      ])
-    default:
-      return join(" | ", [
-        artistNames(artwork),
-        titleWithDate(artwork),
-        forSaleIndication(artwork),
-        "Artsy",
-      ])
-  }
-}


### PR DESCRIPTION
Closes [DI-227](https://app.notion.com/p/artsy/Unleash-Clean-up-experiment-flag-345cab0764a0807b9ac0ca443e4dac3e)

To recap the history here…

|version|title format|
|---|---|
|original version|`Mevlana Lipp \| Cups (2021) \| Available for Sale \| Artsy`|
| https://github.com/artsy/metaphysics/pull/7609 Test #⁣1 |`Mevlana Lipp \| Cups (2021) \| For Sale \| Artsy`|
| https://github.com/artsy/metaphysics/pull/7721 Test #⁣2 🏆 now adopted as [winner](https://artsy.slack.com/archives/C05EEBNEF71/p1787931475814669) | `Cups (2021) by Mevlana Lipp - For Sale \| Artsy`|

## Todo

- [ ] Retire Unleash flag `diamond_artwork-title-experiment`

cc @artsy/diamond-devs 