### PR TITLE
feat: add itinerary(id:) root field and loaders

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23330,6 +23330,137 @@ enum InvoiceState {
   READY
 }
 
+type Itinerary {
+  authorName: String
+  citySlug: String!
+  description: String
+  heroImage: Image
+
+  """
+  A globally unique ID.
+  """
+  id: ID!
+
+  """
+  The itinerary's UUID
+  """
+  internalID: String!
+  isCurated: Boolean!
+  publishedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  sections: [ItinerarySection!]!
+  sectionsCount: Int!
+  shareToken: String
+
+  """
+  Only published, curated guides have a slug. Null otherwise.
+  """
+  slug: String
+  subtitle: String
+  title: String!
+  updatedAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  visibility: ItineraryVisibility!
+}
+
+type ItinerarySection {
+  internalID: String!
+
+  """
+  An editorial note about the section, shown under its title
+  """
+  note: String
+  position: Int!
+  stops: [ItineraryStop!]!
+  stopsCount: Int!
+
+  """
+  An opaque display string for the section, e.g. "Day 1", "Morning", or "Peckham"
+  """
+  title: String
+}
+
+type ItineraryStop {
+  address: String
+  category: ItineraryStopCategory
+  endAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  eventID: String
+
+  """
+  PartnerShowEvent on a show stop, FairEvent on a fair stop. Null when the stop names no event.
+  """
+  eventType: String
+  imageURL: String
+  internalID: String!
+  isFreeAdmission: Boolean
+
+  """
+  The Show, gallery location, or Fair this stop refers to, if any. A stop without an `item_id` (e.g. a café) resolves to null.
+  """
+  item: ItineraryStopItem
+  latitude: Float
+  longitude: Float
+  note: String
+  position: Int!
+
+  """
+  Where the curator found this stop
+  """
+  sourceURL: String
+  startAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+
+  """
+  IANA identifier saying which wall clock startAt and endAt were written against, e.g. Europe/London. Pass it to those fields as `timezone` to render the time the curator meant.
+  """
+  timeZone: String
+
+  """
+  The editorial override for this stop's display title
+  """
+  title: String
+}
+
+enum ItineraryStopCategory {
+  FAIR
+  GALLERY
+  MUSEUM
+  SHOW
+}
+
+union ItineraryStopItem = Fair | Location | Show
+
+enum ItineraryVisibility {
+  PRIVATE
+  PUBLIC
+  UNLISTED
+}
+
 """
 Represents untyped JSON
 """
@@ -33776,6 +33907,21 @@ type Query {
     partnerId: String!
   ): InstagramPostConnection
   invoice(token: String!): Invoice
+
+  """
+  A City Guide itinerary
+  """
+  itinerary(
+    """
+    The internal ID or slug of the Itinerary
+    """
+    id: String!
+
+    """
+    The share token for an unlisted itinerary. Gravity returns 404 without it, so a caller who is neither the owner nor holding the token cannot tell an unlisted guide from one that does not exist.
+    """
+    shareToken: String
+  ): Itinerary
   job(id: ID!): Job!
   jobs: [Job!]!
 
@@ -43539,6 +43685,21 @@ type Viewer {
     partnerId: String!
   ): InstagramPostConnection
   invoice(token: String!): Invoice
+
+  """
+  A City Guide itinerary
+  """
+  itinerary(
+    """
+    The internal ID or slug of the Itinerary
+    """
+    id: String!
+
+    """
+    The share token for an unlisted itinerary. Gravity returns 404 without it, so a caller who is neither the owner nor holding the token cannot tell an unlisted guide from one that does not exist.
+    """
+    shareToken: String
+  ): Itinerary
   job(id: ID!): Job!
   jobs: [Job!]!
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1445,6 +1445,9 @@ export default (accessToken, userID, opts) => {
     ),
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     showLoader: gravityLoader((id) => `show/${id}`),
+    // Authenticated so a signed-in caller also sees their own private and unlisted itineraries.
+    itineraryLoader: gravityLoader((id) => `itinerary/${id}`),
+    itinerariesLoader: gravityLoader("itineraries", {}, { headers: true }),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     partnerShowLoader: gravityLoader<
       any,

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -335,6 +335,8 @@ export default (opts) => {
     setsLoader: gravityLoader("sets", {}, { headers: true }),
     shortcutLoader: gravityLoader((id) => `shortcut/${id}`),
     showLoader: gravityLoader((id) => `show/${id}`),
+    itineraryLoader: gravityLoader((id) => `itinerary/${id}`),
+    itinerariesLoader: gravityLoader("itineraries", {}, { headers: true }),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -1,4 +1,5 @@
 import { runQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
 
 const gravityItinerary = {
   id: "b0b1c2d3-e4f5-4a6b-8c9d-0e1f2a3b4c5d",
@@ -220,14 +221,28 @@ describe("Itinerary", () => {
     })
   })
 
-  it("resolves null when Gravity does not return one", async () => {
+  it("resolves null on a Gravity 404", async () => {
     const query = `{ itinerary(id: "nope") { title } }`
 
     const data = await runQuery(query, {
-      itineraryLoader: jest.fn().mockRejectedValue(new Error("Not Found")),
+      itineraryLoader: jest
+        .fn()
+        .mockRejectedValue(new HTTPError("Not Found", 404)),
     })
 
     expect(data.itinerary).toBeNull()
+  })
+
+  it("propagates a non-404 loader failure instead of resolving null", async () => {
+    const query = `{ itinerary(id: "chill-vibes-only") { title } }`
+
+    await expect(
+      runQuery(query, {
+        itineraryLoader: jest
+          .fn()
+          .mockRejectedValue(new HTTPError("Gravity down", 500)),
+      })
+    ).rejects.toThrow("Gravity down")
   })
 
   it("passes a share token through to Gravity", async () => {

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -179,6 +179,25 @@ describe("Itinerary", () => {
     expect(custom.address).toEqual("2 Park Street, London SE1 9AB")
   })
 
+  it("maps a non-public Gravity visibility value", async () => {
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          visibility
+        }
+      }
+    `
+
+    const data = await runQuery(query, {
+      ...loaders(),
+      itineraryLoader: jest
+        .fn()
+        .mockResolvedValue({ ...gravityItinerary, visibility: "unlisted" }),
+    })
+
+    expect(data.itinerary.visibility).toEqual("UNLISTED")
+  })
+
   // Gravity sends `image_urls` keyed by version but no `image_versions`.
   it("derives the image versions from the URL hash", async () => {
     const query = `

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -1,0 +1,247 @@
+import { runQuery } from "schema/v2/test/utils"
+
+const gravityItinerary = {
+  id: "b0b1c2d3-e4f5-4a6b-8c9d-0e1f2a3b4c5d",
+  slug: "chill-vibes-only",
+  user_id: "user-1",
+  city_slug: "london-united-kingdom",
+  title: "Chill Vibes Only",
+  subtitle: "Take it slow",
+  description: "A gentle day.",
+  author_name: "Casey Lesser",
+  is_curated: true,
+  visibility: "public",
+  published_at: "2026-08-01T09:00:00Z",
+  published_by_id: "editor-1",
+  share_token: null,
+  sections_count: 1,
+  image_url:
+    "https://d32dm0rphc51dk.cloudfront.net/9f8e7d6c5b4a3f2e1d0c9b8a/:version.jpg",
+  image_urls: {
+    large:
+      "https://d32dm0rphc51dk.cloudfront.net/9f8e7d6c5b4a3f2e1d0c9b8a/large.jpg",
+    small:
+      "https://d32dm0rphc51dk.cloudfront.net/9f8e7d6c5b4a3f2e1d0c9b8a/small.jpg",
+  },
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-02T09:00:00Z",
+  sections: [
+    {
+      id: "section-1",
+      itinerary_id: "b0b1c2d3-e4f5-4a6b-8c9d-0e1f2a3b4c5d",
+      title: "Morning",
+      note: "Start early, the galleries are empty before noon.",
+      position: 0,
+      stops_count: 3,
+      created_at: "2026-08-01T09:00:00Z",
+      updated_at: "2026-08-01T09:00:00Z",
+      stops: [
+        {
+          id: "stop-1",
+          itinerary_section_id: "section-1",
+          position: 0,
+          item_type: "PartnerShow",
+          item_id: "show-1",
+          event_type: "PartnerShowEvent",
+          event_id: "event-1",
+          title: null,
+          address: null,
+          image_url: null,
+          latitude: null,
+          longitude: null,
+          start_at: "2026-09-12T10:00:00Z",
+          end_at: "2026-09-12T11:00:00Z",
+          time_zone: "Europe/London",
+          note: null,
+          category: "SHOW",
+          is_free_admission: true,
+          source_url: "https://example.com/source",
+          created_at: "2026-08-01T09:00:00Z",
+          updated_at: "2026-08-01T09:00:00Z",
+        },
+        {
+          id: "stop-2",
+          itinerary_section_id: "section-1",
+          position: 1,
+          item_type: "PartnerLocation",
+          item_id: "location-1",
+          event_type: null,
+          event_id: null,
+          title: null,
+          address: null,
+          image_url: null,
+          latitude: null,
+          longitude: null,
+          start_at: null,
+          end_at: null,
+          time_zone: null,
+          note: null,
+          category: "GALLERY",
+          is_free_admission: null,
+          source_url: null,
+          created_at: "2026-08-01T09:00:00Z",
+          updated_at: "2026-08-01T09:00:00Z",
+        },
+        {
+          id: "stop-3",
+          itinerary_section_id: "section-1",
+          position: 2,
+          item_type: null,
+          item_id: null,
+          event_type: null,
+          event_id: null,
+          title: "Coffee at Monmouth",
+          address: "2 Park Street, London SE1 9AB",
+          image_url: null,
+          latitude: 51.5055,
+          longitude: -0.0911,
+          start_at: null,
+          end_at: null,
+          time_zone: null,
+          note: "Queue moves faster than it looks.",
+          category: null,
+          is_free_admission: null,
+          source_url: null,
+          created_at: "2026-08-01T09:00:00Z",
+          updated_at: "2026-08-01T09:00:00Z",
+        },
+      ],
+    },
+  ],
+}
+
+const loaders = () => ({
+  itineraryLoader: jest.fn().mockResolvedValue(gravityItinerary),
+  showsLoader: jest.fn().mockResolvedValue([{ _id: "show-1" }]),
+  partnerLocationsByIdsLoader: jest
+    .fn()
+    .mockResolvedValue([{ id: "location-1", city: "London" }]),
+  fairsLoader: jest.fn().mockResolvedValue({ body: [], headers: {} }),
+})
+
+describe("Itinerary", () => {
+  it("maps Gravity's payload onto the type", async () => {
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          internalID
+          slug
+          title
+          subtitle
+          authorName
+          citySlug
+          isCurated
+          visibility
+          sectionsCount
+          sections {
+            title
+            note
+            position
+            stopsCount
+            stops {
+              position
+              title
+              address
+              category
+              isFreeAdmission
+              timeZone
+              sourceURL
+              eventType
+              eventID
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, loaders())
+
+    expect(data.itinerary.title).toEqual("Chill Vibes Only")
+    expect(data.itinerary.slug).toEqual("chill-vibes-only")
+    expect(data.itinerary.authorName).toEqual("Casey Lesser")
+    expect(data.itinerary.citySlug).toEqual("london-united-kingdom")
+    expect(data.itinerary.isCurated).toEqual(true)
+    expect(data.itinerary.visibility).toEqual("PUBLIC")
+
+    const section = data.itinerary.sections[0]
+    expect(section.note).toEqual(
+      "Start early, the galleries are empty before noon."
+    )
+
+    const [show, gallery, custom] = section.stops
+    expect(show.timeZone).toEqual("Europe/London")
+    expect(show.sourceURL).toEqual("https://example.com/source")
+    expect(show.eventType).toEqual("PartnerShowEvent")
+    expect(show.eventID).toEqual("event-1")
+    expect(gallery.category).toEqual("GALLERY")
+    expect(custom.title).toEqual("Coffee at Monmouth")
+    expect(custom.address).toEqual("2 Park Street, London SE1 9AB")
+  })
+
+  // Gravity sends `image_urls` keyed by version but no `image_versions`.
+  it("derives the image versions from the URL hash", async () => {
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          heroImage {
+            versions
+            url(version: "small")
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, loaders())
+
+    expect(data.itinerary.heroImage.versions).toEqual(["large", "small"])
+    expect(data.itinerary.heroImage.url).toEqual(
+      "https://d32dm0rphc51dk.cloudfront.net/9f8e7d6c5b4a3f2e1d0c9b8a/small.jpg"
+    )
+  })
+
+  it("resolves each stop's item through the batched loaders", async () => {
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          sections { stops { item { __typename } } }
+        }
+      }
+    `
+
+    const context = loaders()
+    const data = await runQuery(query, context)
+
+    const typenames = data.itinerary.sections[0].stops.map(
+      (stop) => stop.item?.__typename ?? null
+    )
+    expect(typenames).toEqual(["Show", "Location", null])
+    expect(context.partnerLocationsByIdsLoader).toHaveBeenCalledWith({
+      id: ["location-1"],
+    })
+  })
+
+  it("resolves null when Gravity does not return one", async () => {
+    const query = `{ itinerary(id: "nope") { title } }`
+
+    const data = await runQuery(query, {
+      itineraryLoader: jest.fn().mockRejectedValue(new Error("Not Found")),
+    })
+
+    expect(data.itinerary).toBeNull()
+  })
+
+  it("passes a share token through to Gravity", async () => {
+    const query = `
+      {
+        itinerary(id: "some-id", shareToken: "tok") { title }
+      }
+    `
+
+    const context = loaders()
+    await runQuery(query, context)
+
+    expect(context.itineraryLoader).toHaveBeenCalledWith("some-id", {
+      share_token: "tok",
+    })
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -218,6 +218,7 @@ describe("Itinerary", () => {
     expect(typenames).toEqual(["Show", "Location", null])
     expect(context.partnerLocationsByIdsLoader).toHaveBeenCalledWith({
       id: ["location-1"],
+      size: 1,
     })
   })
 

--- a/src/schema/v2/itinerary/index.ts
+++ b/src/schema/v2/itinerary/index.ts
@@ -1,0 +1,38 @@
+import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
+import { ResolverContext } from "types/graphql"
+import { ItineraryType } from "./itinerary"
+import { attachStopItems } from "./stopItems"
+
+export const Itinerary: GraphQLFieldConfig<void, ResolverContext> = {
+  type: ItineraryType,
+  description: "A City Guide itinerary",
+  args: {
+    id: {
+      type: new GraphQLNonNull(GraphQLString),
+      description: "The internal ID or slug of the Itinerary",
+    },
+    shareToken: {
+      description:
+        "The share token for an unlisted itinerary. Gravity returns 404 " +
+        "without it, so a caller who is neither the owner nor holding the " +
+        "token cannot tell an unlisted guide from one that does not exist.",
+      type: GraphQLString,
+    },
+  },
+  resolve: async (_root, { id, shareToken }, context) => {
+    const loader =
+      context.itineraryLoader ?? context.unauthenticatedLoaders?.itineraryLoader
+    if (!loader) return null
+
+    // Gravity 404s a private/missing itinerary; resolve null rather than erroring.
+    const itinerary = await loader(
+      id,
+      shareToken ? { share_token: shareToken } : {}
+    ).catch(() => null)
+    if (!itinerary) return null
+
+    return attachStopItems(itinerary, context)
+  },
+}
+
+export default Itinerary

--- a/src/schema/v2/itinerary/index.ts
+++ b/src/schema/v2/itinerary/index.ts
@@ -21,9 +21,7 @@ export const Itinerary: GraphQLFieldConfig<void, ResolverContext> = {
     },
   },
   resolve: async (_root, { id, shareToken }, context) => {
-    const loader =
-      context.itineraryLoader ?? context.unauthenticatedLoaders?.itineraryLoader
-    if (!loader) return null
+    const loader = context.itineraryLoader
 
     // Gravity 404s a private/missing itinerary; resolve null rather than erroring.
     const itinerary = await loader(

--- a/src/schema/v2/itinerary/index.ts
+++ b/src/schema/v2/itinerary/index.ts
@@ -1,5 +1,6 @@
 import { GraphQLFieldConfig, GraphQLNonNull, GraphQLString } from "graphql"
 import { ResolverContext } from "types/graphql"
+import { HTTPError } from "lib/HTTPError"
 import { ItineraryType } from "./itinerary"
 import { attachStopItems } from "./stopItems"
 
@@ -28,7 +29,10 @@ export const Itinerary: GraphQLFieldConfig<void, ResolverContext> = {
     const itinerary = await loader(
       id,
       shareToken ? { share_token: shareToken } : {}
-    ).catch(() => null)
+    ).catch((error) => {
+      if (error instanceof HTTPError && error.statusCode === 404) return null
+      throw error
+    })
     if (!itinerary) return null
 
     return attachStopItems(itinerary, context)

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -355,6 +355,7 @@ import { PrivateViewingRoom } from "./privateViewingRoom"
 import { ViewingRoomsConnection } from "./viewingRoomConnection"
 import { Invoice } from "./Invoice/invoice"
 import { createInvoicePaymentMutation } from "./Invoice/createInvoicePaymentMutation"
+import { Itinerary } from "./itinerary"
 import { ackTaskMutation } from "./me/ack_task_mutation"
 import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import {
@@ -534,6 +535,7 @@ const rootFields = {
   identityVerification: IdentityVerification,
   identityVerificationsConnection,
   invoice: Invoice,
+  itinerary: Itinerary,
   job,
   jobs,
   saleAgreement: SaleAgreement,


### PR DESCRIPTION
Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-26

This is PR 3a of the split of #7884. It stacks on PR 2b (#7887).

Both loader files gain `itineraryLoader` and `itinerariesLoader`. Only the first is used here; `itinerariesLoader` is consumed by the listings in #7889, which stacks on this PR. They land together so the loader files change once.

Files changed:
- `src/lib/loaders/loaders_without_authentication/gravity.ts`
- `src/lib/loaders/loaders_with_authentication/gravity.ts`
- `src/schema/v2/itinerary/index.ts`
- `src/schema/v2/itinerary/__tests__/itinerary.test.ts`
- `src/schema/v2/schema.ts`
- `_schemaV2.graphql`

This is the first PR in the split that makes anything reachable from the schema, so `_schemaV2.graphql` gains the `itinerary` root field along with the `Itinerary`, `ItinerarySection`, and `ItineraryStop` types, the `ItineraryVisibility` and `ItineraryStopCategory` enums, and the `ItineraryStopItem` union.

Behavior:
- Gravity 404s a private itinerary instead of returning 403, so a caller can never confirm one exists. A Gravity 404 resolves the field to `null`; any other loader failure (5xx, timeout) propagates as a GraphQL error, so an outage does not read as "not found".
- `shareToken` is the read capability for an unlisted itinerary. Metaphysics passes it straight through to Gravity as `share_token`; it is never stored or listed.
- When there is a viewer, the field uses the authenticated loader, so an owner or editor gets the `:all` properties (share token, publisher) and everyone else gets `:public`.

Verify: `yarn jest src/schema/v2/itinerary/__tests__/itinerary.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
