### PR TITLE
feat: prevent agent from using internal pricing

### DIFF
--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -332,6 +332,71 @@ describe("the root field allowlist", () => {
   })
 })
 
+describe("the price field denylist", () => {
+  // Gravity returns a real number for works the site shows as "Contact for
+  // price", and nothing in the read path checks `price_hidden` -- so the only
+  // way the agent can't quote one is for the field not to exist.
+  const validationErrors = (query: string) =>
+    validate(narrowSchemaFor(schema), parse(query), [...specifiedRules]).map(
+      (error) => error.message
+    )
+
+  it.each([
+    "priceMin { display }",
+    "priceMax { display }",
+    "listPrice { __typename }",
+    "price",
+    "priceCurrency",
+    "priceDisplay",
+    "priceListed { display }",
+    "priceListedDisplay",
+    "pricePaid { display }",
+    "displayPriceRange",
+    "internalDisplayPrice",
+  ])("makes Artwork.%s unaskable", (selection) => {
+    const errors = validationErrors(
+      `{ artwork(id: "piotre-box-3") { ${selection} } }`
+    )
+    expect(errors.join(" ")).toMatch(/Cannot query field/)
+  })
+
+  it("closes the same hole on edition sets", () => {
+    const errors = validationErrors(
+      '{ artwork(id: "piotre-box-3") { editionSets { priceMin { display } } } }'
+    )
+    expect(errors.join(" ")).toMatch(/Cannot query field/)
+  })
+
+  it("leaves the display-safe fields the prompt relies on", () => {
+    expect(
+      validationErrors(
+        '{ artwork(id: "piotre-box-3") { saleMessage isPriceHidden isAcquireable editionSets { saleMessage isPriceHidden } } }'
+      )
+    ).toEqual([])
+  })
+
+  it("still allows filtering by price, which reveals no figure", () => {
+    expect(
+      validationErrors(
+        '{ artworksConnection(artistIDs: ["x"], priceRange: "*-5000", forSale: true, first: 5) { edges { node { internalID saleMessage } } } }'
+      )
+    ).toEqual([])
+  })
+
+  it("refuses to build the narrowed schema if a denylisted type is renamed", () => {
+    const renamed = mapSchema(schema, {
+      [MapperKind.OBJECT_TYPE]: (type) =>
+        type.name === "EditionSet"
+          ? new GraphQLObjectType({ ...type.toConfig(), name: "EditionSetV2" })
+          : type,
+    })
+
+    expect(() => narrowSchemaFor(renamed)).toThrow(
+      /unknown type\(s\).*EditionSet/s
+    )
+  })
+})
+
 describe("the Me field allowlist", () => {
   // `me` is the one root field whose *fields* are gated too: it resolves the
   // signed-in collector's own record, so root-field filtering alone would put

--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -21,6 +21,29 @@ describe("buildAgentTools", () => {
     expect(tools.query_artsy.description).toContain("artworksConnection")
     expect(tools.query_artsy.description).toContain("introspection")
   })
+
+  it("recommends no field the narrowed schema has removed", () => {
+    const { description } = buildAgentTools(
+      schema,
+      {} as ResolverContext
+    ).query_artsy
+    const artwork = narrowSchemaFor(schema).getType("Artwork") as
+      | GraphQLObjectType
+      | undefined
+
+    const denied = [
+      "priceMin",
+      "priceMax",
+      "listPrice",
+      "pricePaid",
+      "costMinor",
+    ]
+
+    denied.forEach((field) => {
+      expect(artwork!.getFields()[field]).toBeUndefined()
+      expect(description).not.toContain(field)
+    })
+  })
 })
 
 describe("runQueryArtsyTool", () => {
@@ -333,52 +356,78 @@ describe("the root field allowlist", () => {
 })
 
 describe("the price field denylist", () => {
-  // Gravity returns a real number for works the site shows as "Contact for
-  // price", and nothing in the read path checks `price_hidden` -- so the only
-  // way the agent can't quote one is for the field not to exist.
   const validationErrors = (query: string) =>
     validate(narrowSchemaFor(schema), parse(query), [...specifiedRules]).map(
       (error) => error.message
     )
 
   it.each([
-    "priceMin { display }",
-    "priceMax { display }",
+    "priceMin { minor }",
+    "priceMax { minor }",
     "listPrice { __typename }",
     "price",
     "priceCurrency",
     "priceDisplay",
-    "priceListed { display }",
+    "priceListed { minor }",
     "priceListedDisplay",
-    "pricePaid { display }",
+    "pricePaid { minor }",
+    "costMinor",
+    "costCurrencyCode",
     "displayPriceRange",
     "internalDisplayPrice",
   ])("makes Artwork.%s unaskable", (selection) => {
-    const errors = validationErrors(
-      `{ artwork(id: "piotre-box-3") { ${selection} } }`
-    )
-    expect(errors.join(" ")).toMatch(/Cannot query field/)
+    expect(
+      validationErrors(`{ artwork(id: "piotre-box-3") { ${selection} } }`).join(
+        " "
+      )
+    ).toMatch(/Cannot query field/)
   })
 
   it("closes the same hole on edition sets", () => {
-    const errors = validationErrors(
-      '{ artwork(id: "piotre-box-3") { editionSets { priceMin { display } } } }'
+    expect(
+      validationErrors(
+        '{ artwork(id: "piotre-box-3") { editionSets { priceMin { minor } } } }'
+      ).join(" ")
+    ).toMatch(/Cannot query field/)
+  })
+
+  it("keeps saleMessage, which is what the artwork page itself shows", async () => {
+    const artworkLoader = jest.fn().mockResolvedValue({
+      _id: "5f5a5b5c5d5e5f6061626364",
+      id: "piotre-box-3",
+      price_hidden: true,
+      price_min: 8500,
+      price_currency: "USD",
+      sale_message: "Contact for price",
+    })
+
+    const result = await runQueryArtsyTool(
+      {
+        query:
+          '{ artwork(id: "piotre-box-3") { saleMessage isPriceHidden isAcquireable } }',
+      },
+      schema,
+      ({ artworkLoader } as unknown) as ResolverContext
     )
-    expect(errors.join(" ")).toMatch(/Cannot query field/)
+
+    expect(result.ok).toBe(true)
+    expect(JSON.parse(result.content).artwork).toMatchObject({
+      saleMessage: "Contact for price",
+      isPriceHidden: true,
+    })
   })
 
-  it("leaves the display-safe fields the prompt relies on", () => {
+  // Arguments, not fields -- filterSchema only removes output fields, so
+  // denying the figures costs the agent no filtering or ordering.
+  it.each([
+    'priceRange: "*-5000"',
+    'sort: "-has_price,prices"',
+    'sort: "-has_price,-prices"',
+    'priceRange: "5000-20000", sort: "-has_price,prices"',
+  ])("still allows artworksConnection(%s)", (args) => {
     expect(
       validationErrors(
-        '{ artwork(id: "piotre-box-3") { saleMessage isPriceHidden isAcquireable editionSets { saleMessage isPriceHidden } } }'
-      )
-    ).toEqual([])
-  })
-
-  it("still allows filtering by price, which reveals no figure", () => {
-    expect(
-      validationErrors(
-        '{ artworksConnection(artistIDs: ["x"], priceRange: "*-5000", forSale: true, first: 5) { edges { node { internalID saleMessage } } } }'
+        `{ artworksConnection(artistIDs: ["x"], forSale: true, ${args}, first: 5) { edges { node { internalID saleMessage } } } }`
       )
     ).toEqual([])
   })

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -101,6 +101,23 @@ not starting over from a bare keyword. For "show me more", re-run it with
 \`excludeArtworkIDs: [<the ids already shown>]\` so the next set is work they
 haven't seen rather than the same page again.
 
+## Prices
+
+\`saleMessage\` is the only price there is: a figure ("$8,500"), a range,
+"Contact for price", or "Sold". Quote it or say nothing. Never state, estimate
+or infer a price that isn't in it — not from another work by the same artist,
+not from what something sold for before, not from the middle of a range. Many
+works have a real price in our records that we deliberately don't publish, and
+naming one tells the collector a number they cannot see anywhere on Artsy.
+
+Prefer works they can act on: pass \`forSale: true\` on searches, plus
+\`acquireable: true\` when they say buy or purchase and \`offerable: true\` for
+making an offer. When a work carries no figure, don't lead with it — cite priced
+works first, and include a price-on-request work only when they asked about that
+specific work, or nothing priced matches. If they ask what something costs and
+\`saleMessage\` has no figure, say the gallery shares the price on request and
+leave it there.
+
 ## Artwork filters
 
 \`artworksConnection\` takes these, combinable and all AND-ed. Prefer a real
@@ -201,17 +218,12 @@ of the question as your other tool calls did cover.
 
 ## Schema gotchas
 
-- \`priceMin\`, \`priceMax\`, \`listPrice\`, \`estimate\`, \`fee\`, and similar
-  money-typed fields return \`Money\`, not a scalar. Always select a subfield:
-  \`{ display }\` for a formatted string, or \`{ major minor currencyCode }\` for
-  numbers.
-- \`Artwork.listPrice\` is a union of \`Money | PriceRange\` — use inline
-  fragments:
-  \`listPrice { ... on Money { display } ... on PriceRange { display minPrice { display } maxPrice { display } } }\`.
-- \`Artwork.price\` and \`Artwork.saleMessage\` are plain \`String\` — no
-  subselection.
-- \`priceMin\`/\`priceMax\` are output fields, not inputs — filter with
-  \`priceRange\` (see Artwork filters).
+- \`saleMessage\` is a plain \`String\` — no subselection. The numeric price
+  fields (\`priceMin\`, \`priceMax\`, \`listPrice\`, \`price\`) are not in the
+  schema at all; asking for one fails validation. Filter by price with the
+  \`priceRange\` argument.
+- Other money-typed fields (e.g. \`estimate\`, \`fee\`) return \`Money\`, not a
+  scalar — select \`{ display }\`, or \`{ major minor currencyCode }\`.
 - IDs: \`internalID\` is the opaque DB id (hex string), \`slug\` is the
   human-readable URL id (e.g. \`"banksy"\`). Both can be passed to
   \`artist(id: …)\` and \`artwork(id: …)\`. Prefer \`internalID\` when passing

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -104,11 +104,12 @@ haven't seen rather than the same page again.
 ## Prices
 
 \`saleMessage\` is the only price there is: a figure ("$8,500"), a range,
-"Contact for price", or "Sold". Quote it or say nothing. Never state, estimate
-or infer a price that isn't in it — not from another work by the same artist,
-not from what something sold for before, not from the middle of a range. Many
-works have a real price in our records that we deliberately don't publish, and
-naming one tells the collector a number they cannot see anywhere on Artsy.
+"Contact for price", or "Sold". It is what the artwork page itself shows, so
+quoting it is always safe. Never state, estimate or infer a price that isn't in
+it — not from another work by the same artist, not from what something sold for
+before, not from the middle of a range. Many works have a real price in our
+records that we deliberately don't publish, and naming one tells the collector a
+number they cannot see anywhere on Artsy.
 
 Prefer works they can act on: pass \`forSale: true\` on searches, plus
 \`acquireable: true\` when they say buy or purchase and \`offerable: true\` for
@@ -148,6 +149,12 @@ filter over stuffing the request into \`keyword\`.
 - Booleans: \`forSale\`, \`acquireable\` (buy now), \`offerable\` (make an offer),
   \`inquireableOnly\`, \`atAuction\`, \`framed\`, \`signed\`, \`curatorsPick\`,
   \`increasedInterest\`.
+- \`sort\` — a plain string, one of: \`"-decayed_merch"\` (relevance, the
+  default), \`"-has_price,prices"\` (cheapest first), \`"-has_price,-prices"\`
+  (most expensive first), \`"-published_at"\` (newest to Artsy), \`"year"\` /
+  \`"-year"\` (when the work was made). Sort in the query rather than reordering
+  results yourself — you cannot read prices as numbers, and the
+  \`-has_price\` prefix keeps works with no published price out of the way.
 
 Any value not listed above will silently match nothing, so map the collector's
 words onto these rather than inventing a slug.

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -92,10 +92,48 @@ const ALLOWED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
   FollowsAndSaves: new Set(["artworksConnection", "artistsConnection"]),
 }
 
+const DENIED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
+  Artwork: new Set([
+    "displayPriceRange",
+    "internalDisplayPrice",
+    "listPrice",
+    "price",
+    "priceCurrency",
+    "priceDisplay",
+    "priceListed",
+    "priceListedDisplay",
+    "priceMax",
+    "priceMin",
+    "pricePaid",
+  ]),
+  EditionSet: new Set([
+    "displayPriceRange",
+    "internalDisplayPrice",
+    "listPrice",
+    "price",
+    "priceDisplay",
+    "priceListed",
+    "priceMax",
+    "priceMin",
+  ]),
+  // Artwork and EditionSet both implement Sellable, which declares four of
+  // these -- drop them there too or neither type satisfies the interface.
+  Sellable: new Set([
+    "displayPriceRange",
+    "internalDisplayPrice",
+    "listPrice",
+    "priceListed",
+  ]),
+}
+
 const objectFieldFilter: FieldFilter = (typeName, fieldName) => {
+  if (DENIED_FIELDS_BY_TYPE[typeName]?.has(fieldName)) return false
   const allowed = ALLOWED_FIELDS_BY_TYPE[typeName]
   return !allowed || allowed.has(fieldName)
 }
+
+const interfaceFieldFilter: FieldFilter = (typeName, fieldName) =>
+  !DENIED_FIELDS_BY_TYPE[typeName]?.has(fieldName)
 
 /**
  * The one way the allowlist above fails *open*: it keys on a type's name, so
@@ -114,15 +152,17 @@ const objectFieldFilter: FieldFilter = (typeName, fieldName) => {
  * (the field just stays unreachable), so it isn't worth taking the tool down.
  */
 function assertFieldAllowlistsResolve(schema: GraphQLSchema): void {
-  const missing = Object.keys(ALLOWED_FIELDS_BY_TYPE).filter(
-    (typeName) => !schema.getType(typeName)
-  )
+  const missing = [
+    ...Object.keys(ALLOWED_FIELDS_BY_TYPE),
+    ...Object.keys(DENIED_FIELDS_BY_TYPE),
+  ].filter((typeName) => !schema.getType(typeName))
   if (missing.length === 0) return
 
   throw new Error(
-    `AI agent field allowlist names unknown type(s): ${missing.join(", ")}. ` +
-      "They were most likely renamed — update ALLOWED_FIELDS_BY_TYPE to match, " +
-      "or every field on them becomes readable by a model-authored query."
+    `AI agent field lists name unknown type(s): ${missing.join(", ")}. ` +
+      "They were most likely renamed — update ALLOWED_FIELDS_BY_TYPE / " +
+      "DENIED_FIELDS_BY_TYPE to match, or every field on them becomes " +
+      "readable by a model-authored query."
   )
 }
 
@@ -143,6 +183,7 @@ export function narrowSchemaFor(realSchema: GraphQLSchema): GraphQLSchema {
     schema: realSchema,
     rootFieldFilter,
     objectFieldFilter,
+    interfaceFieldFilter,
   })
   const pruned = pruneSchema(filtered)
 

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -92,8 +92,14 @@ const ALLOWED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
   FollowsAndSaves: new Set(["artworksConnection", "artistsConnection"]),
 }
 
+// Gravity returns a real figure for works whose price Artsy withholds
+// (`isPriceHidden`) and no read resolver checks it, so reading one of these
+// puts a number in the agent's context that the collector cannot see anywhere.
+// `saleMessage` stays: it is the string every artwork card on Artsy renders.
 const DENIED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
   Artwork: new Set([
+    "costCurrencyCode",
+    "costMinor",
     "displayPriceRange",
     "internalDisplayPrice",
     "listPrice",
@@ -116,8 +122,8 @@ const DENIED_FIELDS_BY_TYPE: Record<string, Set<string>> = {
     "priceMax",
     "priceMin",
   ]),
-  // Artwork and EditionSet both implement Sellable, which declares four of
-  // these -- drop them there too or neither type satisfies the interface.
+  // Both implement Sellable, which declares four of these -- drop them there
+  // too or neither type satisfies the interface.
   Sellable: new Set([
     "displayPriceRange",
     "internalDisplayPrice",
@@ -493,10 +499,13 @@ export function buildAgentTools(
         "request `internalID` and `slug` for anything you might reference " +
         `again. \`first\`/\`last\`/\`size\` are capped at ${MAX_PAGE_SIZE}. ` +
         "Never pass mode: INTERNAL_AUTOSUGGEST to matchConnection — it " +
-        "requires a signed-in session and will error. Price/estimate/fee " +
-        "fields (e.g. priceMin, priceMax, listPrice) are typed `Money`, not " +
-        "a scalar — select a subfield, usually `display` for a formatted " +
-        "string or `major`/`minor` for a number.",
+        "requires a signed-in session and will error. `saleMessage` is the " +
+        "only price an artwork exposes and it is a plain String — the " +
+        "numeric price fields are not in the schema; filter by price with " +
+        "the `priceRange` argument. Other money-typed fields (e.g. " +
+        "`estimate`, `fee`) return `Money`, not a scalar — select a " +
+        "subfield, usually `display` for a formatted string or " +
+        "`major`/`minor` for a number.",
       inputSchema: jsonSchema({
         type: "object",
         properties: {


### PR DESCRIPTION
Make the agent refer to the sale price, never mentioning internal price. Prevents scenarios like the following. Also discourage non actionable artworks from showing up

<img width="1306" height="676" alt="Screenshot 2026-09-02 at 14 17 33" src="https://github.com/user-attachments/assets/7c475f46-8b7b-402f-8dc3-309a3892de38" />
