### PR TITLE
fix: Mark publishedSince as deprecated argument and dont hard delete it just yet

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -2850,7 +2850,9 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   """
   The most recent editorial article featuring this artist, published in the last 12 months.
   """
-  latestArticle: ArtistLatestArticle
+  latestArticle(
+    publishedSince: String @deprecated(reason: "Filtering is deprecated")
+  ): ArtistLatestArticle
   location: String
   marketingCollections(
     after: String

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -448,6 +448,12 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
         }),
         description:
           "The most recent editorial article featuring this artist, published in the last 12 months. ",
+        args: {
+          publishedSince: {
+            type: GraphQLString,
+            deprecationReason: "Filtering is deprecated",
+          },
+        },
         resolve: ({ latest_article_href, latest_article_published_at }) => {
           if (!latest_article_href || !latest_article_published_at) return null
 


### PR DESCRIPTION
Fast follow most recent deployment

Marking `publishedSince` as temporarily deprecated as CMS production DOES pass the argument down the chain
We need to support it in the schema temporarily to remove changes of downtime

In Volt, the `editorial_feature_enabled` flag gates rendering, but `publishedSince` is always sent in the query regardless as since GraphQL fragments are static

<img width="2028" height="754" alt="Screenshot 2026-08-31 at 12 33 14 PM" src="https://github.com/user-attachments/assets/898fe2ba-ab39-4bd9-b2c0-fb0f59f315b8" />
