### PR TITLE
chore: add unmatched artist support (schema + mutation) for the artnet import

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -3927,6 +3927,50 @@ type ArtnetEditionSet {
   ): String
 }
 
+type ArtnetImport {
+  completedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  createdAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  createdCount: Int
+  deletedCount: Int
+  errorCount: Int
+  errorMessage: String
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  A type-specific ID likely used as a database ID.
+  """
+  internalID: ID!
+  skippedCount: Int
+  state: ArtnetImportState
+  totalCount: Int
+  unmatchedArtistNames: [String!]!
+}
+
+enum ArtnetImportState {
+  COMPLETED
+  FAILED
+  PENDING
+  PROCESSING
+}
+
 type ArtsyShippingOptInMutationFailure {
   mutationError: GravityMutationError
 }
@@ -14485,6 +14529,40 @@ type CreateArtistSuccess {
 }
 
 union CreateArtistSuccessOrErrorType = CreateArtistFailure | CreateArtistSuccess
+
+type CreateArtnetImportArtistAssignmentFailure {
+  mutationError: GravityMutationError
+}
+
+input CreateArtnetImportArtistAssignmentInput {
+  """
+  The artist ID to assign to the unmatched name
+  """
+  artistID: String!
+
+  """
+  The unmatched artist name to assign
+  """
+  artistName: String!
+  artnetImportID: String!
+  clientMutationId: String
+}
+
+type CreateArtnetImportArtistAssignmentPayload {
+  clientMutationId: String
+  createArtnetImportArtistAssignmentOrError: CreateArtnetImportArtistAssignmentResponseOrError
+}
+
+union CreateArtnetImportArtistAssignmentResponseOrError =
+    CreateArtnetImportArtistAssignmentFailure
+  | CreateArtnetImportArtistAssignmentSuccess
+
+type CreateArtnetImportArtistAssignmentSuccess {
+  artnetImport: ArtnetImport
+  artnetImportID: String!
+  matchedRowsCount: Int!
+  updatedArtworksCount: Int!
+}
 
 type CreateArtnetImportFailure {
   mutationError: GravityMutationError
@@ -25997,6 +26075,9 @@ type Mutation {
   createArtnetImport(
     input: CreateArtnetImportMutationInput!
   ): CreateArtnetImportMutationPayload
+  createArtnetImportArtistAssignment(
+    input: CreateArtnetImportArtistAssignmentInput!
+  ): CreateArtnetImportArtistAssignmentPayload
 
   """
   Creates a new artwork, optionally with associated images.
@@ -32307,6 +32388,7 @@ type Query {
     """
     term: String
   ): ArtistConnection
+  artnetImport(id: String!): ArtnetImport
 
   """
   An Artwork
@@ -42260,6 +42342,7 @@ type Viewer {
     """
     term: String
   ): ArtistConnection
+  artnetImport(id: String!): ArtnetImport
 
   """
   An Artwork

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -257,6 +257,15 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    artnetImportLoader: gravityLoader((id) => `artnet_import/${id}`),
+    artnetImportUnmatchedArtistNamesLoader: gravityLoader(
+      (id) => `artnet_import/${id}/unmatched_artist_names`
+    ),
+    artnetImportCreateArtistAssignmentLoader: gravityLoader(
+      (id) => `artnet_import/${id}/artist_assignments`,
+      {},
+      { method: "POST" }
+    ),
     createArtworkImportLoader: gravityLoader(
       "artwork_import",
       {},

--- a/src/schema/v2/artnet/__tests__/artnetImport.test.ts
+++ b/src/schema/v2/artnet/__tests__/artnetImport.test.ts
@@ -1,0 +1,93 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("ArtnetImport type", () => {
+  const query = `
+    {
+      artnetImport(id: "artnet-import-1") {
+        internalID
+        state
+        totalCount
+        createdCount
+        skippedCount
+        deletedCount
+        errorCount
+        unmatchedArtistNames
+      }
+    }
+  `
+
+  it("resolves scalar fields and maps state to the enum", async () => {
+    const context = {
+      artnetImportLoader: () =>
+        Promise.resolve({
+          id: "artnet-import-1",
+          state: "completed",
+          total_count: 10,
+          created_count: 8,
+          skipped_count: 1,
+          deleted_count: 0,
+          error_count: 1,
+        }),
+      artnetImportUnmatchedArtistNamesLoader: () =>
+        Promise.resolve({ unmatched_artist_names: ["Foo Bar"] }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      artnetImport: {
+        internalID: "artnet-import-1",
+        state: "COMPLETED",
+        totalCount: 10,
+        createdCount: 8,
+        skippedCount: 1,
+        deletedCount: 0,
+        errorCount: 1,
+        unmatchedArtistNames: ["Foo Bar"],
+      },
+    })
+  })
+
+  it("returns unmatched artist names via the loader when the import is completed", async () => {
+    const artnetImportUnmatchedArtistNamesLoader = jest
+      .fn()
+      .mockResolvedValue({ unmatched_artist_names: ["Alice", "Bob"] })
+
+    const context = {
+      artnetImportLoader: () =>
+        Promise.resolve({ id: "artnet-import-1", state: "completed" }),
+      artnetImportUnmatchedArtistNamesLoader,
+    }
+
+    const data = await runAuthenticatedQuery(
+      `{ artnetImport(id: "artnet-import-1") { unmatchedArtistNames } }`,
+      context
+    )
+
+    expect(artnetImportUnmatchedArtistNamesLoader).toHaveBeenCalledWith(
+      "artnet-import-1"
+    )
+    expect(data).toEqual({
+      artnetImport: { unmatchedArtistNames: ["Alice", "Bob"] },
+    })
+  })
+
+  it("returns an empty list without calling the loader while pending or processing", async () => {
+    const artnetImportUnmatchedArtistNamesLoader = jest.fn()
+
+    const context = {
+      artnetImportLoader: () =>
+        Promise.resolve({ id: "artnet-import-1", state: "processing" }),
+      artnetImportUnmatchedArtistNamesLoader,
+    }
+
+    const data = await runAuthenticatedQuery(
+      `{ artnetImport(id: "artnet-import-1") { unmatchedArtistNames } }`,
+      context
+    )
+
+    expect(artnetImportUnmatchedArtistNamesLoader).not.toHaveBeenCalled()
+    expect(data).toEqual({
+      artnetImport: { unmatchedArtistNames: [] },
+    })
+  })
+})

--- a/src/schema/v2/artnet/__tests__/createArtnetImportArtistAssignmentMutation.test.ts
+++ b/src/schema/v2/artnet/__tests__/createArtnetImportArtistAssignmentMutation.test.ts
@@ -1,0 +1,95 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("createArtnetImportArtistAssignment mutation", () => {
+  const query = `
+    mutation {
+      createArtnetImportArtistAssignment(
+        input: {
+          artnetImportID: "artnet-import-1"
+          artistName: "Foo Bar"
+          artistID: "foo-bar-id"
+        }
+      ) {
+        createArtnetImportArtistAssignmentOrError {
+          ... on CreateArtnetImportArtistAssignmentSuccess {
+            artnetImportID
+            matchedRowsCount
+            updatedArtworksCount
+            artnetImport {
+              internalID
+            }
+          }
+          ... on CreateArtnetImportArtistAssignmentFailure {
+            mutationError {
+              type
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("assigns the artist and returns the updated counts", async () => {
+    const artnetImportCreateArtistAssignmentLoader = jest
+      .fn()
+      .mockResolvedValue({
+        matched_rows_count: 3,
+        updated_artworks_count: 2,
+        skipped_already_assigned_artwork_ids: ["a1"],
+        missing_artnet_artwork_ids: [],
+        failed_artwork_ids: [],
+      })
+
+    const context = {
+      artnetImportCreateArtistAssignmentLoader,
+      artnetImportLoader: () =>
+        Promise.resolve({ id: "artnet-import-1", state: "completed" }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(artnetImportCreateArtistAssignmentLoader).toHaveBeenCalledWith(
+      "artnet-import-1",
+      {
+        artist_name: "Foo Bar",
+        artist_id: "foo-bar-id",
+      }
+    )
+    expect(data).toEqual({
+      createArtnetImportArtistAssignment: {
+        createArtnetImportArtistAssignmentOrError: {
+          artnetImportID: "artnet-import-1",
+          matchedRowsCount: 3,
+          updatedArtworksCount: 2,
+          artnetImport: {
+            internalID: "artnet-import-1",
+          },
+        },
+      },
+    })
+  })
+
+  it("returns a mutation error when there are no unresolved matches", async () => {
+    const context = {
+      artnetImportCreateArtistAssignmentLoader: () =>
+        Promise.reject(
+          new Error(
+            `https://stagingapi.artsy.net/api/v1/artnet_import/artnet-import-1/artist_assignments - {"type":"error","message":"No unresolved artworks found for this artist name"}`
+          )
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+    expect(data).toEqual({
+      createArtnetImportArtistAssignment: {
+        createArtnetImportArtistAssignmentOrError: {
+          mutationError: {
+            type: "error",
+            message: "No unresolved artworks found for this artist name",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/artnet/artnetImport.ts
+++ b/src/schema/v2/artnet/artnetImport.ts
@@ -1,0 +1,93 @@
+import {
+  GraphQLEnumType,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { InternalIDFields } from "../object_identification"
+import { ResolverContext } from "types/graphql"
+import { date } from "schema/v2/fields/date"
+
+export const ArtnetImportStateType = new GraphQLEnumType({
+  name: "ArtnetImportState",
+  values: {
+    PENDING: { value: "pending" },
+    PROCESSING: { value: "processing" },
+    COMPLETED: { value: "completed" },
+    FAILED: { value: "failed" },
+  },
+})
+
+const IN_PROGRESS_STATES = ["pending", "processing"]
+
+export const ArtnetImportType = new GraphQLObjectType<any, ResolverContext>({
+  name: "ArtnetImport",
+  fields: () => ({
+    ...InternalIDFields,
+    state: {
+      type: ArtnetImportStateType,
+    },
+    totalCount: {
+      type: GraphQLInt,
+      resolve: ({ total_count }) => total_count,
+    },
+    createdCount: {
+      type: GraphQLInt,
+      resolve: ({ created_count }) => created_count,
+    },
+    skippedCount: {
+      type: GraphQLInt,
+      resolve: ({ skipped_count }) => skipped_count,
+    },
+    deletedCount: {
+      type: GraphQLInt,
+      resolve: ({ deleted_count }) => deleted_count,
+    },
+    errorCount: {
+      type: GraphQLInt,
+      resolve: ({ error_count }) => error_count,
+    },
+    errorMessage: {
+      type: GraphQLString,
+      resolve: ({ error_message }) => error_message,
+    },
+    createdAt: date(),
+    completedAt: date(),
+    unmatchedArtistNames: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(GraphQLString))
+      ),
+      resolve: async (
+        { id, state },
+        _args,
+        { artnetImportUnmatchedArtistNamesLoader }
+      ) => {
+        if (!artnetImportUnmatchedArtistNamesLoader) return []
+        if (IN_PROGRESS_STATES.includes(state)) return []
+
+        const {
+          unmatched_artist_names,
+        } = await artnetImportUnmatchedArtistNamesLoader(id)
+
+        return unmatched_artist_names
+      },
+    },
+  }),
+})
+
+export const ArtnetImport: GraphQLFieldConfig<any, ResolverContext> = {
+  type: ArtnetImportType,
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  resolve: (_parent, { id }, { artnetImportLoader }) => {
+    if (!artnetImportLoader) return null
+
+    return artnetImportLoader(id)
+  },
+}

--- a/src/schema/v2/artnet/createArtnetImportArtistAssignmentMutation.ts
+++ b/src/schema/v2/artnet/createArtnetImportArtistAssignmentMutation.ts
@@ -1,0 +1,111 @@
+import {
+  GraphQLString,
+  GraphQLObjectType,
+  GraphQLUnionType,
+  GraphQLNonNull,
+  GraphQLInt,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ArtnetImportType } from "./artnetImport"
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtnetImportArtistAssignmentSuccess",
+  isTypeOf: (data) => !!data.artnetImportID,
+  fields: () => ({
+    artnetImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    matchedRowsCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    updatedArtworksCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+    },
+    artnetImport: {
+      type: ArtnetImportType,
+      resolve: ({ artnetImportID }, _args, { artnetImportLoader }) => {
+        if (!artnetImportLoader) return null
+        return artnetImportLoader(artnetImportID)
+      },
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreateArtnetImportArtistAssignmentFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreateArtnetImportArtistAssignmentResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreateArtnetImportArtistAssignmentMutation = mutationWithClientMutationId<
+  any,
+  any,
+  ResolverContext
+>({
+  name: "CreateArtnetImportArtistAssignment",
+  inputFields: {
+    artnetImportID: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    artistName: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The unmatched artist name to assign",
+    },
+    artistID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The artist ID to assign to the unmatched name",
+    },
+  },
+  outputFields: {
+    createArtnetImportArtistAssignmentOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artnetImportID, artistName, artistID },
+    { artnetImportCreateArtistAssignmentLoader }
+  ) => {
+    if (!artnetImportCreateArtistAssignmentLoader) {
+      throw new Error("This operation requires an `X-Access-Token` header.")
+    }
+
+    try {
+      const result = await artnetImportCreateArtistAssignmentLoader(
+        artnetImportID,
+        {
+          artist_name: artistName,
+          artist_id: artistID,
+        }
+      )
+
+      return {
+        artnetImportID,
+        matchedRowsCount: result.matched_rows_count,
+        updatedArtworksCount: result.updated_artworks_count,
+      }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -156,6 +156,8 @@ import { createArtistMutation } from "./artist/createArtistMutation"
 import { createCanonicalArtistMutation } from "./artist/createCanonicalArtistMutation"
 import { deleteArtistMutation } from "./artist/deleteArtistMutation"
 import { createArtnetImportMutation } from "./artnet/artnetImportMutation"
+import { ArtnetImport } from "./artnet/artnetImport"
+import { CreateArtnetImportArtistAssignmentMutation } from "./artnet/createArtnetImportArtistAssignmentMutation"
 import { createArtworkMutation } from "./artwork/createArtworkMutation"
 import { deleteArtworkMutation } from "./artwork/deleteArtworkMutation"
 import { updateCatalogArtworkMutation } from "./artwork/updateCatalogArtworkMutation"
@@ -471,6 +473,7 @@ const rootFields = {
   artistsConnection,
   artistSeries: ArtistSeries,
   artistSeriesConnection: ArtistSeriesConnection,
+  artnetImport: ArtnetImport,
   artwork: Artwork,
   artworkAttributionClasses: ArtworkAttributionClasses,
   artworkDuplicatePair,
@@ -644,6 +647,7 @@ export default new GraphQLSchema({
       createAccountRequest: createAccountRequestMutation,
       createAlert: createAlertMutation,
       createArtnetImport: createArtnetImportMutation,
+      createArtnetImportArtistAssignment: CreateArtnetImportArtistAssignmentMutation,
       createArtwork: createArtworkMutation,
       createAndSendBackupSecondFactor: createAndSendBackupSecondFactorMutation,
       createAppSecondFactor: createAppSecondFactorMutation,


### PR DESCRIPTION
Pretty boilerplate, adds the `ArtnetImport` type that resolves with the unmatched artist names for an import, as well as the mutation that lets you assign an artist to an unmatched artist name for an import.