### PR TITLE
feat: add Show.isFreeAdmission, Location.partner and followed shows totalCount

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -20529,6 +20529,7 @@ type FollowedShowConnection {
   Information to aid in pagination.
   """
   pageInfo: PageInfo!
+  totalCount: Int
 }
 
 """
@@ -23485,6 +23486,7 @@ type Location {
   Union returning opening hours in formatted structure or a string
   """
   openingHours: OpeningHoursUnion
+  partner: Partner
   phone: String
   pier: String
   postalCode: String
@@ -37368,6 +37370,11 @@ type Show implements EntityWithFilterArtworksConnectionInterface & Node {
   Is the user following this show
   """
   isFollowed: Boolean
+
+  """
+  Is entry to this show free? Null means this is genuinely unknown, not that admission isn't free.
+  """
+  isFreeAdmission: Boolean
 
   """
   Does the show exist soley online

--- a/src/schema/v2/location.ts
+++ b/src/schema/v2/location.ts
@@ -64,6 +64,14 @@ export const LocationType = new GraphQLObjectType<any, ResolverContext>({
   fields: () => ({
     ...IDFields,
     cached,
+    // Only present when the location was loaded in its own right — Gravity
+    // serialises a partner reference on `PartnerLocation`, but an embedded
+    // location (a show's, a fair's) has no partner of its own. Imported
+    // lazily because `partner/partner.ts` imports this module.
+    partner: {
+      type: require("schema/v2/partner/partner").PartnerType,
+      resolve: ({ partner }) => partner ?? null,
+    },
     name: {
       type: GraphQLString,
     },

--- a/src/schema/v2/me/followed_shows.ts
+++ b/src/schema/v2/me/followed_shows.ts
@@ -10,6 +10,11 @@ import { LOCAL_DISCOVERY_RADIUS_KM } from "../city/constants"
 export const FollowedShowConnection = connectionDefinitions({
   name: "FollowedShow",
   nodeType: ShowType,
+  connectionFields: {
+    totalCount: {
+      type: GraphQLInt,
+    },
+  },
 })
 
 const FollowedShows: GraphQLFieldConfig<void, ResolverContext> = {
@@ -62,11 +67,16 @@ const FollowedShows: GraphQLFieldConfig<void, ResolverContext> = {
     }
 
     return followedShowsLoader(gravityArgs).then(({ body, headers }) => {
-      return connectionFromArraySlice(body, options, {
-        arrayLength: parseInt(headers["x-total-count"] || "0", 10),
-        sliceStart: offset,
-        resolveNode: (follow_show) => follow_show.partner_show,
-      })
+      const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+      return {
+        totalCount,
+        ...connectionFromArraySlice(body, options, {
+          arrayLength: totalCount,
+          sliceStart: offset,
+          resolveNode: (follow_show) => follow_show.partner_show,
+        }),
+      }
     })
   },
 }

--- a/src/schema/v2/show.ts
+++ b/src/schema/v2/show.ts
@@ -522,6 +522,12 @@ export const ShowType = new GraphQLObjectType<any, ResolverContext>({
         type: GraphQLBoolean,
         resolve: ({ featured }) => featured,
       },
+      isFreeAdmission: {
+        description:
+          "Is entry to this show free? Null means this is genuinely unknown, not that admission isn't free.",
+        type: GraphQLBoolean,
+        resolve: ({ is_free_admission }) => is_free_admission,
+      },
       isActive: {
         type: GraphQLBoolean,
         description:


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-23

This PR makes the following changes:

- Add `Show.isFreeAdmission`
- Add `Location.partner`
- Add `FollowedShowConnection.totalCount`

Three unrelated field additions pulled off `mounir/city-guide-itineraries` ahead of the itinerary work (PR 1 of the split of #7884).

`Show.isFreeAdmission` is three-valued. `null` means unknown and renders as nothing, which is not "entry is not free". Gravity added the column in artsy/gravity#20503.

`Location.partner` is nullable on a widely used type. Gravity serialises a partner reference on `PartnerLocation`; an embedded location (a show's, a fair's) has none and resolves `null`. It is imported with `require` inside the field config because `partner/partner.ts` imports `location.ts`.

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
