### PR TITLE
feat: add boolean to OrderType to expose if PartnerOffer exists on the lineItem.

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -28417,6 +28417,11 @@ type Order {
   fulfillmentOptions: [FulfillmentOption!]!
 
   """
+  Flag indicating whether the order has a partner offer associated with it
+  """
+  hasPartnerOffer: Boolean!
+
+  """
   A globally unique ID.
   """
   id: ID!

--- a/src/schema/v2/order/__tests__/MeOrder.test.ts
+++ b/src/schema/v2/order/__tests__/MeOrder.test.ts
@@ -2440,6 +2440,46 @@ describe("Me", () => {
       })
     })
 
+    describe("hasPartnerOffer", () => {
+      const query = gql`
+        query {
+          me {
+            order(id: "order-id") {
+              hasPartnerOffer
+            }
+          }
+        }
+      `
+
+      it("returns true when a line item has a partnerOfferId", async () => {
+        const localOrderJson = {
+          ...baseOrderJson,
+          line_items: [
+            {
+              ...baseOrderJson.line_items[0],
+              partner_offer_id: "partner-offer-123",
+            },
+          ],
+        }
+
+        const result = await runAuthenticatedQuery(query, {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(localOrderJson),
+        })
+
+        expect(result.me.order.hasPartnerOffer).toBe(true)
+      })
+
+      it("returns false when no line item has a partnerOfferId", async () => {
+        const result = await runAuthenticatedQuery(query, {
+          meLoader: jest.fn().mockResolvedValue({ id: "me-id" }),
+          meOrderLoader: jest.fn().mockResolvedValue(baseOrderJson),
+        })
+
+        expect(result.me.order.hasPartnerOffer).toBe(false)
+      })
+    })
+
     describe("fulfillmentOptions shippingQuoteId", () => {
       const shippingQuoteIdQuery = gql`
         query {

--- a/src/schema/v2/order/types/OrderType.ts
+++ b/src/schema/v2/order/types/OrderType.ts
@@ -394,6 +394,13 @@ export const OrderType = new GraphQLObjectType<OrderJSON, ResolverContext>({
       type: new GraphQLNonNull(new GraphQLList(LineItemType)),
       resolve: ({ line_items }) => line_items,
     },
+    hasPartnerOffer: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      description:
+        "Flag indicating whether the order has a partner offer associated with it",
+      resolve: ({ line_items }) =>
+        !!line_items?.some((lineItem) => !!lineItem.partner_offer_id),
+    },
     mode: {
       type: new GraphQLNonNull(OrderModeEnum),
       resolve: (order) => resolveMode(order),


### PR DESCRIPTION

After over-engineering the partnerOffer into OrderType (https://github.com/artsy/metaphysics/pull/7876) followed the other pass and just adding what is needed for current task - boolean to flag PartnerOffer presence. 

Minimal change for now.