### PR TITLE
feat: add ItineraryStop type and stop item batching

### DIFF
--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1445,6 +1445,7 @@ export default (accessToken, userID, opts) => {
     ),
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
+    partnerLocationByIdLoader: gravityLoader((id) => `partner_location/${id}`),
     partnerShowLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1445,7 +1445,7 @@ export default (accessToken, userID, opts) => {
     ),
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
-    partnerLocationByIdLoader: gravityLoader((id) => `partner_location/${id}`),
+    partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     partnerShowLoader: gravityLoader<
       any,
       { partner_id: string; show_id: string }

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -335,8 +335,7 @@ export default (opts) => {
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     shortcutLoader: gravityLoader((id) => `shortcut/${id}`),
     showLoader: gravityLoader((id) => `show/${id}`),
-    // Keyed by location id alone; partnerLocationLoader needs the partner id too.
-    partnerLocationByIdLoader: gravityLoader((id) => `partner_location/${id}`),
+    partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),
     similarArtworksLoader: gravityLoader("related/artworks"),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -335,10 +335,7 @@ export default (opts) => {
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     shortcutLoader: gravityLoader((id) => `shortcut/${id}`),
     showLoader: gravityLoader((id) => `show/${id}`),
-    // Gravity's root-level location route, added so a stop whose item is a
-    // `PartnerLocation` resolves for a logged-out reader of a public guide.
-    // The authenticated `partnerLocationLoader` is a different thing: it is
-    // keyed by `{ partnerId, locationId }`, which a stop does not carry.
+    // Keyed by location id alone; partnerLocationLoader needs the partner id too.
     partnerLocationByIdLoader: gravityLoader((id) => `partner_location/${id}`),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -335,6 +335,11 @@ export default (opts) => {
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     shortcutLoader: gravityLoader((id) => `shortcut/${id}`),
     showLoader: gravityLoader((id) => `show/${id}`),
+    // Gravity's root-level location route, added so a stop whose item is a
+    // `PartnerLocation` resolves for a logged-out reader of a public guide.
+    // The authenticated `partnerLocationLoader` is a different thing: it is
+    // keyed by `{ partnerId, locationId }`, which a stop does not carry.
+    partnerLocationByIdLoader: gravityLoader((id) => `partner_location/${id}`),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),
     similarArtworksLoader: gravityLoader("related/artworks"),

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -41,11 +41,8 @@ describe("loadStopItems", () => {
     const stops = [
       buildStop({ item_type: "PartnerShow", item_id: "show-1" }),
       buildStop({ item_type: "PartnerLocation", item_id: "location-1" }),
-      // A second stop referencing the same location -- must not trigger a
-      // second call, even though locations are fetched one id at a time.
       buildStop({ item_type: "PartnerLocation", item_id: "location-1" }),
       buildStop({ item_type: "Fair", item_id: "fair-1" }),
-      // No item behind this stop at all.
       buildStop({ item_type: null, item_id: null }),
     ]
 
@@ -86,9 +83,6 @@ describe("loadStopItems", () => {
     expect(map.get("Fair:gone")).toBeUndefined()
   })
 
-  // A guide outlives its stops' entities. A location that has been deleted,
-  // or made private since the guide was written, must leave that one stop
-  // without an item rather than failing the whole itinerary.
   it("leaves out a location that 404s rather than failing the itinerary", async () => {
     const partnerLocationByIdLoader = jest
       .fn()

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -1,4 +1,8 @@
-import { attachStopItems, loadStopItems } from "../stopItems"
+import {
+  attachStopItems,
+  attachStopItemsToMany,
+  loadStopItems,
+} from "../stopItems"
 import { GravityItinerary, GravityItineraryStop } from "../types"
 
 const buildStop = (
@@ -28,6 +32,42 @@ const buildStop = (
   ...overrides,
 })
 
+const buildItinerary = (
+  stopsBySection: GravityItineraryStop[][],
+  overrides: Partial<GravityItinerary> = {}
+): GravityItinerary => ({
+  id: "itinerary-id",
+  slug: null,
+  title: "Test itinerary",
+  subtitle: null,
+  description: null,
+  author_name: null,
+  user_id: "user-1",
+  city_slug: "london-united-kingdom",
+  is_curated: false,
+  visibility: "private",
+  share_token: null,
+  published_at: null,
+  published_by_id: null,
+  image_url: null,
+  image_urls: null,
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-01T00:00:00Z",
+  sections_count: stopsBySection.length,
+  sections: stopsBySection.map((stops, index) => ({
+    id: `section-${index}`,
+    itinerary_id: "itinerary-id",
+    title: null,
+    note: null,
+    position: index,
+    stops_count: stops.length,
+    stops,
+    created_at: "2026-09-01T00:00:00Z",
+    updated_at: "2026-09-01T00:00:00Z",
+  })),
+  ...overrides,
+})
+
 describe("loadStopItems", () => {
   it("batches ids by type, calling each loader at most once", async () => {
     const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
@@ -53,13 +93,14 @@ describe("loadStopItems", () => {
     } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
-    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"] })
+    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
     expect(partnerLocationsByIdsLoader).toHaveBeenCalledTimes(1)
     expect(partnerLocationsByIdsLoader).toHaveBeenCalledWith({
       id: ["location-1"],
+      size: 1,
     })
     expect(fairsLoader).toHaveBeenCalledTimes(1)
-    expect(fairsLoader).toHaveBeenCalledWith({ id: ["fair-1"] })
+    expect(fairsLoader).toHaveBeenCalledWith({ id: ["fair-1"], size: 1 })
 
     expect(map.get("PartnerShow:show-1")).toEqual({
       _id: "show-1",
@@ -72,6 +113,42 @@ describe("loadStopItems", () => {
     expect(map.get("Fair:fair-1")).toEqual({
       _id: "fair-1",
       __typename: "Fair",
+    })
+  })
+
+  it("keys a partner location by id even when an unrelated _id is present", async () => {
+    const partnerLocationsByIdsLoader = jest
+      .fn()
+      .mockResolvedValue([{ id: "location-1", _id: "unrelated-mongo-id" }])
+
+    const stops = [
+      buildStop({ item_type: "PartnerLocation", item_id: "location-1" }),
+    ]
+
+    const map = await loadStopItems(stops, {
+      partnerLocationsByIdsLoader,
+    } as any)
+
+    expect(map.get("PartnerLocation:location-1")).toEqual({
+      id: "location-1",
+      _id: "unrelated-mongo-id",
+      __typename: "PartnerLocation",
+    })
+  })
+
+  it("keys a partner show by _id even when it also has a slug id", async () => {
+    const showsLoader = jest
+      .fn()
+      .mockResolvedValue([{ _id: "show-1", id: "andy-warhol-retrospective" }])
+
+    const stops = [buildStop({ item_type: "PartnerShow", item_id: "show-1" })]
+
+    const map = await loadStopItems(stops, { showsLoader } as any)
+
+    expect(map.get("PartnerShow:show-1")).toEqual({
+      _id: "show-1",
+      id: "andy-warhol-retrospective",
+      __typename: "Show",
     })
   })
 
@@ -105,6 +182,15 @@ describe("loadStopItems", () => {
     expect(map.size).toEqual(0)
   })
 
+  it("returns early without calling any loader when there are no stops", async () => {
+    const fairsLoader = jest.fn()
+
+    const map = await loadStopItems([], { fairsLoader } as any)
+
+    expect(map.size).toEqual(0)
+    expect(fairsLoader).not.toHaveBeenCalled()
+  })
+
   it("propagates a loader failure instead of swallowing it into a null item", async () => {
     const fairsLoader = jest.fn().mockRejectedValue(new Error("Gravity 500"))
 
@@ -131,40 +217,6 @@ describe("loadStopItems", () => {
 })
 
 describe("attachStopItems", () => {
-  const buildItinerary = (
-    stopsBySection: GravityItineraryStop[][]
-  ): GravityItinerary => ({
-    id: "itinerary-id",
-    slug: null,
-    title: "Test itinerary",
-    subtitle: null,
-    description: null,
-    author_name: null,
-    user_id: "user-1",
-    city_slug: "london-united-kingdom",
-    is_curated: false,
-    visibility: "private",
-    share_token: null,
-    published_at: null,
-    published_by_id: null,
-    image_url: null,
-    image_urls: null,
-    created_at: "2026-09-01T00:00:00Z",
-    updated_at: "2026-09-01T00:00:00Z",
-    sections_count: stopsBySection.length,
-    sections: stopsBySection.map((stops, index) => ({
-      id: `section-${index}`,
-      itinerary_id: "itinerary-id",
-      title: null,
-      note: null,
-      position: index,
-      stops_count: stops.length,
-      stops,
-      created_at: "2026-09-01T00:00:00Z",
-      updated_at: "2026-09-01T00:00:00Z",
-    })),
-  })
-
   it("resolves stops across every section in a single batch per type", async () => {
     const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
 
@@ -176,7 +228,7 @@ describe("attachStopItems", () => {
     await attachStopItems(itinerary, { showsLoader } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
-    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"] })
+    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
 
     const resolvedItems = itinerary.sections.flatMap((section) =>
       section.stops.map((stop: any) => stop._resolvedItem)
@@ -193,5 +245,58 @@ describe("attachStopItems", () => {
     await attachStopItems(itinerary, {} as any)
 
     expect((itinerary.sections[0].stops[0] as any)._resolvedItem).toBeNull()
+  })
+
+  it("resolves without throwing and calls no loader when sections is absent", async () => {
+    const showsLoader = jest.fn()
+    const itinerary = buildItinerary([])
+    delete (itinerary as any).sections
+
+    await expect(
+      attachStopItems(itinerary, { showsLoader } as any)
+    ).resolves.toBe(itinerary)
+    expect(showsLoader).not.toHaveBeenCalled()
+  })
+
+  it("resolves without throwing and calls no loader when a section has no stops", async () => {
+    const showsLoader = jest.fn()
+    const itinerary = buildItinerary([[]])
+    delete (itinerary.sections[0] as any).stops
+
+    await expect(
+      attachStopItems(itinerary, { showsLoader } as any)
+    ).resolves.toBe(itinerary)
+    expect(showsLoader).not.toHaveBeenCalled()
+  })
+})
+
+describe("attachStopItemsToMany", () => {
+  it("dedupes ids across itineraries into a single loader call and stamps every stop", async () => {
+    const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
+
+    const itineraryA = buildItinerary(
+      [[buildStop({ item_type: "PartnerShow", item_id: "show-1" })]],
+      { id: "itinerary-a" }
+    )
+    const itineraryB = buildItinerary(
+      [[buildStop({ item_type: "PartnerShow", item_id: "show-1" })]],
+      { id: "itinerary-b" }
+    )
+
+    await attachStopItemsToMany([itineraryA, itineraryB], {
+      showsLoader,
+    } as any)
+
+    expect(showsLoader).toHaveBeenCalledTimes(1)
+    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
+
+    expect((itineraryA.sections[0].stops[0] as any)._resolvedItem).toEqual({
+      _id: "show-1",
+      __typename: "Show",
+    })
+    expect((itineraryB.sections[0].stops[0] as any)._resolvedItem).toEqual({
+      _id: "show-1",
+      __typename: "Show",
+    })
   })
 })

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -93,7 +93,11 @@ describe("loadStopItems", () => {
     } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
-    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
+    expect(showsLoader).toHaveBeenCalledWith({
+      id: ["show-1"],
+      size: 1,
+      include_local_discovery: true,
+    })
     expect(partnerLocationsByIdsLoader).toHaveBeenCalledTimes(1)
     expect(partnerLocationsByIdsLoader).toHaveBeenCalledWith({
       id: ["location-1"],
@@ -228,7 +232,11 @@ describe("attachStopItems", () => {
     await attachStopItems(itinerary, { showsLoader } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
-    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
+    expect(showsLoader).toHaveBeenCalledWith({
+      id: ["show-1"],
+      size: 1,
+      include_local_discovery: true,
+    })
 
     const resolvedItems = itinerary.sections.flatMap((section) =>
       section.stops.map((stop: any) => stop._resolvedItem)
@@ -288,7 +296,11 @@ describe("attachStopItemsToMany", () => {
     } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
-    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"], size: 1 })
+    expect(showsLoader).toHaveBeenCalledWith({
+      id: ["show-1"],
+      size: 1,
+      include_local_discovery: true,
+    })
 
     expect((itineraryA.sections[0].stops[0] as any)._resolvedItem).toEqual({
       _id: "show-1",

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -1,0 +1,189 @@
+import { attachStopItems, loadStopItems } from "../stopItems"
+import { GravityItinerary, GravityItineraryStop } from "../types"
+
+const buildStop = (
+  overrides: Partial<GravityItineraryStop>
+): GravityItineraryStop => ({
+  id: "stop-id",
+  itinerary_section_id: "section-0",
+  position: 0,
+  title: null,
+  address: null,
+  image_url: null,
+  latitude: null,
+  longitude: null,
+  start_at: null,
+  end_at: null,
+  time_zone: null,
+  note: null,
+  category: null,
+  is_free_admission: null,
+  item_type: null,
+  item_id: null,
+  event_type: null,
+  event_id: null,
+  source_url: null,
+  created_at: "2026-09-01T00:00:00Z",
+  updated_at: "2026-09-01T00:00:00Z",
+  ...overrides,
+})
+
+describe("loadStopItems", () => {
+  it("batches ids by type, calling each loader at most once", async () => {
+    const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
+    const partnerLocationByIdLoader = jest
+      .fn()
+      .mockResolvedValue({ _id: "location-1" })
+    const fairsLoader = jest
+      .fn()
+      .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} })
+
+    const stops = [
+      buildStop({ item_type: "PartnerShow", item_id: "show-1" }),
+      buildStop({ item_type: "PartnerLocation", item_id: "location-1" }),
+      // A second stop referencing the same location -- must not trigger a
+      // second call, even though locations are fetched one id at a time.
+      buildStop({ item_type: "PartnerLocation", item_id: "location-1" }),
+      buildStop({ item_type: "Fair", item_id: "fair-1" }),
+      // No item behind this stop at all.
+      buildStop({ item_type: null, item_id: null }),
+    ]
+
+    const map = await loadStopItems(stops, {
+      showsLoader,
+      partnerLocationByIdLoader,
+      fairsLoader,
+    } as any)
+
+    expect(showsLoader).toHaveBeenCalledTimes(1)
+    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"] })
+    expect(partnerLocationByIdLoader).toHaveBeenCalledTimes(1)
+    expect(partnerLocationByIdLoader).toHaveBeenCalledWith("location-1")
+    expect(fairsLoader).toHaveBeenCalledTimes(1)
+    expect(fairsLoader).toHaveBeenCalledWith({ id: ["fair-1"] })
+
+    expect(map.get("PartnerShow:show-1")).toEqual({
+      _id: "show-1",
+      __typename: "Show",
+    })
+    expect(map.get("PartnerLocation:location-1")).toEqual({
+      _id: "location-1",
+      __typename: "PartnerLocation",
+    })
+    expect(map.get("Fair:fair-1")).toEqual({
+      _id: "fair-1",
+      __typename: "Fair",
+    })
+  })
+
+  it("leaves a deleted/unmatched entity out of the map rather than erroring", async () => {
+    const fairsLoader = jest.fn().mockResolvedValue({ body: [], headers: {} })
+
+    const stops = [buildStop({ item_type: "Fair", item_id: "gone" })]
+
+    const map = await loadStopItems(stops, { fairsLoader } as any)
+
+    expect(map.get("Fair:gone")).toBeUndefined()
+  })
+
+  // A guide outlives its stops' entities. A location that has been deleted,
+  // or made private since the guide was written, must leave that one stop
+  // without an item rather than failing the whole itinerary.
+  it("leaves out a location that 404s rather than failing the itinerary", async () => {
+    const partnerLocationByIdLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Not Found"))
+
+    const stops = [buildStop({ item_type: "PartnerLocation", item_id: "gone" })]
+
+    const map = await loadStopItems(stops, {
+      partnerLocationByIdLoader,
+    } as any)
+
+    expect(map.get("PartnerLocation:gone")).toBeUndefined()
+  })
+
+  it("skips a type entirely when its loader isn't wired into the context", async () => {
+    const stops = [buildStop({ item_type: "Fair", item_id: "fair-1" })]
+
+    const map = await loadStopItems(stops, {} as any)
+
+    expect(map.size).toEqual(0)
+  })
+
+  it("propagates a loader failure instead of swallowing it into a null item", async () => {
+    const fairsLoader = jest.fn().mockRejectedValue(new Error("Gravity 500"))
+
+    const stops = [buildStop({ item_type: "Fair", item_id: "fair-1" })]
+
+    await expect(loadStopItems(stops, { fairsLoader } as any)).rejects.toThrow(
+      "Gravity 500"
+    )
+  })
+})
+
+describe("attachStopItems", () => {
+  const buildItinerary = (
+    stopsBySection: GravityItineraryStop[][]
+  ): GravityItinerary => ({
+    id: "itinerary-id",
+    slug: null,
+    title: "Test itinerary",
+    subtitle: null,
+    description: null,
+    author_name: null,
+    user_id: "user-1",
+    city_slug: "london-united-kingdom",
+    is_curated: false,
+    visibility: "private",
+    share_token: null,
+    published_at: null,
+    published_by_id: null,
+    image_url: null,
+    image_urls: null,
+    created_at: "2026-09-01T00:00:00Z",
+    updated_at: "2026-09-01T00:00:00Z",
+    sections_count: stopsBySection.length,
+    sections: stopsBySection.map((stops, index) => ({
+      id: `section-${index}`,
+      itinerary_id: "itinerary-id",
+      title: null,
+      note: null,
+      position: index,
+      stops_count: stops.length,
+      stops,
+      created_at: "2026-09-01T00:00:00Z",
+      updated_at: "2026-09-01T00:00:00Z",
+    })),
+  })
+
+  it("resolves stops across every section in a single batch per type", async () => {
+    const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
+
+    const itinerary = buildItinerary([
+      [buildStop({ item_type: "PartnerShow", item_id: "show-1" })],
+      [buildStop({ item_type: "PartnerShow", item_id: "show-1" })],
+    ])
+
+    await attachStopItems(itinerary, { showsLoader } as any)
+
+    expect(showsLoader).toHaveBeenCalledTimes(1)
+    expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"] })
+
+    const resolvedItems = itinerary.sections.flatMap((section) =>
+      section.stops.map((stop: any) => stop._resolvedItem)
+    )
+    expect(resolvedItems).toEqual([
+      { _id: "show-1", __typename: "Show" },
+      { _id: "show-1", __typename: "Show" },
+    ])
+  })
+
+  it("stamps null onto a stop with no item reference", async () => {
+    const itinerary = buildItinerary([[buildStop({})]])
+
+    await attachStopItems(itinerary, {} as any)
+
+    expect((itinerary.sections[0].stops[0] as any)._resolvedItem).toBeNull()
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -31,9 +31,9 @@ const buildStop = (
 describe("loadStopItems", () => {
   it("batches ids by type, calling each loader at most once", async () => {
     const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
-    const partnerLocationByIdLoader = jest
+    const partnerLocationsByIdsLoader = jest
       .fn()
-      .mockResolvedValue({ _id: "location-1" })
+      .mockResolvedValue([{ id: "location-1" }])
     const fairsLoader = jest
       .fn()
       .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} })
@@ -48,14 +48,16 @@ describe("loadStopItems", () => {
 
     const map = await loadStopItems(stops, {
       showsLoader,
-      partnerLocationByIdLoader,
+      partnerLocationsByIdsLoader,
       fairsLoader,
     } as any)
 
     expect(showsLoader).toHaveBeenCalledTimes(1)
     expect(showsLoader).toHaveBeenCalledWith({ id: ["show-1"] })
-    expect(partnerLocationByIdLoader).toHaveBeenCalledTimes(1)
-    expect(partnerLocationByIdLoader).toHaveBeenCalledWith("location-1")
+    expect(partnerLocationsByIdsLoader).toHaveBeenCalledTimes(1)
+    expect(partnerLocationsByIdsLoader).toHaveBeenCalledWith({
+      id: ["location-1"],
+    })
     expect(fairsLoader).toHaveBeenCalledTimes(1)
     expect(fairsLoader).toHaveBeenCalledWith({ id: ["fair-1"] })
 
@@ -64,7 +66,7 @@ describe("loadStopItems", () => {
       __typename: "Show",
     })
     expect(map.get("PartnerLocation:location-1")).toEqual({
-      _id: "location-1",
+      id: "location-1",
       __typename: "PartnerLocation",
     })
     expect(map.get("Fair:fair-1")).toEqual({
@@ -83,15 +85,13 @@ describe("loadStopItems", () => {
     expect(map.get("Fair:gone")).toBeUndefined()
   })
 
-  it("leaves out a location that 404s rather than failing the itinerary", async () => {
-    const partnerLocationByIdLoader = jest
-      .fn()
-      .mockRejectedValue(new Error("Not Found"))
+  it("leaves a location missing from the batch response out of the map", async () => {
+    const partnerLocationsByIdsLoader = jest.fn().mockResolvedValue([])
 
     const stops = [buildStop({ item_type: "PartnerLocation", item_id: "gone" })]
 
     const map = await loadStopItems(stops, {
-      partnerLocationByIdLoader,
+      partnerLocationsByIdsLoader,
     } as any)
 
     expect(map.get("PartnerLocation:gone")).toBeUndefined()
@@ -113,6 +113,20 @@ describe("loadStopItems", () => {
     await expect(loadStopItems(stops, { fairsLoader } as any)).rejects.toThrow(
       "Gravity 500"
     )
+  })
+
+  it("propagates a location loader failure instead of swallowing it into a null item", async () => {
+    const partnerLocationsByIdsLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Gravity 500"))
+
+    const stops = [
+      buildStop({ item_type: "PartnerLocation", item_id: "loc-1" }),
+    ]
+
+    await expect(
+      loadStopItems(stops, { partnerLocationsByIdsLoader } as any)
+    ).rejects.toThrow("Gravity 500")
   })
 })
 

--- a/src/schema/v2/itinerary/itineraryStop.ts
+++ b/src/schema/v2/itinerary/itineraryStop.ts
@@ -1,0 +1,134 @@
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLUnionType,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { date } from "schema/v2/fields/date"
+import { ShowType } from "schema/v2/show"
+import { LocationType } from "schema/v2/location"
+import { FairType } from "schema/v2/fair"
+import { StopWithResolvedItem } from "./stopItems"
+
+export const ItineraryStopCategory = new GraphQLEnumType({
+  name: "ItineraryStopCategory",
+  values: {
+    MUSEUM: { value: "MUSEUM" },
+    GALLERY: { value: "GALLERY" },
+    SHOW: { value: "SHOW" },
+    FAIR: { value: "FAIR" },
+  },
+})
+
+export const ItineraryStopItem = new GraphQLUnionType({
+  name: "ItineraryStopItem",
+  types: [ShowType, LocationType, FairType],
+  // graphql-js 16 requires `resolveType` to return the type NAME, not the
+  // GraphQLObjectType itself — returning the object throws at execution
+  // time.
+  resolveType: (value) => {
+    switch (value?.__typename) {
+      case "Show":
+        return ShowType.name
+      case "PartnerLocation":
+        return LocationType.name
+      case "Fair":
+        return FairType.name
+      default:
+        return null
+    }
+  },
+})
+
+export const ItineraryStopType = new GraphQLObjectType<
+  StopWithResolvedItem,
+  ResolverContext
+>({
+  name: "ItineraryStop",
+  fields: {
+    internalID: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ id }) => id,
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ position }) => position,
+    },
+    title: {
+      description: "The editorial override for this stop's display title",
+      type: GraphQLString,
+      resolve: ({ title }) => title,
+    },
+    address: {
+      type: GraphQLString,
+      resolve: ({ address }) => address,
+    },
+    imageURL: {
+      type: GraphQLString,
+      resolve: ({ image_url }) => image_url,
+    },
+    latitude: {
+      type: GraphQLFloat,
+      resolve: ({ latitude }) => latitude,
+    },
+    longitude: {
+      type: GraphQLFloat,
+      resolve: ({ longitude }) => longitude,
+    },
+    startAt: date(({ start_at }) => start_at),
+    endAt: date(({ end_at }) => end_at),
+    timeZone: {
+      description:
+        "IANA identifier saying which wall clock startAt and endAt were " +
+        "written against, e.g. Europe/London. Pass it to those fields as " +
+        "`timezone` to render the time the curator meant.",
+      type: GraphQLString,
+      resolve: ({ time_zone }) => time_zone,
+    },
+    note: {
+      type: GraphQLString,
+      resolve: ({ note }) => note,
+    },
+    category: {
+      type: ItineraryStopCategory,
+      resolve: ({ category }) => category,
+    },
+    isFreeAdmission: {
+      type: GraphQLBoolean,
+      resolve: ({ is_free_admission }) => is_free_admission,
+    },
+    eventType: {
+      description:
+        "PartnerShowEvent on a show stop, FairEvent on a fair stop. Null " +
+        "when the stop names no event.",
+      type: GraphQLString,
+      resolve: ({ event_type }) => event_type,
+    },
+    eventID: {
+      type: GraphQLString,
+      resolve: ({ event_id }) => event_id,
+    },
+    sourceURL: {
+      description: "Where the curator found this stop",
+      type: GraphQLString,
+      resolve: ({ source_url }) => source_url,
+    },
+    item: {
+      description:
+        "The Show, gallery location, or Fair this stop refers to, if " +
+        "any. A stop " +
+        "without an `item_id` (e.g. a café) resolves to null.",
+      type: ItineraryStopItem,
+      // Resolved by `attachStopItems`, which every resolver returning an
+      // `Itinerary` must call before returning it (the root `itinerary`
+      // field and both `itinerariesConnection` resolvers). This is a
+      // lookup, not a request -- the batched fetch already happened.
+      resolve: ({ _resolvedItem }) => _resolvedItem ?? null,
+    },
+  },
+})

--- a/src/schema/v2/itinerary/itineraryStop.ts
+++ b/src/schema/v2/itinerary/itineraryStop.ts
@@ -28,9 +28,7 @@ export const ItineraryStopCategory = new GraphQLEnumType({
 export const ItineraryStopItem = new GraphQLUnionType({
   name: "ItineraryStopItem",
   types: [ShowType, LocationType, FairType],
-  // graphql-js 16 requires `resolveType` to return the type NAME, not the
-  // GraphQLObjectType itself — returning the object throws at execution
-  // time.
+  // Must return the type NAME, not the GraphQLObjectType itself.
   resolveType: (value) => {
     switch (value?.__typename) {
       case "Show":
@@ -124,10 +122,8 @@ export const ItineraryStopType = new GraphQLObjectType<
         "any. A stop " +
         "without an `item_id` (e.g. a café) resolves to null.",
       type: ItineraryStopItem,
-      // Resolved by `attachStopItems`, which every resolver returning an
-      // `Itinerary` must call before returning it (the root `itinerary`
-      // field and both `itinerariesConnection` resolvers). This is a
-      // lookup, not a request -- the batched fetch already happened.
+      // `_resolvedItem` is filled by `attachStopItems`, which every
+      // resolver returning an `Itinerary` must call first.
       resolve: ({ _resolvedItem }) => _resolvedItem ?? null,
     },
   },

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -9,9 +9,16 @@ const LOADER_BY_ITEM_TYPE: Record<
     loaderKey: "showsLoader" | "fairsLoader" | "partnerLocationsByIdsLoader"
     typename: string
     idKey: "_id" | "id"
+    extraParams?: Record<string, unknown>
   }
 > = {
-  PartnerShow: { loaderKey: "showsLoader", typename: "Show", idKey: "_id" },
+  // Gravity's shows index excludes is_local_discovery shows by default.
+  PartnerShow: {
+    loaderKey: "showsLoader",
+    typename: "Show",
+    idKey: "_id",
+    extraParams: { include_local_discovery: true },
+  },
   Fair: { loaderKey: "fairsLoader", typename: "Fair", idKey: "_id" },
   PartnerLocation: {
     loaderKey: "partnerLocationsByIdsLoader",
@@ -57,11 +64,17 @@ export const loadStopItems = async (
       const ids = Array.from(idsByType[itemType])
       if (ids.length === 0) return
 
-      const { loaderKey, typename, idKey } = LOADER_BY_ITEM_TYPE[itemType]
+      const { loaderKey, typename, idKey, extraParams } = LOADER_BY_ITEM_TYPE[
+        itemType
+      ]
       const loader = context[loaderKey]
       if (!loader) return
 
-      const result = await loader({ id: ids, size: ids.length })
+      const result = await loader({
+        id: ids,
+        size: ids.length,
+        ...extraParams,
+      })
       const records: any[] = Array.isArray(result) ? result : result.body
 
       for (const record of records) {

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -4,14 +4,18 @@ import { GravityItinerary, GravityItineraryStop } from "./types"
 type StopItemType = "PartnerShow" | "PartnerLocation" | "Fair"
 
 const LOADER_BY_ITEM_TYPE: Record<
-  "PartnerShow" | "Fair",
+  StopItemType,
   {
-    loaderKey: "showsLoader" | "fairsLoader"
+    loaderKey: "showsLoader" | "fairsLoader" | "partnerLocationsByIdsLoader"
     typename: string
   }
 > = {
   PartnerShow: { loaderKey: "showsLoader", typename: "Show" },
   Fair: { loaderKey: "fairsLoader", typename: "Fair" },
+  PartnerLocation: {
+    loaderKey: "partnerLocationsByIdsLoader",
+    typename: "PartnerLocation",
+  },
 }
 
 const isStopItemType = (value: string | null): value is StopItemType =>
@@ -47,41 +51,26 @@ export const loadStopItems = async (
 
   const map = new Map<string, ResolvedStopItem>()
 
-  const fetches = (["PartnerShow", "Fair"] as const).map(async (itemType) => {
-    const ids = Array.from(idsByType[itemType])
-    if (ids.length === 0) return
+  const fetches = (["PartnerShow", "Fair", "PartnerLocation"] as const).map(
+    async (itemType) => {
+      const ids = Array.from(idsByType[itemType])
+      if (ids.length === 0) return
 
-    const { loaderKey, typename } = LOADER_BY_ITEM_TYPE[itemType]
-    const loader = context[loaderKey]
-    if (!loader) return
+      const { loaderKey, typename } = LOADER_BY_ITEM_TYPE[itemType]
+      const loader = context[loaderKey]
+      if (!loader) return
 
-    const result = await loader({ id: ids })
-    const records: any[] = Array.isArray(result) ? result : result.body
+      const result = await loader({ id: ids })
+      const records: any[] = Array.isArray(result) ? result : result.body
 
-    for (const record of records) {
-      map.set(mapKey(itemType, record._id), {
-        ...record,
-        __typename: typename,
-      })
+      for (const record of records) {
+        map.set(mapKey(itemType, record._id ?? record.id), {
+          ...record,
+          __typename: typename,
+        })
+      }
     }
-  })
-
-  // Gravity has no batch route for locations, so these go one request each.
-  const locationIds = Array.from(idsByType.PartnerLocation)
-  const locationLoader = context.partnerLocationByIdLoader
-  if (locationIds.length > 0 && locationLoader) {
-    await Promise.all(
-      locationIds.map(async (id) => {
-        const location = await locationLoader(id).catch(() => null)
-        if (location) {
-          map.set(mapKey("PartnerLocation", id), {
-            ...location,
-            __typename: "PartnerLocation",
-          })
-        }
-      })
-    )
-  }
+  )
 
   await Promise.all(fetches)
 

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -1,0 +1,150 @@
+import { ResolverContext } from "types/graphql"
+import { GravityItinerary, GravityItineraryStop } from "./types"
+
+/**
+ * The three entity kinds a stop's `item_type` can name. `PartnerShow` maps
+ * to `ShowType` (Gravity's `shows` endpoint is keyed on the show, not the
+ * `PartnerShow` join model — `showsLoader` is the right loader for it).
+ */
+type StopItemType = "PartnerShow" | "PartnerLocation" | "Fair"
+
+const LOADER_BY_ITEM_TYPE: Record<
+  "PartnerShow" | "Fair",
+  {
+    loaderKey: "showsLoader" | "fairsLoader"
+    typename: string
+  }
+> = {
+  PartnerShow: { loaderKey: "showsLoader", typename: "Show" },
+  Fair: { loaderKey: "fairsLoader", typename: "Fair" },
+}
+
+const isStopItemType = (value: string | null): value is StopItemType =>
+  value === "PartnerShow" || value === "PartnerLocation" || value === "Fair"
+
+const mapKey = (itemType: string, itemId: string) => `${itemType}:${itemId}`
+
+/** A resolved Show/Partner/Fair, tagged so `ItineraryStopItem`'s
+ * `resolveType` can key off `__typename` the same way it already does for
+ * fixture data. */
+export type ResolvedStopItem = Record<string, unknown> & { __typename: string }
+
+export type StopWithResolvedItem = GravityItineraryStop & {
+  _resolvedItem?: ResolvedStopItem | null
+}
+
+/**
+ * Batch-resolves every stop's `item_type` / `item_id` into the referenced
+ * Show, Partner, or Fair, issuing at most one loader call per type no
+ * matter how many stops reference that type. Returns a map keyed by
+ * `"<item_type>:<item_id>"`.
+ *
+ * A missing/unwired loader (e.g. an unauthenticated test context that never
+ * stubbed one) is treated as "nothing to resolve" and skipped, matching the
+ * `if (!someLoader) return null` guard used elsewhere in this codebase
+ * (e.g. `collectionsConnection`). A loader that IS called and rejects
+ * (timeout, Gravity 500) is left to reject `Promise.all` and propagate —
+ * that failure must surface as a GraphQL error, not a null `item`.
+ */
+export const loadStopItems = async (
+  stops: GravityItineraryStop[],
+  context: ResolverContext
+): Promise<Map<string, ResolvedStopItem>> => {
+  const idsByType: Record<StopItemType, Set<string>> = {
+    PartnerShow: new Set(),
+    PartnerLocation: new Set(),
+    Fair: new Set(),
+  }
+
+  for (const { item_type, item_id } of stops) {
+    if (item_id && isStopItemType(item_type)) {
+      idsByType[item_type].add(item_id)
+    }
+  }
+
+  const map = new Map<string, ResolvedStopItem>()
+
+  const fetches = (["PartnerShow", "Fair"] as const).map(async (itemType) => {
+    const ids = Array.from(idsByType[itemType])
+    if (ids.length === 0) return
+
+    const { loaderKey, typename } = LOADER_BY_ITEM_TYPE[itemType]
+    const loader = context[loaderKey]
+    if (!loader) return
+
+    // `showsLoader` resolves directly to an array; `partnersLoader` and
+    // `fairsLoader` resolve to `{ body, headers }`, matching each
+    // loader's shape elsewhere in the schema (e.g.
+    // `notifications/index.ts` vs. `fairs.ts`).
+    const result = await loader({ id: ids })
+    const records: any[] = Array.isArray(result) ? result : result.body
+
+    // Gravity's `.in(_id: params[:id])` returns matches unordered, and a
+    // deleted entity simply doesn't come back — that stop's `item`
+    // resolves to null further down, which is correct: a published guide
+    // can outlive one of its shows.
+    for (const record of records) {
+      map.set(mapKey(itemType, record._id), {
+        ...record,
+        __typename: typename,
+      })
+    }
+  })
+
+  // Gravity has no batch route for locations — `partner_location/:id` takes
+  // one id — so these go one request per location rather than one per type.
+  // A guide holds a handful of gallery stops, so that is a few parallel
+  // calls, not a fan-out worth batching around.
+  const locationIds = Array.from(idsByType.PartnerLocation)
+  const locationLoader = context.partnerLocationByIdLoader
+  if (locationIds.length > 0 && locationLoader) {
+    await Promise.all(
+      locationIds.map(async (id) => {
+        // A location that has been deleted, or made private since the guide
+        // was written, 404s or 403s. That stop's `item` resolves to null,
+        // the same as a deleted show — one dead reference must not fail the
+        // whole guide.
+        const location = await locationLoader(id).catch(() => null)
+        if (location) {
+          map.set(mapKey("PartnerLocation", id), {
+            ...location,
+            __typename: "PartnerLocation",
+          })
+        }
+      })
+    )
+  }
+
+  await Promise.all(fetches)
+
+  return map
+}
+
+/**
+ * Flattens every stop across every section of an itinerary, resolves their
+ * items in one batch per type, and stamps the result onto each stop as
+ * `_resolvedItem` for `ItineraryStop.item` to read back synchronously.
+ *
+ * Must be called by every resolver that returns an `Itinerary` — the root
+ * `itinerary` field and both `itinerariesConnection` resolvers — or `item`
+ * resolves to null on every stop even though the query otherwise succeeds.
+ */
+export const attachStopItems = async (
+  itinerary: GravityItinerary,
+  context: ResolverContext
+): Promise<GravityItinerary> => {
+  const stops: StopWithResolvedItem[] = itinerary.sections.flatMap(
+    (section) => section.stops
+  )
+
+  const itemsByKey = await loadStopItems(stops, context)
+
+  for (const stop of stops) {
+    stop._resolvedItem =
+      stop.item_id && isStopItemType(stop.item_type)
+        ? itemsByKey.get(mapKey(stop.item_type, stop.item_id)) ?? null
+        : null
+  }
+
+  return itinerary
+}

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -1,11 +1,6 @@
 import { ResolverContext } from "types/graphql"
 import { GravityItinerary, GravityItineraryStop } from "./types"
 
-/**
- * The three entity kinds a stop's `item_type` can name. `PartnerShow` maps
- * to `ShowType` (Gravity's `shows` endpoint is keyed on the show, not the
- * `PartnerShow` join model — `showsLoader` is the right loader for it).
- */
 type StopItemType = "PartnerShow" | "PartnerLocation" | "Fair"
 
 const LOADER_BY_ITEM_TYPE: Record<
@@ -24,28 +19,16 @@ const isStopItemType = (value: string | null): value is StopItemType =>
 
 const mapKey = (itemType: string, itemId: string) => `${itemType}:${itemId}`
 
-/** A resolved Show/Partner/Fair, tagged so `ItineraryStopItem`'s
- * `resolveType` can key off `__typename` the same way it already does for
- * fixture data. */
+// A resolved Show/Partner/Fair, tagged for `ItineraryStopItem.resolveType`.
 export type ResolvedStopItem = Record<string, unknown> & { __typename: string }
 
 export type StopWithResolvedItem = GravityItineraryStop & {
   _resolvedItem?: ResolvedStopItem | null
 }
 
-/**
- * Batch-resolves every stop's `item_type` / `item_id` into the referenced
- * Show, Partner, or Fair, issuing at most one loader call per type no
- * matter how many stops reference that type. Returns a map keyed by
- * `"<item_type>:<item_id>"`.
- *
- * A missing/unwired loader (e.g. an unauthenticated test context that never
- * stubbed one) is treated as "nothing to resolve" and skipped, matching the
- * `if (!someLoader) return null` guard used elsewhere in this codebase
- * (e.g. `collectionsConnection`). A loader that IS called and rejects
- * (timeout, Gravity 500) is left to reject `Promise.all` and propagate —
- * that failure must surface as a GraphQL error, not a null `item`.
- */
+// Batch-resolves every stop's item into the referenced Show, Partner, or
+// Fair, at most one loader call per type. Returns a map keyed by
+// `"<item_type>:<item_id>"`.
 export const loadStopItems = async (
   stops: GravityItineraryStop[],
   context: ResolverContext
@@ -72,17 +55,9 @@ export const loadStopItems = async (
     const loader = context[loaderKey]
     if (!loader) return
 
-    // `showsLoader` resolves directly to an array; `partnersLoader` and
-    // `fairsLoader` resolve to `{ body, headers }`, matching each
-    // loader's shape elsewhere in the schema (e.g.
-    // `notifications/index.ts` vs. `fairs.ts`).
     const result = await loader({ id: ids })
     const records: any[] = Array.isArray(result) ? result : result.body
 
-    // Gravity's `.in(_id: params[:id])` returns matches unordered, and a
-    // deleted entity simply doesn't come back — that stop's `item`
-    // resolves to null further down, which is correct: a published guide
-    // can outlive one of its shows.
     for (const record of records) {
       map.set(mapKey(itemType, record._id), {
         ...record,
@@ -91,19 +66,12 @@ export const loadStopItems = async (
     }
   })
 
-  // Gravity has no batch route for locations — `partner_location/:id` takes
-  // one id — so these go one request per location rather than one per type.
-  // A guide holds a handful of gallery stops, so that is a few parallel
-  // calls, not a fan-out worth batching around.
+  // Gravity has no batch route for locations, so these go one request each.
   const locationIds = Array.from(idsByType.PartnerLocation)
   const locationLoader = context.partnerLocationByIdLoader
   if (locationIds.length > 0 && locationLoader) {
     await Promise.all(
       locationIds.map(async (id) => {
-        // A location that has been deleted, or made private since the guide
-        // was written, 404s or 403s. That stop's `item` resolves to null,
-        // the same as a deleted show — one dead reference must not fail the
-        // whole guide.
         const location = await locationLoader(id).catch(() => null)
         if (location) {
           map.set(mapKey("PartnerLocation", id), {
@@ -120,15 +88,8 @@ export const loadStopItems = async (
   return map
 }
 
-/**
- * Flattens every stop across every section of an itinerary, resolves their
- * items in one batch per type, and stamps the result onto each stop as
- * `_resolvedItem` for `ItineraryStop.item` to read back synchronously.
- *
- * Must be called by every resolver that returns an `Itinerary` — the root
- * `itinerary` field and both `itinerariesConnection` resolvers — or `item`
- * resolves to null on every stop even though the query otherwise succeeds.
- */
+// Must be called by every resolver that returns an `Itinerary`, or `item`
+// resolves to null on every stop.
 export const attachStopItems = async (
   itinerary: GravityItinerary,
   context: ResolverContext

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -8,13 +8,15 @@ const LOADER_BY_ITEM_TYPE: Record<
   {
     loaderKey: "showsLoader" | "fairsLoader" | "partnerLocationsByIdsLoader"
     typename: string
+    idKey: "_id" | "id"
   }
 > = {
-  PartnerShow: { loaderKey: "showsLoader", typename: "Show" },
-  Fair: { loaderKey: "fairsLoader", typename: "Fair" },
+  PartnerShow: { loaderKey: "showsLoader", typename: "Show", idKey: "_id" },
+  Fair: { loaderKey: "fairsLoader", typename: "Fair", idKey: "_id" },
   PartnerLocation: {
     loaderKey: "partnerLocationsByIdsLoader",
     typename: "PartnerLocation",
+    idKey: "id",
   },
 }
 
@@ -23,20 +25,21 @@ const isStopItemType = (value: string | null): value is StopItemType =>
 
 const mapKey = (itemType: string, itemId: string) => `${itemType}:${itemId}`
 
-// A resolved Show/Partner/Fair, tagged for `ItineraryStopItem.resolveType`.
+// A resolved Show, Location, or Fair, tagged for `ItineraryStopItem.resolveType`.
 export type ResolvedStopItem = Record<string, unknown> & { __typename: string }
 
 export type StopWithResolvedItem = GravityItineraryStop & {
   _resolvedItem?: ResolvedStopItem | null
 }
 
-// Batch-resolves every stop's item into the referenced Show, Partner, or
-// Fair, at most one loader call per type. Returns a map keyed by
-// `"<item_type>:<item_id>"`.
+// One loader call per item type; returns a map keyed "<item_type>:<item_id>".
 export const loadStopItems = async (
   stops: GravityItineraryStop[],
   context: ResolverContext
 ): Promise<Map<string, ResolvedStopItem>> => {
+  const map = new Map<string, ResolvedStopItem>()
+  if (stops.length === 0) return map
+
   const idsByType: Record<StopItemType, Set<string>> = {
     PartnerShow: new Set(),
     PartnerLocation: new Set(),
@@ -49,22 +52,20 @@ export const loadStopItems = async (
     }
   }
 
-  const map = new Map<string, ResolvedStopItem>()
-
   const fetches = (["PartnerShow", "Fair", "PartnerLocation"] as const).map(
     async (itemType) => {
       const ids = Array.from(idsByType[itemType])
       if (ids.length === 0) return
 
-      const { loaderKey, typename } = LOADER_BY_ITEM_TYPE[itemType]
+      const { loaderKey, typename, idKey } = LOADER_BY_ITEM_TYPE[itemType]
       const loader = context[loaderKey]
       if (!loader) return
 
-      const result = await loader({ id: ids })
+      const result = await loader({ id: ids, size: ids.length })
       const records: any[] = Array.isArray(result) ? result : result.body
 
       for (const record of records) {
-        map.set(mapKey(itemType, record._id ?? record.id), {
+        map.set(mapKey(itemType, record[idKey]), {
           ...record,
           __typename: typename,
         })
@@ -77,14 +78,14 @@ export const loadStopItems = async (
   return map
 }
 
-// Must be called by every resolver that returns an `Itinerary`, or `item`
-// resolves to null on every stop.
-export const attachStopItems = async (
-  itinerary: GravityItinerary,
+// Call from every resolver that returns Itinerary nodes, once per page.
+// Tolerates list payloads with no sections.
+export const attachStopItemsToMany = async <T extends GravityItinerary>(
+  itineraries: T[],
   context: ResolverContext
-): Promise<GravityItinerary> => {
-  const stops: StopWithResolvedItem[] = itinerary.sections.flatMap(
-    (section) => section.stops
+): Promise<T[]> => {
+  const stops: StopWithResolvedItem[] = itineraries.flatMap((itinerary) =>
+    (itinerary.sections ?? []).flatMap((section) => section.stops ?? [])
   )
 
   const itemsByKey = await loadStopItems(stops, context)
@@ -96,5 +97,13 @@ export const attachStopItems = async (
         : null
   }
 
-  return itinerary
+  return itineraries
+}
+
+export const attachStopItems = async (
+  itinerary: GravityItinerary,
+  context: ResolverContext
+): Promise<GravityItinerary> => {
+  const [attached] = await attachStopItemsToMany([itinerary], context)
+  return attached
 }

--- a/src/schema/v2/itinerary/types.ts
+++ b/src/schema/v2/itinerary/types.ts
@@ -1,9 +1,4 @@
-/**
- * The shapes Gravity's itinerary endpoints return, in the snake_case they
- * arrive in. These mirror `json_properties` on `Itinerary`,
- * `ItinerarySection` and `ItineraryStop` — if a field is missing here, check
- * the model rather than assuming Gravity sends it.
- */
+// The shapes Gravity's itinerary endpoints return, in snake_case.
 
 export interface GravityItineraryStop {
   id: string

--- a/src/schema/v2/itinerary/types.ts
+++ b/src/schema/v2/itinerary/types.ts
@@ -1,0 +1,72 @@
+/**
+ * The shapes Gravity's itinerary endpoints return, in the snake_case they
+ * arrive in. These mirror `json_properties` on `Itinerary`,
+ * `ItinerarySection` and `ItineraryStop` — if a field is missing here, check
+ * the model rather than assuming Gravity sends it.
+ */
+
+export interface GravityItineraryStop {
+  id: string
+  itinerary_section_id: string
+  position: number
+  /** One of `PartnerShow`, `PartnerLocation`, `Fair`. Null for a custom stop. */
+  item_type: string | null
+  item_id: string | null
+  /** `PartnerShowEvent` or `FairEvent`, and only on a show or fair stop. */
+  event_type: string | null
+  event_id: string | null
+  /** Overrides the item's name. Required when there is no item. */
+  title: string | null
+  address: string | null
+  image_url: string | null
+  latitude: number | null
+  longitude: number | null
+  start_at: string | null
+  end_at: string | null
+  /** IANA identifier saying which wall clock start_at/end_at were written against. */
+  time_zone: string | null
+  note: string | null
+  category: string | null
+  is_free_admission: boolean | null
+  source_url: string | null
+  created_at: string
+  updated_at: string
+}
+
+export interface GravityItinerarySection {
+  id: string
+  itinerary_id: string
+  title: string | null
+  note: string | null
+  position: number
+  stops_count: number
+  stops: GravityItineraryStop[]
+  created_at: string
+  updated_at: string
+}
+
+export interface GravityItinerary {
+  id: string
+  /** Only a published, curated guide has one. */
+  slug: string | null
+  user_id: string
+  city_slug: string
+  title: string
+  subtitle: string | null
+  description: string | null
+  author_name: string | null
+  is_curated: boolean
+  /** Gravity derives this from published_at and share_token. */
+  visibility: string
+  published_at: string | null
+  published_by_id: string | null
+  share_token: string | null
+  sections_count: number
+  sections: GravityItinerarySection[]
+  /** Templated URL with a `:version` placeholder. */
+  image_url: string | null
+  /** Version name to URL. Its keys are the available versions. */
+  image_urls: Record<string, string> | null
+  created_at: string
+  updated_at: string
+}


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-24

This is PR 2a of the split of #7884, and stacks on #7885.

This PR depends on artsy/gravity#20512 (`partner_locations?id[]=`), which must be deployed before it ships.

Files:
- `src/schema/v2/itinerary/types.ts`
- `src/schema/v2/itinerary/itineraryStop.ts`
- `src/schema/v2/itinerary/stopItems.ts`
- `src/schema/v2/itinerary/__tests__/stopItems.test.ts`
- `src/lib/loaders/loaders_without_authentication/gravity.ts`
- `src/lib/loaders/loaders_with_authentication/gravity.ts`

The two loader files carry only the `partnerLocationsByIdsLoader` entry (named that way because `partnerLocationsLoader` already means `partner/:id/locations`). The stop item resolver in `stopItems.ts` is its only consumer, so it belongs in this PR rather than waiting for a later one. The other two itinerary loaders, `itineraryLoader` and `itinerariesLoader`, come in PR 3a.

Nothing here is reachable from the schema yet, so `_schemaV2.graphql` does not change.

Design decisions a reviewer will otherwise flag as mistakes:

1. A gallery stop's item resolves to a `Location`, not a `Partner`. A partner can have many spaces and no single pin, so the stop points at one `PartnerLocation` and inherits that space's address and hours. Gravity's `item_type` values are `PartnerShow`, `PartnerLocation`, and `Fair`.

2. Locations now batch through `partner_locations?id[]=` exactly like shows and fairs: one Gravity call per item type per itinerary. Each batch passes `size: ids.length` so Gravity's default page size cannot drop ids. The shows batch also passes `include_local_discovery: true` because Gravity's index hides local discovery shows by default.

3. A stop whose item fails to resolve still keeps its own fields. Gravity omits unknown or unauthorized ids from the batch response, so a deleted show or a private location simply leaves `item` null, with no error handling needed in Metaphysics. A Gravity outage rejects the loader and propagates for all three item types.

4. `eventType` and `eventID` are exposed on the stop, but there is no resolved `event` field yet. Gravity has no root route for show events, and fair events sit under the fair. Resolving the event is a later addition, not something missed here.

5. `isFreeAdmission` is three-valued on a stop, and it overrides the show's own value when set. `null` means the stop inherits the show's value instead of overriding it.

6. `attachStopItemsToMany` resolves a whole page of itineraries with one Gravity call per item type, and tolerates Gravity's list payloads, which carry no `sections`.

Verify: `yarn jest src/schema/v2/itinerary/__tests__/stopItems.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
