### PR TITLE
fix: Add fallback shim for ID

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3187,6 +3187,7 @@ type ArtistInstagramMedia {
 
 type ArtistLatestArticle {
   href: String
+  id: String @deprecated(reason: "Use href instead")
 }
 
 type ArtistMeta {

--- a/src/schema/v2/artist/__tests__/latestArticle.test.ts
+++ b/src/schema/v2/artist/__tests__/latestArticle.test.ts
@@ -30,6 +30,17 @@ const query = gql`
   }
 `
 
+const legacyQueryWithId = gql`
+  {
+    artist(id: "gerhard-richter") {
+      latestArticle {
+        href
+        id
+      }
+    }
+  }
+`
+
 describe("Artist#latestArticle", () => {
   it("returns href when article was published within the last year", async () => {
     const artistLoader = jest.fn().mockResolvedValue({
@@ -75,6 +86,18 @@ describe("Artist#latestArticle", () => {
     const { artist } = await runQuery(query, { artistLoader })
 
     expect(artist.latestArticle).toBeNull()
+  })
+
+  it("returns null for the deprecated id field (backwards compat for old cached clients)", async () => {
+    const artistLoader = jest.fn().mockResolvedValue({
+      ...ARTIST_FIXTURE,
+      latest_article_href: "/article/gerhard-richter-moma",
+      latest_article_published_at: RECENT_DATE,
+    })
+
+    const { artist } = await runQuery(legacyQueryWithId, { artistLoader })
+
+    expect(artist.latestArticle.id).toBeNull()
   })
 
   it("returns null when the article is just over a year old", async () => {

--- a/src/schema/v2/artist/index.ts
+++ b/src/schema/v2/artist/index.ts
@@ -444,6 +444,11 @@ export const ArtistType = new GraphQLObjectType<any, ResolverContext>({
           name: "ArtistLatestArticle",
           fields: {
             href: { type: GraphQLString },
+            id: {
+              type: GraphQLString,
+              resolve: () => null,
+              deprecationReason: "Use href instead",
+            },
           },
         }),
         description:


### PR DESCRIPTION
fix: Add fallback shim for article ID to help users on an older cached version of Volt

A deployment around 2pm ET went out and changed the signature of the `type` of object that was being returned from the `latestArticle` object in Metaphysics. Volt (the only consumer of this field) was deployed about 3 minutes later but there are some users hitting into the following exception if they are using a version of Volt that was bundled and cached by the browser.

This change just adds in a fallback handling for id to return nothing vs raise a graphql exception

Seeing that there are some `id: resolve () => null` in other areas of MP as well


⚠️ This is only a temporary patch while older cached versions Volt dwindle out ⚠️ 


Here's what the exception looks like:
<img width="1960" height="165" alt="Screenshot 2026-08-31 at 4 39 23 PM" src="https://github.com/user-attachments/assets/725969ae-0817-415f-87f2-14fe2a8a3c75" />



Users faced with this exception can resolve by refreshing and getting the latest bundle of Volt's code. This is an edge case behavior that is happening for those returning to an old version of Volt in the browser (the number is pretty low on Sentry (~20s) and going down but not yet `0`


- https://artsynet.sentry.io/issues/7247697018/?environment=production&project=1281370&query=is%3Aunresolved&referrer=issue-stream


- Anomaly was detected by [Watchdog here](https://app.datadoghq.com/apm/entity/service%3Ametaphysics.graphql?query=operation_name%3Agraphql.execute%20service%3Ametaphysics.graphql%20%40span.kind%3Aserver%20artistRoute&dependencyMap.showNetworkMetrics=false&env=%2A&errors=qson%3A%28data%3A%28issueSort%3ATOTAL_COUNT%29%2Cversion%3A%210%29&fromUser=true&groupMapByOperation=null&historicalData=true&operationName=graphql.execute&panels=qson%3A%28data%3A%28%29%2Cversion%3A%210%29&spanKind=server&start=1787603897789&end=1788208697789&paused=false)

<img width="1921" height="892" alt="Screenshot 2026-08-31 at 4 52 40 PM" src="https://github.com/user-attachments/assets/4168418f-141a-47fd-9ce1-6c4d8cb3e9be" />



Also tested and confirmed this works locally running an older version of Volt against the most recent MP

