### PR TITLE
feat: Enable OS artworks to be duplicated

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -18385,6 +18385,34 @@ enum DomesticType {
   FREE_SHIPPING
 }
 
+type DuplicateCatalogArtworkFailure {
+  mutationError: GravityMutationError
+}
+
+input DuplicateCatalogArtworkMutationInput {
+  """
+  The ID of the artwork to duplicate.
+  """
+  artworkID: String!
+  clientMutationId: String
+}
+
+type DuplicateCatalogArtworkMutationPayload {
+  """
+  On success: the newly created duplicate artwork. On error: the error that occurred.
+  """
+  artworkOrError: DuplicateCatalogArtworkResponseOrError
+  clientMutationId: String
+}
+
+union DuplicateCatalogArtworkResponseOrError =
+    DuplicateCatalogArtworkFailure
+  | DuplicateCatalogArtworkSuccess
+
+type DuplicateCatalogArtworkSuccess {
+  artwork: Artwork
+}
+
 input EditableLocation {
   """
   First line of an address
@@ -26747,6 +26775,13 @@ type Mutation {
   distributePartnerList(
     input: DistributePartnerListMutationInput!
   ): DistributePartnerListMutationPayload
+
+  """
+  Duplicates an OS inventory (catalog) artwork's OS-editable fields into a new, inventory-only artwork.
+  """
+  duplicateCatalogArtwork(
+    input: DuplicateCatalogArtworkMutationInput!
+  ): DuplicateCatalogArtworkMutationPayload
   enableSecondFactor(input: EnableSecondFactorInput!): EnableSecondFactorPayload
 
   """

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -408,6 +408,11 @@ export default (accessToken, userID, opts) => {
       { method: "POST" }
     ),
     createCollectionLoader: gravityLoader("collection", {}, { method: "POST" }),
+    duplicateCatalogArtworkLoader: gravityLoader(
+      (id) => `catalog_artwork/${id}/duplicate`,
+      {},
+      { method: "POST" }
+    ),
     createIdentityVerificationOverrideLoader: gravityLoader(
       (id) => `identity_verification/${id}/override`,
       {},

--- a/src/schema/v2/artwork/__tests__/duplicateCatalogArtworkMutation.test.ts
+++ b/src/schema/v2/artwork/__tests__/duplicateCatalogArtworkMutation.test.ts
@@ -1,0 +1,99 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DuplicateCatalogArtworkMutation", () => {
+  const mutation = gql`
+    mutation {
+      duplicateCatalogArtwork(input: { artworkID: "artwork-123" }) {
+        artworkOrError {
+          __typename
+          ... on DuplicateCatalogArtworkSuccess {
+            artwork {
+              internalID
+              title
+            }
+          }
+          ... on DuplicateCatalogArtworkFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  describe("on success", () => {
+    it("returns the newly created duplicate artwork", async () => {
+      const context = {
+        duplicateCatalogArtworkLoader: jest.fn(() =>
+          Promise.resolve({ id: "artwork-456", _id: "artwork-456" })
+        ),
+        artworkLoader: jest.fn(() =>
+          Promise.resolve({
+            _id: "artwork-456",
+            id: "artwork-456-slug",
+            title: "Original Title",
+          })
+        ),
+      }
+
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(context.duplicateCatalogArtworkLoader).toHaveBeenCalledWith(
+        "artwork-123"
+      )
+      expect(context.artworkLoader).toHaveBeenCalledWith("artwork-456")
+      expect(result).toEqual({
+        duplicateCatalogArtwork: {
+          artworkOrError: {
+            __typename: "DuplicateCatalogArtworkSuccess",
+            artwork: {
+              internalID: "artwork-456",
+              title: "Original Title",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("on API failure", () => {
+    it("returns a mutation error", async () => {
+      const context = {
+        duplicateCatalogArtworkLoader: jest.fn(() =>
+          Promise.reject(
+            new Error(
+              `https://stagingapi.artsy.net/api/v1/catalog_artwork/artwork-123/duplicate - {"type":"error","message":"Catalog artwork not found"}`
+            )
+          )
+        ),
+      }
+
+      const result = await runAuthenticatedQuery(mutation, context)
+
+      expect(result).toEqual({
+        duplicateCatalogArtwork: {
+          artworkOrError: {
+            __typename: "DuplicateCatalogArtworkFailure",
+            mutationError: {
+              message: "Catalog artwork not found",
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe("when unauthenticated", () => {
+    it("returns an error", async () => {
+      const context = {
+        duplicateCatalogArtworkLoader: undefined,
+      }
+
+      await expect(runAuthenticatedQuery(mutation, context)).rejects.toThrow(
+        "You need to be signed in to perform this action"
+      )
+    })
+  })
+})

--- a/src/schema/v2/artwork/duplicateCatalogArtworkMutation.ts
+++ b/src/schema/v2/artwork/duplicateCatalogArtworkMutation.ts
@@ -1,0 +1,88 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import Artwork from "schema/v2/artwork"
+
+interface DuplicateCatalogArtworkMutationInputProps {
+  artworkID: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DuplicateCatalogArtworkSuccess",
+  isTypeOf: (data) => data._type === "DuplicateCatalogArtworkSuccess",
+  fields: () => ({
+    artwork: {
+      type: Artwork.type,
+      resolve: ({ id }, _args, { artworkLoader }) => artworkLoader(id),
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DuplicateCatalogArtworkFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DuplicateCatalogArtworkResponseOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const duplicateCatalogArtworkMutation = mutationWithClientMutationId<
+  DuplicateCatalogArtworkMutationInputProps,
+  any,
+  ResolverContext
+>({
+  name: "DuplicateCatalogArtworkMutation",
+  description:
+    "Duplicates an OS inventory (catalog) artwork's OS-editable fields into a new, inventory-only artwork.",
+  inputFields: {
+    artworkID: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the artwork to duplicate.",
+    },
+  },
+  outputFields: {
+    artworkOrError: {
+      type: ResponseOrErrorType,
+      description:
+        "On success: the newly created duplicate artwork. On error: the error that occurred.",
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { artworkID },
+    { duplicateCatalogArtworkLoader }
+  ) => {
+    if (!duplicateCatalogArtworkLoader) {
+      return new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await duplicateCatalogArtworkLoader(artworkID)
+      return { ...response, _type: "DuplicateCatalogArtworkSuccess" }
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error instanceof Error ? error : new Error(String(error))
+      }
+    }
+  },
+})

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -163,6 +163,7 @@ import { deleteArtworkMutation } from "./artwork/deleteArtworkMutation"
 import { updateCatalogArtworkMutation } from "./artwork/updateCatalogArtworkMutation"
 import { updateCatalogEditionSetMutation } from "./artwork/updateCatalogEditionSetMutation"
 import { syncCatalogToArtworkMutation } from "./artwork/syncCatalogToArtworkMutation"
+import { duplicateCatalogArtworkMutation } from "./artwork/duplicateCatalogArtworkMutation"
 import { updateArtworkMutation } from "./artwork/updateArtworkMutation"
 import { repositionArtworkImagesMutation } from "./artwork/repositionArtworkImagesMutation"
 import { artworkFilterSuggestions } from "./artworkFilterSuggestions"
@@ -727,6 +728,7 @@ export default new GraphQLSchema({
       deleteConversationMessageTemplate: deleteConversationMessageTemplateMutation,
       detectArtworkDuplicates: detectArtworkDuplicatesMutation,
       dismissArtworkDuplicatePair: dismissArtworkDuplicatePairMutation,
+      duplicateCatalogArtwork: duplicateCatalogArtworkMutation,
       deleteArtworkImage: DeleteArtworkImageMutation,
       reprocessArtworkImage: ReprocessArtworkImageMutation,
       deleteBankAccount: deleteBankAccountMutation,


### PR DESCRIPTION
This PR resolves [notion card](https://app.notion.com/p/artsy/Add-Duplicate-Function-to-Action-Bar-Row-Level-3a7cab0764a080619928f8ed0b945498)

Add mutation to allow artworks in OS inventory to be duplicated through the new Gravity endpoint (https://github.com/artsy/gravity/pull/20495)

_Assisted-by: Claude Sonnet 5 [claude-code]_

cc @artsy/amber-devs 