### PR TITLE
feat: Add `generateArtworkDescription` mutation and brand kit writing fields

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -21094,9 +21094,9 @@ union GenerateArtworkDescriptionResponseOrError =
 
 type GenerateArtworkDescriptionSuccess {
   """
-  The generated artwork description
+  AI-generated artwork description suggestion. Not saved to the artwork until the user applies it.
   """
-  additionalInformation: String!
+  generatedDescription: String!
 }
 
 type GravityARImage {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -7853,6 +7853,8 @@ type BrandKit {
     """
     timezone: String
   ): String
+  writingLanguage: String
+  writingSample: String
 }
 
 type BulkAddArtworksToPartnerListFailure {
@@ -14967,6 +14969,16 @@ input CreateBrandKitInput {
   Text color hex code (e.g. #FF0000)
   """
   textColor: String
+
+  """
+  Language used for generated artwork descriptions
+  """
+  writingLanguage: String
+
+  """
+  Writing sample used to match tone in generated descriptions
+  """
+  writingSample: String
 }
 
 type CreateBrandKitPayload {
@@ -21055,6 +21067,38 @@ type GeneMeta {
   description: String!
 }
 
+type GenerateArtworkDescriptionFailure {
+  mutationError: GravityMutationError
+}
+
+input GenerateArtworkDescriptionInput {
+  clientMutationId: String
+
+  """
+  The internal ID of the artwork to generate a description for
+  """
+  id: String!
+}
+
+type GenerateArtworkDescriptionPayload {
+  """
+  On success: the generated artwork description
+  """
+  artworkDescriptionOrError: GenerateArtworkDescriptionResponseOrError
+  clientMutationId: String
+}
+
+union GenerateArtworkDescriptionResponseOrError =
+    GenerateArtworkDescriptionFailure
+  | GenerateArtworkDescriptionSuccess
+
+type GenerateArtworkDescriptionSuccess {
+  """
+  The generated artwork description
+  """
+  additionalInformation: String!
+}
+
 type GravityARImage {
   height: Int
   imageURLs: GravityImageURLs
@@ -26891,6 +26935,13 @@ type Mutation {
   Follow (or unfollow) a show
   """
   followShow(input: FollowShowInput!): FollowShowPayload
+
+  """
+  Generate an AI artwork description without saving it to the artwork
+  """
+  generateArtworkDescription(
+    input: GenerateArtworkDescriptionInput!
+  ): GenerateArtworkDescriptionPayload
 
   """
   Links a 3rd party account
@@ -39019,6 +39070,16 @@ input UpdateBrandKitInput {
   Text color hex code (e.g. #FF0000)
   """
   textColor: String
+
+  """
+  Language used for generated artwork descriptions
+  """
+  writingLanguage: String
+
+  """
+  Writing sample used to match tone in generated descriptions
+  """
+  writingSample: String
 }
 
 type UpdateBrandKitLogoFailure {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1535,6 +1535,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "PUT" }
     ),
+    generateArtworkDescriptionLoader: gravityLoader(
+      (id) => `artwork/${id}/generate_description`,
+      {},
+      { method: "POST" }
+    ),
     updateCollectionLoader: gravityLoader(
       (id) => `collection/${id}`,
       {},

--- a/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
@@ -1,0 +1,92 @@
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import { ResolverContext } from "types/graphql"
+
+const mutation = `
+  mutation {
+    generateArtworkDescription(input: { id: "artwork-1" }) {
+      artworkDescriptionOrError {
+        ... on GenerateArtworkDescriptionSuccess {
+          additionalInformation
+        }
+
+        ... on GenerateArtworkDescriptionFailure {
+          mutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`
+
+describe("generateArtworkDescription", () => {
+  describe("valid query", () => {
+    const mockGravityResponse = {
+      id: "artwork-1",
+      additional_information: "AI generated description.",
+    }
+
+    let context: Partial<ResolverContext>
+
+    beforeEach(() => {
+      context = {
+        generateArtworkDescriptionLoader: jest
+          .fn()
+          .mockResolvedValue(mockGravityResponse),
+      }
+    })
+
+    it("POSTs the artwork id to Gravity", async () => {
+      await runAuthenticatedQuery(mutation, context)
+
+      expect(
+        context.generateArtworkDescriptionLoader as jest.Mock
+      ).toHaveBeenCalledWith("artwork-1")
+    })
+
+    it("returns the generated description", async () => {
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toMatchInlineSnapshot(`
+        {
+          "generateArtworkDescription": {
+            "artworkDescriptionOrError": {
+              "additionalInformation": "AI generated description.",
+            },
+          },
+        }
+      `)
+    })
+  })
+
+  it("returns failure on Gravity error", async () => {
+    const gravityResponseBody = {
+      type: "error",
+      message: "Unable to generate artwork description",
+      detail: {},
+    }
+    const error = new HTTPError(
+      "http://artsy.net - {}",
+      422,
+      gravityResponseBody
+    )
+    const context = {
+      generateArtworkDescriptionLoader: jest.fn().mockRejectedValue(error),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "generateArtworkDescription": {
+          "artworkDescriptionOrError": {
+            "mutationError": {
+              "message": "Unable to generate artwork description",
+            },
+          },
+        },
+      }
+    `)
+  })
+})

--- a/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
@@ -60,6 +60,28 @@ describe("generateArtworkDescription", () => {
     })
   })
 
+  it("returns failure when Gravity omits the generated description", async () => {
+    const context = {
+      generateArtworkDescriptionLoader: jest.fn().mockResolvedValue({
+        id: "artwork-1",
+      }),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "generateArtworkDescription": {
+          "artworkDescriptionOrError": {
+            "mutationError": {
+              "message": "Unable to generate artwork description",
+            },
+          },
+        },
+      }
+    `)
+  })
+
   it("returns failure on Gravity error", async () => {
     const gravityResponseBody = {
       type: "error",

--- a/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/generateArtworkDescriptionMutation.test.ts
@@ -7,7 +7,7 @@ const mutation = `
     generateArtworkDescription(input: { id: "artwork-1" }) {
       artworkDescriptionOrError {
         ... on GenerateArtworkDescriptionSuccess {
-          additionalInformation
+          generatedDescription
         }
 
         ... on GenerateArtworkDescriptionFailure {
@@ -52,7 +52,7 @@ describe("generateArtworkDescription", () => {
         {
           "generateArtworkDescription": {
             "artworkDescriptionOrError": {
-              "additionalInformation": "AI generated description.",
+              "generatedDescription": "AI generated description.",
             },
           },
         }

--- a/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
+++ b/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
@@ -1,0 +1,90 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "GenerateArtworkDescriptionSuccess",
+  isTypeOf: (data) => data.id,
+  fields: () => ({
+    additionalInformation: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The generated artwork description",
+      resolve: ({ additional_information }) => additional_information,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "GenerateArtworkDescriptionFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "GenerateArtworkDescriptionResponseOrError",
+  types: [SuccessType, FailureType],
+  resolveType: (data) => {
+    if (data._type === "GravityMutationError") {
+      return "GenerateArtworkDescriptionFailure"
+    }
+    return "GenerateArtworkDescriptionSuccess"
+  },
+})
+
+export const generateArtworkDescriptionMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "GenerateArtworkDescription",
+  description:
+    "Generate an AI artwork description without saving it to the artwork",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        "The internal ID of the artwork to generate a description for",
+    },
+  },
+  outputFields: {
+    artworkDescriptionOrError: {
+      type: ResponseOrErrorType,
+      description: "On success: the generated artwork description",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { generateArtworkDescriptionLoader }) => {
+    if (!generateArtworkDescriptionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await generateArtworkDescriptionLoader(id)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
+++ b/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
@@ -78,7 +78,16 @@ export const generateArtworkDescriptionMutation = mutationWithClientMutationId<
     }
 
     try {
-      return await generateArtworkDescriptionLoader(id)
+      const result = await generateArtworkDescriptionLoader(id)
+
+      if (!result?.additional_information) {
+        return {
+          message: "Unable to generate artwork description",
+          _type: "GravityMutationError",
+        }
+      }
+
+      return result
     } catch (error) {
       const formattedErr = formatGravityError(error)
       if (formattedErr) {

--- a/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
+++ b/src/schema/v2/artwork/generateArtworkDescriptionMutation.ts
@@ -19,9 +19,10 @@ const SuccessType = new GraphQLObjectType<any, ResolverContext>({
   name: "GenerateArtworkDescriptionSuccess",
   isTypeOf: (data) => data.id,
   fields: () => ({
-    additionalInformation: {
+    generatedDescription: {
       type: new GraphQLNonNull(GraphQLString),
-      description: "The generated artwork description",
+      description:
+        "AI-generated artwork description suggestion. Not saved to the artwork until the user applies it.",
       resolve: ({ additional_information }) => additional_information,
     },
   }),

--- a/src/schema/v2/partner/Mutations/__tests__/createBrandKitMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/createBrandKitMutation.test.ts
@@ -12,6 +12,8 @@ const mutation = `
       fontFamily: "Helvetica"
       fontWeight: "bold"
       fontStyle: "normal"
+      writingLanguage: "English"
+      writingSample: "A spare, observational gallery voice."
     }) {
       brandKitOrError {
         ... on CreateBrandKitSuccess {
@@ -24,6 +26,8 @@ const mutation = `
             fontFamily
             fontWeight
             fontStyle
+            writingLanguage
+            writingSample
           }
         }
 
@@ -48,6 +52,8 @@ describe("createBrandKit", () => {
       font_family: "Helvetica",
       font_weight: "bold",
       font_style: "normal",
+      writing_language: "English",
+      writing_sample: "A spare, observational gallery voice.",
     }
 
     let context: Partial<ResolverContext>
@@ -69,6 +75,8 @@ describe("createBrandKit", () => {
         font_family: "Helvetica",
         font_weight: "bold",
         font_style: "normal",
+        writing_language: "English",
+        writing_sample: "A spare, observational gallery voice.",
       })
     })
 
@@ -88,6 +96,8 @@ describe("createBrandKit", () => {
                 "internalID": "brand-kit-1",
                 "partnerID": "partner-1",
                 "textColor": "#FF0000",
+                "writingLanguage": "English",
+                "writingSample": "A spare, observational gallery voice.",
               },
             },
           },

--- a/src/schema/v2/partner/Mutations/__tests__/updateBrandKitMutation.test.ts
+++ b/src/schema/v2/partner/Mutations/__tests__/updateBrandKitMutation.test.ts
@@ -8,6 +8,8 @@ const mutation = `
       id: "brand-kit-1"
       textColor: "#FF0000"
       fontFamily: "Courier"
+      writingLanguage: "English"
+      writingSample: "A spare, observational gallery voice."
     }) {
       brandKitOrError {
         ... on UpdateBrandKitSuccess {
@@ -15,6 +17,8 @@ const mutation = `
             internalID
             textColor
             fontFamily
+            writingLanguage
+            writingSample
           }
         }
 
@@ -35,6 +39,8 @@ describe("updateBrandKit", () => {
       partner_id: "partner-1",
       text_color: "#FF0000",
       font_family: "Courier",
+      writing_language: "English",
+      writing_sample: "A spare, observational gallery voice.",
     }
 
     let context: Partial<ResolverContext>
@@ -57,6 +63,8 @@ describe("updateBrandKit", () => {
           font_family: "Courier",
           font_weight: undefined,
           font_style: undefined,
+          writing_language: "English",
+          writing_sample: "A spare, observational gallery voice.",
         }
       )
     })
@@ -72,6 +80,8 @@ describe("updateBrandKit", () => {
                 "fontFamily": "Courier",
                 "internalID": "brand-kit-1",
                 "textColor": "#FF0000",
+                "writingLanguage": "English",
+                "writingSample": "A spare, observational gallery voice.",
               },
             },
           },

--- a/src/schema/v2/partner/Mutations/createBrandKitMutation.ts
+++ b/src/schema/v2/partner/Mutations/createBrandKitMutation.ts
@@ -20,6 +20,8 @@ interface Input {
   fontFamily?: string
   fontWeight?: string
   fontStyle?: string
+  writingLanguage?: string
+  writingSample?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -91,6 +93,15 @@ export const createBrandKitMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Font style",
     },
+    writingLanguage: {
+      type: GraphQLString,
+      description: "Language used for generated artwork descriptions",
+    },
+    writingSample: {
+      type: GraphQLString,
+      description:
+        "Writing sample used to match tone in generated descriptions",
+    },
   },
   outputFields: {
     brandKitOrError: {
@@ -108,6 +119,8 @@ export const createBrandKitMutation = mutationWithClientMutationId<
       fontFamily,
       fontWeight,
       fontStyle,
+      writingLanguage,
+      writingSample,
     },
     { createBrandKitLoader }
   ) => {
@@ -124,6 +137,8 @@ export const createBrandKitMutation = mutationWithClientMutationId<
         font_family: fontFamily,
         font_weight: fontWeight,
         font_style: fontStyle,
+        writing_language: writingLanguage,
+        writing_sample: writingSample,
       })
     } catch (error) {
       const formattedErr = formatGravityError(error)

--- a/src/schema/v2/partner/Mutations/updateBrandKitMutation.ts
+++ b/src/schema/v2/partner/Mutations/updateBrandKitMutation.ts
@@ -20,6 +20,8 @@ interface Input {
   fontFamily?: string
   fontWeight?: string
   fontStyle?: string
+  writingLanguage?: string
+  writingSample?: string
 }
 
 const SuccessType = new GraphQLObjectType<any, ResolverContext>({
@@ -91,6 +93,15 @@ export const updateBrandKitMutation = mutationWithClientMutationId<
       type: GraphQLString,
       description: "Font style",
     },
+    writingLanguage: {
+      type: GraphQLString,
+      description: "Language used for generated artwork descriptions",
+    },
+    writingSample: {
+      type: GraphQLString,
+      description:
+        "Writing sample used to match tone in generated descriptions",
+    },
   },
   outputFields: {
     brandKitOrError: {
@@ -108,6 +119,8 @@ export const updateBrandKitMutation = mutationWithClientMutationId<
       fontFamily,
       fontWeight,
       fontStyle,
+      writingLanguage,
+      writingSample,
     },
     { updateBrandKitLoader }
   ) => {
@@ -123,6 +136,8 @@ export const updateBrandKitMutation = mutationWithClientMutationId<
         font_family: fontFamily,
         font_weight: fontWeight,
         font_style: fontStyle,
+        writing_language: writingLanguage,
+        writing_sample: writingSample,
       })
     } catch (error) {
       const formattedErr = formatGravityError(error)

--- a/src/schema/v2/partner/__tests__/brandKit.test.ts
+++ b/src/schema/v2/partner/__tests__/brandKit.test.ts
@@ -14,6 +14,8 @@ describe("Partner brandKit field", () => {
           fontFamily
           fontWeight
           fontStyle
+          writingLanguage
+          writingSample
         }
       }
     }
@@ -34,6 +36,8 @@ describe("Partner brandKit field", () => {
       font_family: "Helvetica",
       font_weight: "bold",
       font_style: "normal",
+      writing_language: "English",
+      writing_sample: "A spare, observational gallery voice.",
     }
 
     const context = {
@@ -57,6 +61,8 @@ describe("Partner brandKit field", () => {
           fontFamily: "Helvetica",
           fontWeight: "bold",
           fontStyle: "normal",
+          writingLanguage: "English",
+          writingSample: "A spare, observational gallery voice.",
         },
       },
     })

--- a/src/schema/v2/partner/brandKit.ts
+++ b/src/schema/v2/partner/brandKit.ts
@@ -36,6 +36,14 @@ export const BrandKitType = new GraphQLObjectType<any, ResolverContext>({
       type: GraphQLString,
       resolve: ({ font_style }) => font_style,
     },
+    writingLanguage: {
+      type: GraphQLString,
+      resolve: ({ writing_language }) => writing_language,
+    },
+    writingSample: {
+      type: GraphQLString,
+      resolve: ({ writing_sample }) => writing_sample,
+    },
     logo: {
       type: Image.type,
       resolve: ({ image }) => {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -165,6 +165,7 @@ import { updateCatalogEditionSetMutation } from "./artwork/updateCatalogEditionS
 import { syncCatalogToArtworkMutation } from "./artwork/syncCatalogToArtworkMutation"
 import { duplicateCatalogArtworkMutation } from "./artwork/duplicateCatalogArtworkMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
+import { generateArtworkDescriptionMutation } from "./artwork/generateArtworkDescriptionMutation"
 import { repositionArtworkImagesMutation } from "./artwork/repositionArtworkImagesMutation"
 import { artworkFilterSuggestions } from "./artworkFilterSuggestions"
 import { artworksForUser } from "./artworksForUser"
@@ -834,6 +835,7 @@ export default new GraphQLSchema({
       updateCatalogEditionSet: updateCatalogEditionSetMutation,
       updateConversationMessageTemplate: updateConversationMessageTemplateMutation,
       updateArtwork: updateArtworkMutation,
+      generateArtworkDescription: generateArtworkDescriptionMutation,
       updateArtworkImport: UpdateArtworkImportMutation,
       updateArtworkImportRow: UpdateArtworkImportRowMutation,
       createArtworkImportArtworks: CreateArtworkImportArtworksMutation,


### PR DESCRIPTION
Resolves [AI Generated Descriptions](https://app.notion.com/p/artsy/AI-Generated-Descriptions-3a7cab0764a0806aa1cece68c5ac0ccb)

- Related Volt PR: https://github.com/artsy/volt/pull/12024
- Related Gravity PR: https://github.com/artsy/gravity/pull/20412

## Description

Adds new mutation `generateArtworkDescription` and extends the partner brandKit with `writingLanguage` and `writingSample` for the new AI Artwork Description UI.


## Examples

Generate an AI artwork description (does not persist it on the artwork):

```graphql
mutation {
  generateArtworkDescription(input: { id: "<artwork-id>" }) {
    artworkDescriptionOrError {
      ... on GenerateArtworkDescriptionSuccess {
        additionalInformation
      }
      ... on GenerateArtworkDescriptionFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

Read writing preferences from a partner's brand kit:

```graphql
{
  partner(id: "<partner-id>") {
    brandKit {
      writingLanguage
      writingSample
    }
  }
}
```

Create a brand kit with writing preferences:

```graphql
mutation {
  createBrandKit(
    input: {
      partnerId: "<partner-id>"
      writingLanguage: "English"
      writingSample: "A spare, observational gallery voice."
    }
  ) {
    brandKitOrError {
      ... on CreateBrandKitSuccess {
        brandKit {
          writingLanguage
          writingSample
        }
      }
      ... on CreateBrandKitFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

Update writing preferences on an existing brand kit:

```graphql
mutation {
  updateBrandKit(
    input: {
      id: "<brand-kit-id>"
      writingLanguage: "English"
      writingSample: "A spare, observational gallery voice."
    }
  ) {
    brandKitOrError {
      ... on UpdateBrandKitSuccess {
        brandKit {
          writingLanguage
          writingSample
        }
      }
      ... on UpdateBrandKitFailure {
        mutationError {
          message
        }
      }
    }
  }
}
```

@artsy/amber-devs 