### PR TITLE
feat: add Itinerary and ItinerarySection types

### DIFF
--- a/src/schema/v2/itinerary/itinerary.ts
+++ b/src/schema/v2/itinerary/itinerary.ts
@@ -24,15 +24,11 @@ export const ItineraryVisibilityEnum = new GraphQLEnumType({
   },
 })
 
-// Derived from published_at / share_token — Gravity has no visibility column.
-const deriveVisibility = ({
-  published_at,
-  share_token,
-}: GravityItinerary): "PRIVATE" | "UNLISTED" | "PUBLIC" => {
-  if (published_at) return "PUBLIC"
-  if (share_token) return "UNLISTED"
-  return "PRIVATE"
-}
+const VISIBILITY_BY_GRAVITY = {
+  private: "PRIVATE",
+  unlisted: "UNLISTED",
+  public: "PUBLIC",
+} as const
 
 export const ItineraryType = new GraphQLObjectType<
   GravityItinerary,
@@ -80,7 +76,7 @@ export const ItineraryType = new GraphQLObjectType<
     },
     visibility: {
       type: new GraphQLNonNull(ItineraryVisibilityEnum),
-      resolve: (itinerary) => deriveVisibility(itinerary),
+      resolve: ({ visibility }) => VISIBILITY_BY_GRAVITY[visibility],
     },
     shareToken: {
       type: GraphQLString,

--- a/src/schema/v2/itinerary/itinerary.ts
+++ b/src/schema/v2/itinerary/itinerary.ts
@@ -1,0 +1,136 @@
+import { sortBy } from "lodash"
+import {
+  GraphQLBoolean,
+  GraphQLEnumType,
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { GlobalIDField } from "schema/v2/object_identification"
+import { date } from "schema/v2/fields/date"
+import { ImageType } from "schema/v2/image"
+import { GravityItinerary } from "./types"
+import { ItinerarySectionType } from "./itinerarySection"
+
+export const ItineraryVisibilityEnum = new GraphQLEnumType({
+  name: "ItineraryVisibility",
+  values: {
+    PRIVATE: { value: "PRIVATE" },
+    UNLISTED: { value: "UNLISTED" },
+    PUBLIC: { value: "PUBLIC" },
+  },
+})
+
+// Gravity has no `visibility` column for itineraries — it's derived from
+// the presence of `published_at` / `share_token`:
+//   - published_at present -> PUBLIC (a published, curated guide)
+//   - else share_token present -> UNLISTED (shareable via link only)
+//   - else -> PRIVATE
+const deriveVisibility = ({
+  published_at,
+  share_token,
+}: GravityItinerary): "PRIVATE" | "UNLISTED" | "PUBLIC" => {
+  if (published_at) return "PUBLIC"
+  if (share_token) return "UNLISTED"
+  return "PRIVATE"
+}
+
+export const ItineraryType = new GraphQLObjectType<
+  GravityItinerary,
+  ResolverContext
+>({
+  name: "Itinerary",
+  fields: () => ({
+    // Deliberately not `SlugAndInternalIDFields`: that helper resolves
+    // `internalID` from `_id` (non-null) and `slug` from `id` (non-null).
+    // Gravity's itinerary payload is an ActiveRecord record — it has `id`
+    // and a genuinely-nullable `slug`, and no `_id` at all. Using the
+    // helper here would return the UUID as the slug and null for a
+    // non-nullable field.
+    id: GlobalIDField,
+    internalID: {
+      description: "The itinerary's UUID",
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ id }) => id,
+    },
+    slug: {
+      description:
+        "Only published, curated guides have a slug. Null otherwise.",
+      type: GraphQLString,
+      resolve: ({ slug }) => slug,
+    },
+    title: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ title }) => title,
+    },
+    subtitle: {
+      type: GraphQLString,
+      resolve: ({ subtitle }) => subtitle,
+    },
+    description: {
+      type: GraphQLString,
+      resolve: ({ description }) => description,
+    },
+    // Free text, not a `User` association. A public curated guide renders
+    // for anonymous readers, and Gravity's user endpoint 403s any caller
+    // who isn't the user themselves, customer support, or has the
+    // `editorial`/`partner_support` role — so an anonymous reader would get
+    // no byline at all. A copied string can go stale, but it at least
+    // always renders.
+    authorName: {
+      type: GraphQLString,
+      resolve: ({ author_name }) => author_name,
+    },
+    citySlug: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ city_slug }) => city_slug,
+    },
+    isCurated: {
+      type: new GraphQLNonNull(GraphQLBoolean),
+      resolve: ({ is_curated }) => is_curated,
+    },
+    visibility: {
+      type: new GraphQLNonNull(ItineraryVisibilityEnum),
+      resolve: (itinerary) => deriveVisibility(itinerary),
+    },
+    shareToken: {
+      type: GraphQLString,
+      resolve: ({ share_token }) => share_token,
+    },
+    // `ImageType`, not `GravityARImageType`: this is the type the rest of
+    // the schema uses for images, and it gives clients `resized(width:
+    // height:)` so the client can request the dimensions it actually needs
+    // instead of pulling the full-size hero. This deliberately diverges
+    // from `ViewingRoom`, which uses the thin type for the same kind of
+    // data — don't "fix" it back to match.
+    heroImage: {
+      type: ImageType,
+      // Gravity sends `image_url` (templated, with a `:version` placeholder)
+      // and `image_urls` (a hash keyed by version), but no `image_versions`
+      // — so derive it from the hash's keys. Without it `setVersion` finds no
+      // version and returns the raw template, `:version` and all.
+      //
+      // `resized(width:)` still cannot work: it scales from `original_width`,
+      // which Gravity does not send. Ask for `url(version:)` instead.
+      resolve: ({ image_url, image_urls }) =>
+        image_urls
+          ? { image_url, image_urls, image_versions: Object.keys(image_urls) }
+          : null,
+    },
+    publishedAt: date(({ published_at }) => published_at),
+    updatedAt: date(({ updated_at }) => updated_at),
+    sectionsCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ sections_count }) => sections_count,
+    },
+    sections: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ItinerarySectionType))
+      ),
+      resolve: ({ sections }) => sortBy(sections, "position"),
+    },
+  }),
+})

--- a/src/schema/v2/itinerary/itinerary.ts
+++ b/src/schema/v2/itinerary/itinerary.ts
@@ -24,11 +24,7 @@ export const ItineraryVisibilityEnum = new GraphQLEnumType({
   },
 })
 
-// Gravity has no `visibility` column for itineraries — it's derived from
-// the presence of `published_at` / `share_token`:
-//   - published_at present -> PUBLIC (a published, curated guide)
-//   - else share_token present -> UNLISTED (shareable via link only)
-//   - else -> PRIVATE
+// Derived from published_at / share_token — Gravity has no visibility column.
 const deriveVisibility = ({
   published_at,
   share_token,
@@ -44,12 +40,8 @@ export const ItineraryType = new GraphQLObjectType<
 >({
   name: "Itinerary",
   fields: () => ({
-    // Deliberately not `SlugAndInternalIDFields`: that helper resolves
-    // `internalID` from `_id` (non-null) and `slug` from `id` (non-null).
-    // Gravity's itinerary payload is an ActiveRecord record — it has `id`
-    // and a genuinely-nullable `slug`, and no `_id` at all. Using the
-    // helper here would return the UUID as the slug and null for a
-    // non-nullable field.
+    // Not `SlugAndInternalIDFields`: this record has `id` but no `_id`,
+    // and `slug` is genuinely nullable.
     id: GlobalIDField,
     internalID: {
       description: "The itinerary's UUID",
@@ -74,12 +66,6 @@ export const ItineraryType = new GraphQLObjectType<
       type: GraphQLString,
       resolve: ({ description }) => description,
     },
-    // Free text, not a `User` association. A public curated guide renders
-    // for anonymous readers, and Gravity's user endpoint 403s any caller
-    // who isn't the user themselves, customer support, or has the
-    // `editorial`/`partner_support` role — so an anonymous reader would get
-    // no byline at all. A copied string can go stale, but it at least
-    // always renders.
     authorName: {
       type: GraphQLString,
       resolve: ({ author_name }) => author_name,
@@ -100,21 +86,10 @@ export const ItineraryType = new GraphQLObjectType<
       type: GraphQLString,
       resolve: ({ share_token }) => share_token,
     },
-    // `ImageType`, not `GravityARImageType`: this is the type the rest of
-    // the schema uses for images, and it gives clients `resized(width:
-    // height:)` so the client can request the dimensions it actually needs
-    // instead of pulling the full-size hero. This deliberately diverges
-    // from `ViewingRoom`, which uses the thin type for the same kind of
-    // data — don't "fix" it back to match.
     heroImage: {
       type: ImageType,
-      // Gravity sends `image_url` (templated, with a `:version` placeholder)
-      // and `image_urls` (a hash keyed by version), but no `image_versions`
-      // — so derive it from the hash's keys. Without it `setVersion` finds no
-      // version and returns the raw template, `:version` and all.
-      //
-      // `resized(width:)` still cannot work: it scales from `original_width`,
-      // which Gravity does not send. Ask for `url(version:)` instead.
+      // image_versions is derived from image_urls' keys; Gravity sends no
+      // versions array.
       resolve: ({ image_url, image_urls }) =>
         image_urls
           ? { image_url, image_urls, image_versions: Object.keys(image_urls) }

--- a/src/schema/v2/itinerary/itinerarySection.ts
+++ b/src/schema/v2/itinerary/itinerarySection.ts
@@ -1,0 +1,50 @@
+import { sortBy } from "lodash"
+import {
+  GraphQLInt,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { GravityItinerarySection } from "./types"
+import { ItineraryStopType } from "./itineraryStop"
+
+export const ItinerarySectionType = new GraphQLObjectType<
+  GravityItinerarySection,
+  ResolverContext
+>({
+  name: "ItinerarySection",
+  fields: {
+    internalID: {
+      type: new GraphQLNonNull(GraphQLString),
+      resolve: ({ id }) => id,
+    },
+    title: {
+      description:
+        'An opaque display string for the section, e.g. "Day 1", ' +
+        '"Morning", or "Peckham"',
+      type: GraphQLString,
+      resolve: ({ title }) => title,
+    },
+    note: {
+      description: "An editorial note about the section, shown under its title",
+      type: GraphQLString,
+      resolve: ({ note }) => note,
+    },
+    position: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ position }) => position,
+    },
+    stopsCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve: ({ stops_count }) => stops_count,
+    },
+    stops: {
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ItineraryStopType))
+      ),
+      resolve: ({ stops }) => sortBy(stops, "position"),
+    },
+  },
+})

--- a/src/schema/v2/itinerary/types.ts
+++ b/src/schema/v2/itinerary/types.ts
@@ -52,7 +52,7 @@ export interface GravityItinerary {
   author_name: string | null
   is_curated: boolean
   /** Gravity derives this from published_at and share_token. */
-  visibility: string
+  visibility: "private" | "unlisted" | "public"
   published_at: string | null
   published_by_id: string | null
   share_token: string | null


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-25

This is PR 2b of the split of #7884, and it stacks on #7886 (PR 2a).

Files:
- `src/schema/v2/itinerary/itinerarySection.ts`
- `src/schema/v2/itinerary/itinerary.ts`

Nothing in the schema references these types yet, so `_schemaV2.graphql` does not change in this PR.

**Description points**

1. Gravity derives `visibility` from `published_at` and `share_token` and sends it on every payload; Metaphysics only maps the lowercase value to the `ItineraryVisibility` enum and keeps no second copy of the rule.

2. `authorName` is free text, not a `User` association. A public curated guide has to render for anonymous readers, and Gravity's user endpoint 403s any caller who isn't the user, support, or has an editorial/partner_support role. Resolving `authorName` through a `User` type would 403 for exactly the readers a published guide is for, so the byline is a plain string copied at write time. It can go stale, but it always renders.

3. `heroImage` derives its versions from the keys of `image_urls`. Gravity's payload has `image_url` (a template with a `:version` placeholder) and `image_urls` (a hash keyed by version) but no `image_versions` array, so the resolver builds `image_versions` from `Object.keys(image_urls)` before handing it to `ImageType`. Without that, `setVersion` finds no version to substitute and the client gets back the literal `:version` placeholder. `resized(width:)` still won't work, because it needs `original_width`, which Gravity doesn't send; clients need `url(version:)` instead. Today every real record has a null hero image, because Gravity's create and update endpoints don't take an image param yet.

4. Section `note` is a line of editorial copy shown under the section's title, separate from any notes on individual stops within that section.

Verify: `yarn type-check`. There's no dedicated test suite for these two files yet; PR 3a's `itinerary.test.ts` exercises them.

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
