### PR TITLE
feat: give the agent the artwork filter surface and more entry points

### DIFF
--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -7,7 +7,7 @@ import {
   summarizeToolCall,
 } from "../tools"
 import { mapSchema, MapperKind } from "@graphql-tools/utils"
-import { GraphQLObjectType } from "graphql"
+import { GraphQLObjectType, parse, specifiedRules, validate } from "graphql"
 import { HTTPError } from "lib/HTTPError"
 
 describe("buildAgentTools", () => {
@@ -248,6 +248,87 @@ describe("runQueryArtsyTool", () => {
     expect(result.ok).toBe(false)
     expect(typeof result.content).toBe("string")
     expect(result.content.length).toBeGreaterThan(0)
+  })
+})
+
+describe("the root field allowlist", () => {
+  const rootFieldNames = () => {
+    const queryType = narrowSchemaFor(schema).getQueryType()
+    return Object.keys(queryType!.getFields()).sort()
+  }
+
+  it("exposes exactly the entry points the prompt documents", () => {
+    expect(rootFieldNames()).toEqual([
+      "artist",
+      "artistSeries",
+      "artistSeriesConnection",
+      "artistsConnection",
+      "artwork",
+      "artworksConnection",
+      "fair",
+      "fairs",
+      "gene",
+      "genes",
+      "marketingCollection",
+      "marketingCollections",
+      "matchConnection",
+      "me",
+      "showsConnection",
+      "trendingSearches",
+    ])
+  })
+
+  // Auction data hangs off Sale/SaleArtwork through meBiddersLoader and
+  // lotStandingLoader -- the collector's own bidding, which is what the Me
+  // allowlist exists to keep out of model context.
+  it("keeps auctions out, reachable only as artworksConnection(atAuction:)", () => {
+    expect(rootFieldNames()).not.toContain("sale")
+    expect(rootFieldNames()).not.toContain("salesConnection")
+    expect(rootFieldNames()).not.toContain("saleArtworksConnection")
+  })
+
+  // Each of these hangs its works off a differently-named connection, which
+  // the prompt spells out; a rename upstream should fail here, not in a
+  // retry loop at runtime.
+  describe("the recipes the prompt gives for them", () => {
+    const validationErrors = (query: string) =>
+      validate(narrowSchemaFor(schema), parse(query), [...specifiedRules]).map(
+        (error) => error.message
+      )
+
+    it.each([
+      [
+        "gene",
+        '{ gene(id: "abstract-expressionism") { name filterArtworksConnection(first: 5) { edges { node { internalID } } } } }',
+      ],
+      [
+        "artistSeries",
+        '{ artistSeries(id: "andy-warhol-flowers") { title filterArtworksConnection(first: 5) { edges { node { internalID } } } } }',
+      ],
+      [
+        "fair",
+        '{ fair(id: "art-basel-2026") { name filterArtworksConnection(first: 5) { edges { node { internalID } } } } }',
+      ],
+      [
+        "marketingCollection",
+        '{ marketingCollection(slug: "prints-under-1000") { title artworksConnection(first: 5) { edges { node { internalID } } } } }',
+      ],
+      [
+        "artistSeriesConnection",
+        '{ artistSeriesConnection(artistID: "4d8b92b34eb68a1b2c000452", first: 5) { edges { node { slug title } } } }',
+      ],
+      [
+        "fairs",
+        "{ fairs(status: RUNNING, sort: START_AT_ASC, size: 5) { slug name startAt endAt } }",
+      ],
+      ["genes", '{ genes(slugs: ["minimalism"]) { name slug } }'],
+      [
+        "marketingCollections",
+        "{ marketingCollections(size: 5) { slug title } }",
+      ],
+    ])("validates the %s recipe", (_name, query) => {
+      expect(validationErrors(query)).toEqual([])
+    })
   })
 })
 
@@ -604,6 +685,20 @@ describe("summarizeToolCall", () => {
           "{ me { followsAndSaves { artworksConnection(first: 10) { edges { node { slug } } } } } }",
       })
     ).toBe("Querying Artsy: followsAndSaves…")
+  })
+
+  it("labels the entry point, not the connection nested under it", () => {
+    expect(
+      summarizeToolCall({
+        query:
+          '{ gene(id: "minimalism") { filterArtworksConnection(first: 5) { edges { node { internalID } } } } }',
+      })
+    ).toBe("Querying Artsy: gene…")
+    expect(
+      summarizeToolCall({
+        query: '{ fair(id: "art-basel-2026") { name } }',
+      })
+    ).toBe("Querying Artsy: fair…")
   })
 
   it("falls back to a generic label when the root field can't be identified", () => {

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -101,6 +101,40 @@ not starting over from a bare keyword. For "show me more", re-run it with
 \`excludeArtworkIDs: [<the ids already shown>]\` so the next set is work they
 haven't seen rather than the same page again.
 
+## Artwork filters
+
+\`artworksConnection\` takes these, combinable and all AND-ed. Prefer a real
+filter over stuffing the request into \`keyword\`.
+
+- \`keyword\` — with \`keywordTypoTolerance: true\`, always; chat input has typos.
+- \`additionalGeneIDs\` — the medium filter, exact slugs only:
+  painting, photography, sculpture, prints, work-on-paper, drawing, design,
+  installation, mixed-media, digital-art, nft, jewelry, poster, textile-arts,
+  film-slash-video, performance-art, reproduction, books-and-portfolios,
+  ephemera-or-merchandise, fashion-design-and-wearable-art, architecture-1.
+  For a style or movement rather than a medium ("abstract expressionism",
+  "street art"), resolve it first with
+  \`matchConnection(term: "<style>", entities: [GENE], first: 1)\` and pass the
+  slug you get back.
+- \`priceRange\` — \`"<min>-<max>"\` in USD, \`*\` for an open end:
+  \`"5000-20000"\`, \`"*-5000"\`, \`"20000-*"\`.
+- \`sizes\` — \`[SMALL]\`, \`[MEDIUM]\`, \`[LARGE]\` (any combination).
+- \`attributionClass\` — \`["unique"]\`, \`["limited edition"]\`,
+  \`["open edition"]\`, \`["unknown edition"]\`. Use it for "one of a kind" and
+  "editions".
+- \`majorPeriods\` — decades as strings: \`"2020"\`, \`"2010"\` … \`"1900"\`.
+- \`colors\` — red, orange, yellow, green, blue, purple, pink, brown, gray,
+  black-and-white.
+- \`artistNationalities\` — e.g. \`["Japanese"]\`, \`["British"]\`.
+- \`artistSeriesIDs\`, \`partnerIDs\`, \`locationCities\`,
+  \`marketingCollectionID\`, \`excludeArtworkIDs\`.
+- Booleans: \`forSale\`, \`acquireable\` (buy now), \`offerable\` (make an offer),
+  \`inquireableOnly\`, \`atAuction\`, \`framed\`, \`signed\`, \`curatorsPick\`,
+  \`increasedInterest\`.
+
+Any value not listed above will silently match nothing, so map the collector's
+words onto these rather than inventing a slug.
+
 ## Recipes
 
 Artworks by a named artist, with price/size filters:
@@ -127,6 +161,24 @@ Recommendations from the collector's own saves ("works similar to my saves",
 The collector's own saved works ("what have I saved", "my saves"):
   \`me { followsAndSaves { artworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } } }\`
   For the artists they follow, use \`artistsConnection\` on that same field.
+
+A style or movement ("abstract expressionism", "street art", "minimalism"):
+  \`gene(id: "<slug>") { name filterArtworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } }\`
+  Resolve the slug first with \`matchConnection(term: "<style>", entities: [GENE], first: 1)\`.
+
+A curated collection ("prints under $1,000", "iconic works", themed lists):
+  \`marketingCollections(size: <=20) { slug title }\` to find one — or
+  \`marketingCollections(artistID: "<internalID>", size: <=20)\` for one artist's — then
+  \`marketingCollection(slug: "<slug>") { title artworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } }\`.
+
+An artist's series ("Warhol's Flowers", "Kusama's Pumpkins"):
+  \`artistSeriesConnection(artistID: "<internalID>", first: <=20) { edges { node { slug title } } }\` then
+  \`artistSeries(id: "<slug>") { title filterArtworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } }\`.
+
+Fairs, and works showing at one:
+  \`fairs(status: RUNNING, sort: START_AT_ASC, size: <=20) { slug name startAt endAt }\`
+  (\`status\` is \`RUNNING\`, \`UPCOMING\`, \`RUNNING_AND_UPCOMING\`, \`CLOSING_SOON\`, \`CLOSED\`), then
+  \`fair(id: "<slug>") { name filterArtworksConnection(first: <=20) { edges { node { internalID slug title artistNames saleMessage } } } }\`.
 
 Trending / most popular artworks or artists ("what's trending", "what's
 popular right now", "what are people looking at"):
@@ -158,17 +210,24 @@ of the question as your other tool calls did cover.
   \`listPrice { ... on Money { display } ... on PriceRange { display minPrice { display } maxPrice { display } } }\`.
 - \`Artwork.price\` and \`Artwork.saleMessage\` are plain \`String\` — no
   subselection.
-- To filter \`artworksConnection\` by price, use the \`priceRange\` argument
-  with the format \`"<min>-<max>"\` (in USD, e.g. \`"5000-20000"\`). Do not try
-  to filter via \`priceMin\`/\`priceMax\` — those are output fields, not inputs.
+- \`priceMin\`/\`priceMax\` are output fields, not inputs — filter with
+  \`priceRange\` (see Artwork filters).
 - IDs: \`internalID\` is the opaque DB id (hex string), \`slug\` is the
   human-readable URL id (e.g. \`"banksy"\`). Both can be passed to
   \`artist(id: …)\` and \`artwork(id: …)\`. Prefer \`internalID\` when passing
   to array args like \`artistIDs\`.
 - Available root fields are only:
   \`artworksConnection\`, \`artistsConnection\`, \`artist\`, \`artwork\`,
+  \`artistSeries\`, \`artistSeriesConnection\`, \`gene\`, \`genes\`,
+  \`marketingCollection\`, \`marketingCollections\`, \`fair\`, \`fairs\`,
   \`showsConnection\`, \`matchConnection\`, \`trendingSearches\`, \`me\`.
-  Anything else will fail validation.
+  Anything else will fail validation. There is no \`sale\` or
+  \`salesConnection\` — for auction works use
+  \`artworksConnection(atAuction: true)\`.
+- Works hang off these under different names: \`gene\`, \`artistSeries\` and
+  \`fair\` use \`filterArtworksConnection\`, \`marketingCollection\` uses
+  \`artworksConnection\`, and \`artist\` uses \`artworksConnection\`. All take
+  the same filter arguments.
 - \`me\` is the signed-in collector, and only their personalization fields are
   reachable: \`basedOnUserSaves\`, \`artworkRecommendations\`,
   \`artistRecommendations\`, and \`followsAndSaves\` (which has

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -48,6 +48,14 @@ const ALLOWED_ROOT_FIELDS = new Set([
   "artistsConnection",
   "artist",
   "artwork",
+  "artistSeries",
+  "artistSeriesConnection",
+  "gene",
+  "genes",
+  "marketingCollection",
+  "marketingCollections",
+  "fair",
+  "fairs",
   "showsConnection",
   "matchConnection",
   "trendingSearches",
@@ -424,12 +432,19 @@ export function buildAgentTools(
     query_artsy: tool({
       description:
         "Run a read-only GraphQL query to search and look up artists, " +
-        "artworks, shows, and fairs. Available root fields: " +
+        "artworks, shows and fairs. Available root fields: " +
         "artworksConnection, artistsConnection, artist, artwork, " +
-        "showsConnection, matchConnection, trendingSearches (for " +
-        "trending/most-popular rankings), and me (the signed-in collector's " +
-        "own saves, follows and recommendations — `me` is null when signed " +
-        "out, and only its personalization fields are reachable). Use " +
+        "artistSeries, artistSeriesConnection, gene, genes (styles and " +
+        "movements), marketingCollection, marketingCollections (curated " +
+        "collections), fair, fairs, showsConnection, matchConnection, " +
+        "trendingSearches (for trending/most-popular rankings), and me (the " +
+        "signed-in collector's own saves, follows and recommendations — " +
+        "`me` is null when signed out, and only its personalization fields " +
+        "are reachable). Auctions are reachable as " +
+        "artworksConnection(atAuction: true), not as a sale root field. " +
+        "Note gene, artistSeries and fair expose their works as " +
+        "`filterArtworksConnection`, while marketingCollection uses " +
+        "`artworksConnection`. Use " +
         "GraphQL introspection (e.g. " +
         '`{ __type(name: "Artwork") { fields { name description } } }`) to ' +
         "discover the fields and args available on any type — one type at a " +
@@ -467,7 +482,7 @@ export function summarizeToolCall(input: unknown): string {
   if (typeof query !== "string") return "Querying Artsy…"
 
   const match = query.match(
-    /\b(artworksConnection|artistsConnection|artist|artwork|showsConnection|matchConnection|trendingSearches|basedOnUserSaves|artworkRecommendations|artistRecommendations|followsAndSaves)\b/
+    /\b(artworksConnection|artistsConnection|artistSeriesConnection|artistSeries|artist|artwork|marketingCollections|marketingCollection|genes|gene|fairs|fair|showsConnection|matchConnection|trendingSearches|basedOnUserSaves|artworkRecommendations|artistRecommendations|followsAndSaves)\b/
   )
   return match ? `Querying Artsy: ${match[1]}…` : "Querying Artsy…"
 }


### PR DESCRIPTION
The existing prompt documented 4 of artworksConnection's ~60 filter args, so anything it couldn't express became a keyword search. Adds a filter reference with exact accepted values (`mediums`, `attributionClass`, `colors`, `majorPeriods`, `priceRange`, `sizes`, `ways-to-buy` booleans)
Also allowlists `gene`, `genes`, `marketingCollection(s)`, `artistSeries(Connection)`, `fair`, `fairs`, each with a recipe. They hang works off differently-named connections (filterArtworksConnection vs artworksConnection), now documented. Fixes fairs being advertised in the prompt while no fair root field existed.

Improved queries would be: "abstract expressionism paintings under 50k" (gene path), "Warhol's Flowers" (series), "what's at Art Basel" (fair), "show me a curated collection of prints under $1,000" (marketing collection), and "what's up for auction"
