### PR TITLE
feat: add PartnerUserNote create/update/delete mutations and query

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -16212,6 +16212,41 @@ type CreatePartnerShowSuccess {
   show: Show
 }
 
+type CreatePartnerUserNoteFailure {
+  mutationError: GravityMutationError
+}
+
+input CreatePartnerUserNoteInput {
+  """
+  Note text.
+  """
+  body: String!
+  clientMutationId: String
+
+  """
+  ID of the partner.
+  """
+  partnerId: String!
+
+  """
+  ID of the collector the note is about.
+  """
+  userId: String!
+}
+
+union CreatePartnerUserNoteOrError =
+    CreatePartnerUserNoteFailure
+  | CreatePartnerUserNoteSuccess
+
+type CreatePartnerUserNotePayload {
+  clientMutationId: String
+  partnerUserNoteOrError: CreatePartnerUserNoteOrError
+}
+
+type CreatePartnerUserNoteSuccess {
+  partnerUserNote: PartnerUserNote
+}
+
 type CreatePurchaseFailure {
   mutationError: GravityMutationError
 }
@@ -17663,6 +17698,32 @@ union DeletePartnerShowResponseOrError =
 
 type DeletePartnerShowSuccess {
   show: Show
+}
+
+type DeletePartnerUserNoteFailure {
+  mutationError: GravityMutationError
+}
+
+input DeletePartnerUserNoteInput {
+  clientMutationId: String
+
+  """
+  ID of the note to delete.
+  """
+  id: String!
+}
+
+union DeletePartnerUserNoteOrError =
+    DeletePartnerUserNoteFailure
+  | DeletePartnerUserNoteSuccess
+
+type DeletePartnerUserNotePayload {
+  clientMutationId: String
+  partnerUserNoteOrError: DeletePartnerUserNoteOrError
+}
+
+type DeletePartnerUserNoteSuccess {
+  partnerUserNote: PartnerUserNote
 }
 
 type DeletePurchaseFailure {
@@ -26453,6 +26514,13 @@ type Mutation {
   ): CreatePartnerShowEventMutationPayload
 
   """
+  Creates a partner's note about a collector.
+  """
+  createPartnerUserNote(
+    input: CreatePartnerUserNoteInput!
+  ): CreatePartnerUserNotePayload
+
+  """
   Create a purchase
   """
   createPurchase(input: createPurchaseInput!): createPurchasePayload
@@ -26741,6 +26809,13 @@ type Mutation {
   deletePartnerShowEvent(
     input: DeletePartnerShowEventMutationInput!
   ): DeletePartnerShowEventMutationPayload
+
+  """
+  Deletes a partner's note about a collector.
+  """
+  deletePartnerUserNote(
+    input: DeletePartnerUserNoteInput!
+  ): DeletePartnerUserNotePayload
 
   """
   Deletes a purchase
@@ -27514,6 +27589,13 @@ type Mutation {
   updatePartnerShowEvent(
     input: UpdatePartnerShowEventMutationInput!
   ): UpdatePartnerShowEventMutationPayload
+
+  """
+  Updates a partner's note about a collector.
+  """
+  updatePartnerUserNote(
+    input: UpdatePartnerUserNoteInput!
+  ): UpdatePartnerUserNotePayload
 
   """
   Updates a profile.
@@ -29743,6 +29825,21 @@ type Partner implements Node {
   type: String
 
   """
+  A connection of notes this partner has made about collectors.
+  """
+  userNotesConnection(
+    after: String
+    before: String
+    first: Int
+    last: Int
+
+    """
+    Only return notes about this collector.
+    """
+    userId: String
+  ): PartnerUserNoteConnection
+
+  """
   Returns VAT number or a fallback message based on the partner's VAT status.
   """
   vatInformation: String
@@ -31379,6 +31476,82 @@ enum PartnerShowPartnerType {
 }
 
 union PartnerTypes = ExternalPartner | Partner
+
+"""
+A partner's private note about a collector.
+"""
+type PartnerUserNote {
+  body: String
+  createdAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  A type-specific ID likely used as a database ID.
+  """
+  internalID: ID!
+  partnerId: String
+  updatedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+
+  """
+  ID of the partner user who last touched this note.
+  """
+  updatedByUserId: String
+
+  """
+  ID of the collector this note is about.
+  """
+  userId: String
+}
+
+"""
+A connection to a list of items.
+"""
+type PartnerUserNoteConnection {
+  """
+  A list of edges.
+  """
+  edges: [PartnerUserNoteEdge]
+  pageCursors: PageCursors!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+"""
+An edge in a connection.
+"""
+type PartnerUserNoteEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge
+  """
+  node: PartnerUserNote
+}
 
 enum PartnersAggregation {
   CATEGORY
@@ -34145,6 +34318,16 @@ type Query {
     size: Int
   ): PartnerShowDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
+
+  """
+  A partner's note about a collector.
+  """
+  partnerUserNote(
+    """
+    The ID of the PartnerUserNote.
+    """
+    id: String!
+  ): PartnerUserNote
 
   """
   A list of Partners
@@ -40871,6 +41054,36 @@ type UpdatePartnerSuccess {
   partner: Partner
 }
 
+type UpdatePartnerUserNoteFailure {
+  mutationError: GravityMutationError
+}
+
+input UpdatePartnerUserNoteInput {
+  """
+  Note text.
+  """
+  body: String!
+  clientMutationId: String
+
+  """
+  ID of the note to update.
+  """
+  id: String!
+}
+
+union UpdatePartnerUserNoteOrError =
+    UpdatePartnerUserNoteFailure
+  | UpdatePartnerUserNoteSuccess
+
+type UpdatePartnerUserNotePayload {
+  clientMutationId: String
+  partnerUserNoteOrError: UpdatePartnerUserNoteOrError
+}
+
+type UpdatePartnerUserNoteSuccess {
+  partnerUserNote: PartnerUserNote
+}
+
 type UpdateProfileFailure {
   mutationError: GravityMutationError
 }
@@ -43837,6 +44050,16 @@ type Viewer {
     size: Int
   ): PartnerShowDocumentConnection
     @deprecated(reason: "Prefer `partner.documentsConnection`")
+
+  """
+  A partner's note about a collector.
+  """
+  partnerUserNote(
+    """
+    The ID of the PartnerUserNote.
+    """
+    id: String!
+  ): PartnerUserNote
 
   """
   A list of Partners

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -480,6 +480,11 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createPartnerUserNoteLoader: gravityLoader(
+      "partner_user_note",
+      {},
+      { method: "POST" }
+    ),
     createPartnerLocationLoader: gravityLoader(
       (id) => `partner/${id}/location`,
       {},
@@ -621,6 +626,11 @@ export default (accessToken, userID, opts) => {
       { partnerId: string; contactId: string }
     >(
       ({ partnerId, contactId }) => `partner/${partnerId}/contact/${contactId}`,
+      {},
+      { method: "DELETE" }
+    ),
+    deletePartnerUserNoteLoader: gravityLoader(
+      (id) => `partner_user_note/${id}`,
       {},
       { method: "DELETE" }
     ),
@@ -1227,6 +1237,14 @@ export default (accessToken, userID, opts) => {
       {},
       { headers: true }
     ),
+    partnerUserNoteLoader: gravityLoader(
+      (id) => `partner_user_note/${id}`
+    ),
+    partnerUserNotesLoader: gravityLoader(
+      "partner_user_notes",
+      {},
+      { headers: true }
+    ),
     conversationMessageTemplateLoader: gravityLoader(
       (id) => `conversation_message_template/${id}`
     ),
@@ -1590,6 +1608,11 @@ export default (accessToken, userID, opts) => {
       { partnerId: string; contactId: string }
     >(
       ({ partnerId, contactId }) => `partner/${partnerId}/contact/${contactId}`,
+      {},
+      { method: "PUT" }
+    ),
+    updatePartnerUserNoteLoader: gravityLoader(
+      (id) => `partner_user_note/${id}`,
       {},
       { method: "PUT" }
     ),

--- a/src/schema/v2/partner/PartnerUserNote/PartnerUserNoteType.ts
+++ b/src/schema/v2/partner/PartnerUserNote/PartnerUserNoteType.ts
@@ -1,0 +1,104 @@
+import {
+  GraphQLFieldConfig,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import { date } from "schema/v2/fields/date"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
+import { InternalIDFields } from "schema/v2/object_identification"
+import { ResolverContext } from "types/graphql"
+
+export const PartnerUserNoteType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "PartnerUserNote",
+  description: "A partner's private note about a collector.",
+  fields: () => ({
+    ...InternalIDFields,
+    partnerId: {
+      type: GraphQLString,
+      resolve: ({ partner_id }) => partner_id,
+    },
+    userId: {
+      type: GraphQLString,
+      description: "ID of the collector this note is about.",
+      resolve: ({ user_id }) => user_id,
+    },
+    body: {
+      type: GraphQLString,
+      resolve: ({ body }) => body,
+    },
+    updatedByUserId: {
+      type: GraphQLString,
+      description: "ID of the partner user who last touched this note.",
+      resolve: ({ updated_by_user_id }) => updated_by_user_id,
+    },
+    createdAt: date(),
+    updatedAt: date(),
+  }),
+})
+
+export const partnerUserNotesConnection = connectionWithCursorInfo({
+  nodeType: PartnerUserNoteType,
+})
+
+export const UserNotesConnection: GraphQLFieldConfig<any, ResolverContext> = {
+  description:
+    "A connection of notes this partner has made about collectors.",
+  type: partnerUserNotesConnection.connectionType,
+  args: pageable({
+    userId: {
+      type: GraphQLString,
+      description: "Only return notes about this collector.",
+    },
+  }),
+  resolve: async ({ _id }, args, { partnerUserNotesLoader }) => {
+    if (!partnerUserNotesLoader) return null
+
+    const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+    const { body, headers } = await partnerUserNotesLoader({
+      partner_id: _id,
+      user_id: args.userId,
+      page,
+      size,
+      total_count: true,
+    })
+
+    const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+    return paginationResolver({
+      totalCount,
+      offset,
+      page,
+      size,
+      body,
+      args,
+    })
+  },
+}
+
+export const PartnerUserNote: GraphQLFieldConfig<void, ResolverContext> = {
+  type: PartnerUserNoteType,
+  description: "A partner's note about a collector.",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The ID of the PartnerUserNote.",
+    },
+  },
+  resolve: (_root, { id }, { partnerUserNoteLoader }) => {
+    if (!partnerUserNoteLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    return partnerUserNoteLoader(id)
+  },
+}

--- a/src/schema/v2/partner/PartnerUserNote/__tests__/createPartnerUserNoteMutation.test.ts
+++ b/src/schema/v2/partner/PartnerUserNote/__tests__/createPartnerUserNoteMutation.test.ts
@@ -1,0 +1,104 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("CreatePartnerUserNoteMutation", () => {
+  const mutation = gql`
+    mutation {
+      createPartnerUserNote(
+        input: {
+          partnerId: "partner-123"
+          userId: "collector-123"
+          body: "Collects ceramics."
+        }
+      ) {
+        partnerUserNoteOrError {
+          __typename
+          ... on CreatePartnerUserNoteSuccess {
+            partnerUserNote {
+              internalID
+              partnerId
+              userId
+              body
+            }
+          }
+          ... on CreatePartnerUserNoteFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("creates a partner user note", async () => {
+    const context = {
+      createPartnerUserNoteLoader: () =>
+        Promise.resolve({
+          id: "note-123",
+          partner_id: "partner-123",
+          user_id: "collector-123",
+          body: "Collects ceramics.",
+          updated_by_user_id: "partner-user-123",
+        }),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      createPartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "CreatePartnerUserNoteSuccess",
+          partnerUserNote: {
+            internalID: "note-123",
+            partnerId: "partner-123",
+            userId: "collector-123",
+            body: "Collects ceramics.",
+          },
+        },
+      },
+    })
+  })
+
+  it("calls the loader with the correct parameters", async () => {
+    const mockLoader = jest.fn().mockResolvedValue({
+      id: "note-123",
+      partner_id: "partner-123",
+      user_id: "collector-123",
+      body: "Collects ceramics.",
+    })
+
+    await runAuthenticatedQuery(mutation, {
+      createPartnerUserNoteLoader: mockLoader,
+    })
+
+    expect(mockLoader).toHaveBeenCalledWith({
+      partner_id: "partner-123",
+      user_id: "collector-123",
+      body: "Collects ceramics.",
+    })
+  })
+
+  it("returns a mutation error when Gravity rejects the request", async () => {
+    const context = {
+      createPartnerUserNoteLoader: () =>
+        Promise.reject(
+          new HTTPError("http://artsy.net - {}", 403, { error: "Forbidden" })
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      createPartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "CreatePartnerUserNoteFailure",
+          mutationError: {
+            message: "Forbidden",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/PartnerUserNote/__tests__/deletePartnerUserNoteMutation.test.ts
+++ b/src/schema/v2/partner/PartnerUserNote/__tests__/deletePartnerUserNoteMutation.test.ts
@@ -1,0 +1,87 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("DeletePartnerUserNoteMutation", () => {
+  const mutation = gql`
+    mutation {
+      deletePartnerUserNote(input: { id: "note-123" }) {
+        partnerUserNoteOrError {
+          __typename
+          ... on DeletePartnerUserNoteSuccess {
+            partnerUserNote {
+              internalID
+              body
+            }
+          }
+          ... on DeletePartnerUserNoteFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("deletes a partner user note", async () => {
+    const context = {
+      deletePartnerUserNoteLoader: () =>
+        Promise.resolve({
+          id: "note-123",
+          partner_id: "partner-123",
+          user_id: "collector-123",
+          body: "Collects ceramics.",
+        }),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      deletePartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "DeletePartnerUserNoteSuccess",
+          partnerUserNote: {
+            internalID: "note-123",
+            body: "Collects ceramics.",
+          },
+        },
+      },
+    })
+  })
+
+  it("calls the loader with the correct parameters", async () => {
+    const mockLoader = jest.fn().mockResolvedValue({
+      id: "note-123",
+      body: "Collects ceramics.",
+    })
+
+    await runAuthenticatedQuery(mutation, {
+      deletePartnerUserNoteLoader: mockLoader,
+    })
+
+    expect(mockLoader).toHaveBeenCalledWith("note-123")
+  })
+
+  it("returns a mutation error when Gravity rejects the request", async () => {
+    const context = {
+      deletePartnerUserNoteLoader: () =>
+        Promise.reject(
+          new HTTPError("http://artsy.net - {}", 403, { error: "Forbidden" })
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      deletePartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "DeletePartnerUserNoteFailure",
+          mutationError: {
+            message: "Forbidden",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/PartnerUserNote/__tests__/partnerUserNote.test.ts
+++ b/src/schema/v2/partner/PartnerUserNote/__tests__/partnerUserNote.test.ts
@@ -1,0 +1,54 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("PartnerUserNote", () => {
+  const query = gql`
+    {
+      partnerUserNote(id: "note-123") {
+        internalID
+        partnerId
+        userId
+        body
+        updatedByUserId
+      }
+    }
+  `
+
+  it("retrieves a partner's note about a collector", async () => {
+    const context = {
+      partnerUserNoteLoader: () =>
+        Promise.resolve({
+          id: "note-123",
+          partner_id: "partner-123",
+          user_id: "collector-123",
+          body: "Repeat buyer.",
+          updated_by_user_id: "partner-user-123",
+        }),
+    }
+
+    const data = await runAuthenticatedQuery(query, context)
+
+    expect(data).toEqual({
+      partnerUserNote: {
+        internalID: "note-123",
+        partnerId: "partner-123",
+        userId: "collector-123",
+        body: "Repeat buyer.",
+        updatedByUserId: "partner-user-123",
+      },
+    })
+  })
+
+  it("calls the loader with the given id", async () => {
+    const mockLoader = jest.fn().mockResolvedValue({
+      id: "note-123",
+      body: "Repeat buyer.",
+    })
+
+    await runAuthenticatedQuery(query, {
+      partnerUserNoteLoader: mockLoader,
+    })
+
+    expect(mockLoader).toHaveBeenCalledWith("note-123")
+  })
+})

--- a/src/schema/v2/partner/PartnerUserNote/__tests__/updatePartnerUserNoteMutation.test.ts
+++ b/src/schema/v2/partner/PartnerUserNote/__tests__/updatePartnerUserNoteMutation.test.ts
@@ -1,0 +1,91 @@
+import gql from "lib/gql"
+import { HTTPError } from "lib/HTTPError"
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+describe("UpdatePartnerUserNoteMutation", () => {
+  const mutation = gql`
+    mutation {
+      updatePartnerUserNote(
+        input: { id: "note-123", body: "Now looking at works on paper." }
+      ) {
+        partnerUserNoteOrError {
+          __typename
+          ... on UpdatePartnerUserNoteSuccess {
+            partnerUserNote {
+              internalID
+              body
+            }
+          }
+          ... on UpdatePartnerUserNoteFailure {
+            mutationError {
+              message
+            }
+          }
+        }
+      }
+    }
+  `
+
+  it("updates a partner user note", async () => {
+    const context = {
+      updatePartnerUserNoteLoader: () =>
+        Promise.resolve({
+          id: "note-123",
+          partner_id: "partner-123",
+          user_id: "collector-123",
+          body: "Now looking at works on paper.",
+        }),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      updatePartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "UpdatePartnerUserNoteSuccess",
+          partnerUserNote: {
+            internalID: "note-123",
+            body: "Now looking at works on paper.",
+          },
+        },
+      },
+    })
+  })
+
+  it("calls the loader with the correct parameters", async () => {
+    const mockLoader = jest.fn().mockResolvedValue({
+      id: "note-123",
+      body: "Now looking at works on paper.",
+    })
+
+    await runAuthenticatedQuery(mutation, {
+      updatePartnerUserNoteLoader: mockLoader,
+    })
+
+    expect(mockLoader).toHaveBeenCalledWith("note-123", {
+      body: "Now looking at works on paper.",
+    })
+  })
+
+  it("returns a mutation error when Gravity rejects the request", async () => {
+    const context = {
+      updatePartnerUserNoteLoader: () =>
+        Promise.reject(
+          new HTTPError("http://artsy.net - {}", 403, { error: "Forbidden" })
+        ),
+    }
+
+    const data = await runAuthenticatedQuery(mutation, context)
+
+    expect(data).toEqual({
+      updatePartnerUserNote: {
+        partnerUserNoteOrError: {
+          __typename: "UpdatePartnerUserNoteFailure",
+          mutationError: {
+            message: "Forbidden",
+          },
+        },
+      },
+    })
+  })
+})

--- a/src/schema/v2/partner/PartnerUserNote/createPartnerUserNoteMutation.ts
+++ b/src/schema/v2/partner/PartnerUserNote/createPartnerUserNoteMutation.ts
@@ -1,0 +1,100 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerUserNoteType } from "./PartnerUserNoteType"
+
+interface Input {
+  partnerId: string
+  userId: string
+  body: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerUserNoteSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    partnerUserNote: {
+      type: PartnerUserNoteType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "CreatePartnerUserNoteFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "CreatePartnerUserNoteOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const CreatePartnerUserNoteMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "CreatePartnerUserNote",
+  description: "Creates a partner's note about a collector.",
+  inputFields: {
+    partnerId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the partner.",
+    },
+    userId: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the collector the note is about.",
+    },
+    body: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Note text.",
+    },
+  },
+  outputFields: {
+    partnerUserNoteOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { partnerId, userId, body },
+    { createPartnerUserNoteLoader }
+  ) => {
+    if (!createPartnerUserNoteLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await createPartnerUserNoteLoader({
+        partner_id: partnerId,
+        user_id: userId,
+        body,
+      })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/PartnerUserNote/deletePartnerUserNoteMutation.ts
+++ b/src/schema/v2/partner/PartnerUserNote/deletePartnerUserNoteMutation.ts
@@ -1,0 +1,83 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerUserNoteType } from "./PartnerUserNoteType"
+
+interface Input {
+  id: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerUserNoteSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    partnerUserNote: {
+      type: PartnerUserNoteType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "DeletePartnerUserNoteFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "DeletePartnerUserNoteOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const DeletePartnerUserNoteMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "DeletePartnerUserNote",
+  description: "Deletes a partner's note about a collector.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the note to delete.",
+    },
+  },
+  outputFields: {
+    partnerUserNoteOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async ({ id }, { deletePartnerUserNoteLoader }) => {
+    if (!deletePartnerUserNoteLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await deletePartnerUserNoteLoader(id)
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/PartnerUserNote/updatePartnerUserNoteMutation.ts
+++ b/src/schema/v2/partner/PartnerUserNote/updatePartnerUserNoteMutation.ts
@@ -1,0 +1,91 @@
+import {
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import {
+  formatGravityError,
+  GravityMutationErrorType,
+} from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { PartnerUserNoteType } from "./PartnerUserNoteType"
+
+interface Input {
+  id: string
+  body: string
+}
+
+const SuccessType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerUserNoteSuccess",
+  isTypeOf: (data) => !!data.id,
+  fields: () => ({
+    partnerUserNote: {
+      type: PartnerUserNoteType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+const FailureType = new GraphQLObjectType<any, ResolverContext>({
+  name: "UpdatePartnerUserNoteFailure",
+  isTypeOf: (data) => data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+const ResponseOrErrorType = new GraphQLUnionType({
+  name: "UpdatePartnerUserNoteOrError",
+  types: [SuccessType, FailureType],
+})
+
+export const UpdatePartnerUserNoteMutation = mutationWithClientMutationId<
+  Input,
+  any,
+  ResolverContext
+>({
+  name: "UpdatePartnerUserNote",
+  description: "Updates a partner's note about a collector.",
+  inputFields: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "ID of the note to update.",
+    },
+    body: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "Note text.",
+    },
+  },
+  outputFields: {
+    partnerUserNoteOrError: {
+      type: ResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (
+    { id, body },
+    { updatePartnerUserNoteLoader }
+  ) => {
+    if (!updatePartnerUserNoteLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const response = await updatePartnerUserNoteLoader(id, { body })
+
+      return response
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw new Error(error)
+      }
+    }
+  },
+})

--- a/src/schema/v2/partner/__tests__/partner.test.js
+++ b/src/schema/v2/partner/__tests__/partner.test.js
@@ -670,6 +670,115 @@ describe("Partner type", () => {
     })
   })
 
+  describe("#userNotesConnection", () => {
+    let notesResponse
+
+    const partnerUserNotesLoader = jest.fn(() => {
+      return Promise.resolve({
+        body: notesResponse,
+        headers: {
+          "x-total-count": notesResponse.length,
+        },
+      })
+    })
+
+    const partnerLoader = jest.fn(() => {
+      return Promise.resolve(partnerData)
+    })
+
+    beforeEach(() => {
+      notesResponse = [
+        {
+          id: "note-1",
+          partner_id: "catty-partner",
+          user_id: "collector-1",
+          body: "Interested in large scale abstract work.",
+          updated_by_user_id: "partner-user-1",
+        },
+        {
+          id: "note-2",
+          partner_id: "catty-partner",
+          user_id: "collector-2",
+          body: "Prefers a studio visit before committing.",
+          updated_by_user_id: "partner-user-1",
+        },
+      ]
+    })
+
+    it("returns a partner's notes about collectors", async () => {
+      context = {
+        partnerUserNotesLoader,
+        partnerLoader,
+      }
+
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            userNotesConnection(first:3) {
+              totalCount
+              edges {
+                node {
+                  body
+                  userId
+                }
+              }
+            }
+          }
+        }
+      `
+
+      const data = await runAuthenticatedQuery(query, context)
+
+      expect(data).toEqual({
+        partner: {
+          userNotesConnection: {
+            totalCount: 2,
+            edges: [
+              {
+                node: {
+                  body: "Interested in large scale abstract work.",
+                  userId: "collector-1",
+                },
+              },
+              {
+                node: {
+                  body: "Prefers a studio visit before committing.",
+                  userId: "collector-2",
+                },
+              },
+            ],
+          },
+        },
+      })
+    })
+
+    it("passes the userId filter through to the loader", async () => {
+      context = {
+        partnerUserNotesLoader,
+        partnerLoader,
+      }
+
+      const query = `
+        {
+          partner(id:"bau-xi-gallery") {
+            userNotesConnection(first:3, userId: "collector-1") {
+              totalCount
+            }
+          }
+        }
+      `
+
+      await runAuthenticatedQuery(query, context)
+
+      expect(partnerUserNotesLoader).toHaveBeenCalledWith(
+        expect.objectContaining({
+          partner_id: "internal-id",
+          user_id: "collector-1",
+        })
+      )
+    })
+  })
+
   describe("#location", () => {
     let singleLocationResponse
 

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -56,6 +56,7 @@ import { setVersion } from "schema/v2/image/normalize"
 import { compact } from "lodash"
 import { InquiryRequestType } from "./partnerInquiryRequest"
 import { PartnerDocumentsConnection } from "./partnerDocumentsConnection"
+import { UserNotesConnection } from "./PartnerUserNote/PartnerUserNoteType"
 import { AlertType, PartnerAlertsEdgeFields } from "../Alerts"
 import {
   ArtworkVisibility,
@@ -853,6 +854,7 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
         },
       },
       artworkDuplicatePairsConnection: ArtworkDuplicatePairsConnection,
+      userNotesConnection: UserNotesConnection,
       conversationMessageTemplatesConnection: ConversationMessageTemplatesConnection,
       artworkTemplatesConnection: ArtworkTemplatesConnection,
       conversationMessageTemplateExamples: {

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -228,6 +228,10 @@ import { PagesConnection } from "./Page/PagesConnection"
 import { UpdatePageMutation } from "./Page/UpdatePageMutation"
 import { PartnerArtistDocumentsConnection } from "./partner/partnerArtistDocumentsConnection"
 import { PartnerShowDocumentsConnection } from "./partner/partnerShowDocumentsConnection"
+import { PartnerUserNote } from "./partner/PartnerUserNote/PartnerUserNoteType"
+import { CreatePartnerUserNoteMutation } from "./partner/PartnerUserNote/createPartnerUserNoteMutation"
+import { UpdatePartnerUserNoteMutation } from "./partner/PartnerUserNote/updatePartnerUserNoteMutation"
+import { DeletePartnerUserNoteMutation } from "./partner/PartnerUserNote/deletePartnerUserNoteMutation"
 import { updateCMSLastAccessTimestampMutation } from "./partner/updateCMSLastAccessTimestampMutation"
 import { updatePartnerFlagsMutation } from "./partner/updatePartnerFlagsMutation"
 import { updatePartnerMutation } from "./partner/updatePartnerMutation"
@@ -570,6 +574,7 @@ const rootFields = {
   partnerCategory: PartnerCategory,
   partnersConnection: PartnersConnection,
   partnerShowDocumentsConnection: PartnerShowDocumentsConnection,
+  partnerUserNote: PartnerUserNote,
   phoneNumber: PhoneNumber,
   previewSavedSearch: PreviewSavedSearchField,
   privateViewingRoom: PrivateViewingRoom,
@@ -682,6 +687,7 @@ export default new GraphQLSchema({
       createNavigationItem: createNavigationItemMutation,
       createOrderedSet: createOrderedSetMutation,
       createPartnerContact: CreatePartnerContactMutation,
+      createPartnerUserNote: CreatePartnerUserNoteMutation,
       createPartnerLocation: CreatePartnerLocationMutation,
       createPartnerLocationDaySchedules: CreatePartnerLocationDaySchedulesMutation,
       createPartnerArtistDocument: createPartnerArtistDocumentMutation,
@@ -749,6 +755,7 @@ export default new GraphQLSchema({
       deletePartnerList: deletePartnerListMutation,
       deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
+      deletePartnerUserNote: DeletePartnerUserNoteMutation,
       deletePartnerArtistDocument: deletePartnerArtistDocumentMutation,
       deletePartnerLocation: DeletePartnerLocationMutation,
       deletePartnerShow: deletePartnerShowMutation,
@@ -864,6 +871,7 @@ export default new GraphQLSchema({
       updatePage: UpdatePageMutation,
       updatePurchase: updatePurchaseMutation,
       updatePartnerContact: UpdatePartnerContactMutation,
+      updatePartnerUserNote: UpdatePartnerUserNoteMutation,
       updatePartnerLocation: UpdatePartnerLocationMutation,
       updatePartnerProfileImage: UpdatePartnerProfileImageMutation,
       updatePartnerShow: updatePartnerShowMutation,


### PR DESCRIPTION
Here is a draft to have CRUD functionality for PartnerUserNote introduced here: https://github.com/artsy/gravity/pull/20498