### PR TITLE
feat: add partnerOffer connection to OrderType to identify that orderwas created with underlying partnerOffer

### DIFF
--- a/src/schema/v2/conversation/__tests__/conversationOrdersConnection.test.ts
+++ b/src/schema/v2/conversation/__tests__/conversationOrdersConnection.test.ts
@@ -214,6 +214,75 @@ describe("conversation orders connections", () => {
     )
   })
 
+  it("resolves partnerOffer on an order reached via partnerOrdersConnection", async () => {
+    const partnerOrdersLoaderWithOffer = jest.fn((_partnerId, params) => {
+      let filteredOrders = [
+        {
+          ...ordersResponse[0],
+          line_items: [
+            {
+              ...ordersResponse[0].line_items[0],
+              partner_offer_id: "partner-offer-1",
+            },
+          ],
+        },
+      ]
+
+      if (params.artwork_id) {
+        filteredOrders = filteredOrders.filter((order) =>
+          order.line_items.some((li) => li.artwork_id === params.artwork_id)
+        )
+      }
+
+      return Promise.resolve({
+        body: filteredOrders,
+        headers: { "x-total-count": filteredOrders.length.toString() },
+      })
+    })
+
+    context.partnerOrdersLoader = partnerOrdersLoaderWithOffer
+    context.partnerOffersLoader = jest.fn().mockResolvedValue({
+      body: [{ id: "partner-offer-1", active: false }],
+    })
+
+    const query = gql`
+      {
+        conversation(id: "conversation-1") {
+          partnerOrdersConnection(first: 5) {
+            edges {
+              node {
+                internalID
+                partnerOffer {
+                  internalID
+                  isActive
+                  isPurchased
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.conversation.partnerOrdersConnection.edges[0].node).toEqual({
+      internalID: "order-1",
+      partnerOffer: {
+        internalID: "partner-offer-1",
+        isActive: false,
+        isPurchased: true,
+      },
+    })
+    expect(context.partnerOffersLoader).toHaveBeenCalledWith({
+      artwork_id: "artwork-1",
+      user_id: "buyer-1",
+    })
+    // isPurchased should come from the stamped value, not a meOrdersLoader
+    // lookup scoped to whichever viewer (here, the partner) ran this query.
+    expect(context.meOrdersLoader).not.toHaveBeenCalled()
+  })
+
   it("returns hasNextPage=true when first is below total for collectorOrdersConnection", async () => {
     const query = gql`
       {

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -578,6 +578,125 @@ describe("Me", () => {
       })
     })
 
+    describe("partnerOffer", () => {
+      const query = gql`
+        query {
+          me {
+            order(id: "order-id") {
+              partnerOffer {
+                internalID
+                isActive
+                isPurchased
+              }
+            }
+          }
+        }
+      `
+
+      it("returns the partner offer matching the line item's partnerOfferId, even when expired", async () => {
+        const localOrderJson = {
+          ...orderJson,
+          line_items: [
+            {
+              ...orderJson.line_items[0],
+              partner_offer_id: "partner-offer-123",
+            },
+          ],
+        }
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+          partnerOffersLoader: jest.fn().mockResolvedValue({
+            body: [
+              { id: "partner-offer-999", active: true },
+              { id: "partner-offer-123", active: false },
+            ],
+          }),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(context.partnerOffersLoader).toHaveBeenCalledWith({
+          artwork_id: localOrderJson.line_items[0].artwork_id,
+          user_id: "buyer-id-1",
+        })
+        expect(result).toEqual({
+          me: {
+            order: {
+              partnerOffer: {
+                internalID: "partner-offer-123",
+                isActive: false,
+                isPurchased: true,
+              },
+            },
+          },
+        })
+      })
+
+      it("returns null when no partner offer matches the stored id", async () => {
+        const localOrderJson = {
+          ...orderJson,
+          line_items: [
+            {
+              ...orderJson.line_items[0],
+              partner_offer_id: "partner-offer-123",
+            },
+          ],
+        }
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+          partnerOffersLoader: jest.fn().mockResolvedValue({ body: [] }),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result).toEqual({
+          me: { order: { partnerOffer: null } },
+        })
+      })
+
+      it("returns null and skips the loader when the order has no partnerOfferId", async () => {
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(orderJson),
+          partnerOffersLoader: jest.fn().mockResolvedValue({ body: [] }),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(context.partnerOffersLoader).not.toHaveBeenCalled()
+        expect(result).toEqual({
+          me: { order: { partnerOffer: null } },
+        })
+      })
+
+      it("returns null when unauthenticated (no partnerOffersLoader)", async () => {
+        const localOrderJson = {
+          ...orderJson,
+          line_items: [
+            {
+              ...orderJson.line_items[0],
+              partner_offer_id: "partner-offer-123",
+            },
+          ],
+        }
+
+        context = {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+        }
+
+        const result = await runAuthenticatedQuery(query, context)
+
+        expect(result).toEqual({
+          me: { order: { partnerOffer: null } },
+        })
+      })
+    })
+
     describe("taxTotal", () => {
       const query = gql`
         query {

--- a/src/schema/v2/order/types/OrderType.ts
+++ b/src/schema/v2/order/types/OrderType.ts
@@ -27,6 +27,7 @@ import { ArtworkType } from "../../artwork"
 import { DisplayTexts } from "./DisplayTexts"
 import { DisplaySellerTexts } from "./DisplaySellerTexts"
 import { PartnerType } from "schema/v2/partner/partner"
+import { PartnerOfferToCollectorType } from "schema/v2/partnerOfferToCollector"
 import { PhoneNumberType, resolvePhoneNumber } from "../../phoneNumber"
 import {
   PricingBreakdownLinesType,
@@ -436,6 +437,40 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
         if (!seller_id) return null
 
         return partnerLoader(seller_id).catch(() => null)
+      },
+    },
+    partnerOffer: {
+      type: PartnerOfferToCollectorType,
+      description:
+        "The limited partner offer associated with this order if offer existed at order creation.",
+      resolve: async (
+        { buyer_id, line_items },
+        _args,
+        { partnerOffersLoader }
+      ) => {
+        if (!partnerOffersLoader) return null
+
+        // Orders are treated as single-artwork as in other places.
+        const partnerOfferId = line_items?.[0]?.partner_offer_id
+        const artworkId = line_items?.[0]?.artwork_id
+        if (!partnerOfferId || !artworkId) return null
+
+        try {
+          const { body } = await partnerOffersLoader({
+            artwork_id: artworkId,
+            user_id: buyer_id,
+          })
+
+          const match = body?.find((po) => po.id === partnerOfferId)
+
+          // This order's existence already proves the offer was used — stamp
+          // _isPurchased so it short-circuits instead of calling
+          // meOrdersLoader, which reflects whichever viewer (buyer or
+          // seller) is running this query, not necessarily the order's buyer.
+          return match ? { ...match, _isPurchased: true } : null
+        } catch {
+          return null
+        }
       },
     },
     sellerState: {


### PR DESCRIPTION

We need to have data about PartnerOffer attribution on Order. We already store PartnerOffer id on the underlying lineItem so figured we can reuse the loader and just expose partnerOffer based on that order.

This is the current proposal: https://www.figma.com/board/jxALf3qizw47e8Ee5nAJP9/Topaz-Q3-Bets?node-id=4-8&t=QK80AqLeDWiFyM3v-0 so technically it would be enough to just have a boolean something like 'isPartnerOfferBased' there - but figured it's better to have the whole PartnerOffer reference there if we want to inspect/include more info there.

Let me know your thoughts plz.

Collab with Claude.