### PR TITLE
feat: hybrid search for the agent

### DIFF
--- a/src/schema/v2/ai/agent/__tests__/tools.test.ts
+++ b/src/schema/v2/ai/agent/__tests__/tools.test.ts
@@ -22,6 +22,21 @@ describe("buildAgentTools", () => {
     expect(tools.query_artsy.description).toContain("introspection")
   })
 
+  it("documents the hybrid (semantic) search args, which the schema still takes", () => {
+    const { description } = buildAgentTools(
+      schema,
+      {} as ResolverContext
+    ).query_artsy
+    const args = (
+      narrowSchemaFor(schema).getQueryType()!.getFields().artworksConnection
+        .args ?? []
+    ).map((arg) => arg.name)
+
+    expect(description).toContain('variant: "hybrid"')
+    expect(description).toContain("hybridWeights")
+    expect(args).toEqual(expect.arrayContaining(["variant", "hybridWeights"]))
+  })
+
   it("recommends no field the narrowed schema has removed", () => {
     const { description } = buildAgentTools(
       schema,

--- a/src/schema/v2/ai/agent/runTurn.ts
+++ b/src/schema/v2/ai/agent/runTurn.ts
@@ -125,6 +125,16 @@ leave it there.
 filter over stuffing the request into \`keyword\`.
 
 - \`keyword\` — with \`keywordTypoTolerance: true\`, always; chat input has typos.
+- \`variant: "hybrid"\` with \`hybridWeights: [0.3, 0.7]\` — semantic search,
+  blended into the keyword one. Turn it on whenever the collector describes
+  rather than names: a mood, a palette, a room, a scene ("something calming in
+  blue for a bedroom"). Pass their own words as the \`keyword\` — hybrid needs
+  one, and the description *is* the query — and keep the other filters, which
+  still apply. Leave it off when they named an artist, series or collection:
+  keyword is already exact there and blending only loosens it. Leave \`sort\`
+  off too, since sorting replaces the blended relevance. If a hybrid search
+  errors, re-run it once without \`variant\` and \`hybridWeights\` before
+  concluding anything.
 - \`additionalGeneIDs\` — the medium filter, exact slugs only:
   painting, photography, sculpture, prints, work-on-paper, drawing, design,
   installation, mixed-media, digital-art, nft, jewelry, poster, textile-arts,

--- a/src/schema/v2/ai/agent/tools.ts
+++ b/src/schema/v2/ai/agent/tools.ts
@@ -489,6 +489,11 @@ export function buildAgentTools(
         "`me` is null when signed out, and only its personalization fields " +
         "are reachable). Auctions are reachable as " +
         "artworksConnection(atAuction: true), not as a sale root field. " +
+        "For a descriptive request (a mood, a palette, a room) rather than a " +
+        "named artist or work, pass the collector's own words as `keyword` " +
+        'and add `variant: "hybrid", hybridWeights: [0.3, 0.7]` to blend ' +
+        "semantic search into the keyword one; if that call fails, re-run it " +
+        "once without those two arguments. " +
         "Note gene, artistSeries and fair expose their works as " +
         "`filterArtworksConnection`, while marketingCollection uses " +
         "`artworksConnection`. Use " +


### PR DESCRIPTION
Integrate semantic search into the asisstant's capabilities.

| Before | After |
| --- | --- |
| <img width="1337" height="746" alt="Screenshot 2026-09-03 at 14 26 26" src="https://github.com/user-attachments/assets/0ec45f85-bd0f-4efc-bb58-dc21c8f3dfb6" /> | <img width="1355" height="702" alt="Screenshot 2026-09-03 at 14 26 29" src="https://github.com/user-attachments/assets/bbf1659a-a8aa-48c0-9571-0e7a4c13f1f7" /> |
| <img width="1330" height="781" alt="Screenshot 2026-09-03 at 14 29 56" src="https://github.com/user-attachments/assets/2963f769-8898-4551-8aac-6cfa3fae085b" /> |  <img width="1353" height="790" alt="Screenshot 2026-09-03 at 15 28 30" src="https://github.com/user-attachments/assets/2c83bd74-ddbc-4957-beb6-af8eb27bbc39" />
| <img width="1680" height="807" alt="Screenshot 2026-09-03 at 15 22 28" src="https://github.com/user-attachments/assets/91a78de6-f73a-41b9-b64c-b7ed27ba6878" /> | <img width="1327" height="675" alt="Screenshot 2026-09-03 at 15 22 20" src="https://github.com/user-attachments/assets/05be71df-299a-4469-af44-5d29a5f63450" /> |
| <img width="1684" height="761" alt="Screenshot 2026-09-03 at 15 22 36" src="https://github.com/user-attachments/assets/61e49ddc-5a7b-4150-b2ec-ee7a8282b868" /> | <img width="1340" height="757" alt="Screenshot 2026-09-03 at 15 22 43" src="https://github.com/user-attachments/assets/f1fc07dd-6509-4193-bf01-e001e8890c1c" />  |

