### PR TITLE
chore: add support to sellerState and ordering for partner.orders connection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -29628,7 +29628,17 @@ type Partner implements Node {
     first: Int
     last: Int
     page: Int
+
+    """
+    Filter by seller states
+    """
+    sellerState: [OrderSellerStateEnum]
     size: Int
+
+    """
+    Sort order for returned orders
+    """
+    sort: PartnerOrdersSortEnum
   ): PartnerOrdersConnection
 
   """
@@ -31339,6 +31349,13 @@ type PartnerOrdersEdge {
   The item at the end of the edge
   """
   node: Order
+}
+
+enum PartnerOrdersSortEnum {
+  STATE_EXPIRES_AT_ASC
+  STATE_EXPIRES_AT_DESC
+  STATE_UPDATED_AT_ASC
+  STATE_UPDATED_AT_DESC
 }
 
 """

--- a/src/schema/v2/order/types/sharedOrderTypes.ts
+++ b/src/schema/v2/order/types/sharedOrderTypes.ts
@@ -214,6 +214,16 @@ export const OrderSellerStateEnum = new GraphQLEnumType({
   },
 })
 
+export const PartnerOrdersSortEnum = new GraphQLEnumType({
+  name: "PartnerOrdersSortEnum",
+  values: {
+    STATE_EXPIRES_AT_ASC: { value: "STATE_EXPIRES_AT_ASC" },
+    STATE_EXPIRES_AT_DESC: { value: "STATE_EXPIRES_AT_DESC" },
+    STATE_UPDATED_AT_ASC: { value: "STATE_UPDATED_AT_ASC" },
+    STATE_UPDATED_AT_DESC: { value: "STATE_UPDATED_AT_DESC" },
+  },
+})
+
 // Enum for fulfillment_option.type field
 const FulfillmentOptionTypeEnum = new GraphQLEnumType({
   name: "FulfillmentOptionTypeEnum",

--- a/src/schema/v2/partner/__tests__/partnerOrdersConnection.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerOrdersConnection.test.ts
@@ -17,6 +17,7 @@ describe("partner.ordersConnection", () => {
         buyer_type: "User",
         seller_id: "partner-id",
         seller_type: "Partner",
+        seller_state: "OFFER_RECEIVED",
         items_total_cents: 100000,
         shipping_total_cents: 2000,
         tax_total_cents: 8000,
@@ -44,6 +45,7 @@ describe("partner.ordersConnection", () => {
         buyer_type: "User",
         seller_id: "partner-id",
         seller_type: "Partner",
+        seller_state: "APPROVED_SELLER_SHIP",
         items_total_cents: 50000,
         shipping_total_cents: 1000,
         tax_total_cents: 4000,
@@ -70,6 +72,13 @@ describe("partner.ordersConnection", () => {
       if (params.artwork_id) {
         filteredOrders = filteredOrders.filter((order) =>
           order.line_items.some((li) => li.artwork_id === params.artwork_id)
+        )
+      }
+
+      if (params.seller_state) {
+        const sellerStates = params.seller_state.split(",")
+        filteredOrders = filteredOrders.filter((order) =>
+          sellerStates.includes(order.seller_state)
         )
       }
 
@@ -170,6 +179,71 @@ describe("partner.ordersConnection", () => {
       "partner-id",
       expect.objectContaining({
         artwork_id: "artwork-1",
+      })
+    )
+  })
+
+  it("filters orders by sellerState", async () => {
+    const query = gql`
+      {
+        partner(id: "partner-id") {
+          ordersConnection(first: 5, sellerState: [OFFER_RECEIVED]) {
+            edges {
+              node {
+                internalID
+                code
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+    expect(data).toEqual({
+      partner: {
+        ordersConnection: {
+          edges: [
+            {
+              node: {
+                internalID: "order-1",
+                code: "ORD001",
+              },
+            },
+          ],
+        },
+      },
+    })
+
+    expect(context.partnerOrdersLoader).toHaveBeenCalledWith(
+      "partner-id",
+      expect.objectContaining({
+        seller_state: "OFFER_RECEIVED",
+      })
+    )
+  })
+
+  it("passes the sort param through to the loader", async () => {
+    const query = gql`
+      {
+        partner(id: "partner-id") {
+          ordersConnection(first: 5, sort: STATE_EXPIRES_AT_ASC) {
+            edges {
+              node {
+                internalID
+              }
+            }
+          }
+        }
+      }
+    `
+
+    await runQuery(query, context)
+
+    expect(context.partnerOrdersLoader).toHaveBeenCalledWith(
+      "partner-id",
+      expect.objectContaining({
+        sort: "STATE_EXPIRES_AT_ASC",
       })
     )
   })

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -249,6 +249,11 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
       PartnerOrdersConnectionType,
     } = require("../order/types/OrderType")
 
+    const {
+      OrderSellerStateEnum,
+      PartnerOrdersSortEnum,
+    } = require("../order/types/sharedOrderTypes")
+
     return {
       ...SlugAndInternalIDFields,
       cached,
@@ -1695,6 +1700,14 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
             type: GraphQLString,
             description: "Filter by artwork ID in line items",
           },
+          sellerState: {
+            type: new GraphQLList(OrderSellerStateEnum),
+            description: "Filter by seller states",
+          },
+          sort: {
+            type: PartnerOrdersSortEnum,
+            description: "Sort order for returned orders",
+          },
         }),
         resolve: async (partner, args, context, _info) => {
           const { partnerOrdersLoader } = context
@@ -1711,6 +1724,14 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
 
           if (args.artworkID) {
             params.artwork_id = args.artworkID
+          }
+
+          if (args.sellerState && args.sellerState.length > 0) {
+            params.seller_state = args.sellerState.join(",")
+          }
+
+          if (args.sort) {
+            params.sort = args.sort
           }
 
           const response = await partnerOrdersLoader(partner.id, params)


### PR DESCRIPTION

This is the minimal that is required to start replacing CommerceOrders with Orders on CMS side for /orders page. Depends on merging this: https://github.com/artsy/exchange/pull/3187

We'll probably have to add more props to this OrderType but that change should be good to start work on CMS side.