### PR TITLE
feat: add itinerariesConnection and me.itinerariesConnection

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23330,6 +23330,38 @@ enum InvoiceState {
   READY
 }
 
+"""
+A connection to a list of items.
+"""
+type ItinerariesConnection {
+  """
+  A list of edges.
+  """
+  edges: [ItinerariesEdge]
+  pageCursors: PageCursors!
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
+}
+
+"""
+An edge in a connection.
+"""
+type ItinerariesEdge {
+  """
+  A cursor for use in pagination
+  """
+  cursor: String!
+
+  """
+  The item at the end of the edge
+  """
+  node: Itinerary
+}
+
 type Itinerary {
   authorName: String
   citySlug: String!
@@ -24792,6 +24824,23 @@ type Me implements Node {
   """
   isEmailConfirmed: Boolean!
   isIdentityVerified: Boolean
+
+  """
+  A connection of the current user's own City Guide itineraries, of any visibility
+  """
+  itinerariesConnection(
+    after: String
+    before: String
+
+    """
+    Only itineraries for this city
+    """
+    citySlug: String
+    first: Int
+    last: Int
+    page: Int
+    size: Int
+  ): ItinerariesConnection
 
   """
   List of lab features for this user
@@ -33907,6 +33956,28 @@ type Query {
     partnerId: String!
   ): InstagramPostConnection
   invoice(token: String!): Invoice
+
+  """
+  A connection of City Guide itineraries
+  """
+  itinerariesConnection(
+    after: String
+    before: String
+
+    """
+    Only itineraries for this city
+    """
+    citySlug: String
+    first: Int
+
+    """
+    Only curated (editorial) or only personal itineraries
+    """
+    isCurated: Boolean
+    last: Int
+    page: Int
+    size: Int
+  ): ItinerariesConnection
 
   """
   A City Guide itinerary
@@ -43685,6 +43756,28 @@ type Viewer {
     partnerId: String!
   ): InstagramPostConnection
   invoice(token: String!): Invoice
+
+  """
+  A connection of City Guide itineraries
+  """
+  itinerariesConnection(
+    after: String
+    before: String
+
+    """
+    Only itineraries for this city
+    """
+    citySlug: String
+    first: Int
+
+    """
+    Only curated (editorial) or only personal itineraries
+    """
+    isCurated: Boolean
+    last: Int
+    page: Int
+    size: Int
+  ): ItinerariesConnection
 
   """
   A City Guide itinerary

--- a/src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts
@@ -1,0 +1,236 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+
+const itinerary = (id: string, overrides = {}) => ({
+  id,
+  slug: id,
+  user_id: "user-42",
+  city_slug: "london-united-kingdom",
+  title: `Guide ${id}`,
+  subtitle: null,
+  description: null,
+  author_name: "Casey Lesser",
+  is_curated: true,
+  visibility: "public",
+  published_at: "2026-08-01T09:00:00Z",
+  published_by_id: null,
+  share_token: null,
+  sections_count: 0,
+  image_url: null,
+  image_urls: null,
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  sections: [],
+  ...overrides,
+})
+
+const loadersReturning = (body: any[], totalCount = body.length) => ({
+  itinerariesLoader: jest.fn().mockResolvedValue({
+    body,
+    headers: { "x-total-count": String(totalCount) },
+  }),
+  showsLoader: jest.fn().mockResolvedValue([]),
+  partnerLocationByIdLoader: jest.fn().mockResolvedValue(null),
+  fairsLoader: jest.fn().mockResolvedValue({ body: [], headers: {} }),
+})
+
+const query = gql`
+  {
+    itinerariesConnection(first: 10) {
+      totalCount
+      edges {
+        node {
+          internalID
+          title
+        }
+      }
+    }
+  }
+`
+
+describe("itinerariesConnection (root field)", () => {
+  it("maps Gravity's page onto the connection", async () => {
+    const context = loadersReturning([itinerary("a"), itinerary("b")], 7)
+
+    const data = await runQuery(query, context)
+
+    expect(data.itinerariesConnection.totalCount).toEqual(7)
+    const ids = data.itinerariesConnection.edges.map((e) => e.node.internalID)
+    expect(ids).toEqual(["a", "b"])
+    expect(data.itinerariesConnection.edges[0].node.title).toEqual("Guide a")
+  })
+
+  it("asks Gravity for a total count, so the connection can report one", async () => {
+    const context = loadersReturning([])
+
+    await runQuery(query, context)
+
+    expect(context.itinerariesLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ total_count: true })
+    )
+  })
+
+  it("passes citySlug and isCurated through as Gravity's own filters", async () => {
+    const context = loadersReturning([])
+
+    await runQuery(
+      gql`
+        {
+          itinerariesConnection(
+            first: 10
+            citySlug: "london-united-kingdom"
+            isCurated: true
+          ) {
+            totalCount
+          }
+        }
+      `,
+      context
+    )
+
+    expect(context.itinerariesLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        city_slug: "london-united-kingdom",
+        is_curated: true,
+      })
+    )
+  })
+
+  // isCurated: false must be sent, not dropped as a falsy value.
+  it("passes isCurated: false rather than omitting it", async () => {
+    const context = loadersReturning([])
+
+    await runQuery(
+      gql`
+        {
+          itinerariesConnection(first: 10, isCurated: false) {
+            totalCount
+          }
+        }
+      `,
+      context
+    )
+
+    expect(context.itinerariesLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ is_curated: false })
+    )
+  })
+
+  it("sends no owner filter on the root field", async () => {
+    const context = loadersReturning([])
+
+    await runAuthenticatedQuery(query, context)
+
+    expect(context.itinerariesLoader).toHaveBeenCalledWith(
+      expect.not.objectContaining({ user_id: expect.anything() })
+    )
+  })
+
+  it("wires attachStopItems in: a returned stop's item resolves", async () => {
+    const withStop = itinerary("a", {
+      sections_count: 1,
+      sections: [
+        {
+          id: "s1",
+          itinerary_id: "a",
+          title: null,
+          note: null,
+          position: 0,
+          stops_count: 1,
+          created_at: "2026-08-01T09:00:00Z",
+          updated_at: "2026-08-01T09:00:00Z",
+          stops: [
+            {
+              id: "stop-1",
+              itinerary_section_id: "s1",
+              position: 0,
+              item_type: "PartnerShow",
+              item_id: "show-1",
+              event_type: null,
+              event_id: null,
+              title: null,
+              address: null,
+              image_url: null,
+              latitude: null,
+              longitude: null,
+              start_at: null,
+              end_at: null,
+              time_zone: null,
+              note: null,
+              category: null,
+              is_free_admission: null,
+              source_url: null,
+              created_at: "2026-08-01T09:00:00Z",
+              updated_at: "2026-08-01T09:00:00Z",
+            },
+          ],
+        },
+      ],
+    })
+
+    const context = {
+      ...loadersReturning([withStop]),
+      showsLoader: jest.fn().mockResolvedValue([{ _id: "show-1" }]),
+    }
+
+    const data = await runAuthenticatedQuery(
+      gql`
+        {
+          itinerariesConnection(first: 10) {
+            edges {
+              node {
+                sections {
+                  stops {
+                    item {
+                      __typename
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(
+      data.itinerariesConnection.edges[0].node.sections[0].stops[0].item
+        .__typename
+    ).toEqual("Show")
+  })
+})
+
+describe("Me.itinerariesConnection", () => {
+  const meQuery = gql`
+    {
+      me {
+        itinerariesConnection(first: 10) {
+          totalCount
+          edges {
+            node {
+              internalID
+            }
+          }
+        }
+      }
+    }
+  `
+
+  // Without user_id this would return every public guide as the viewer's own.
+  it("restricts the listing to the viewer by passing their user_id", async () => {
+    const context = {
+      ...loadersReturning([itinerary("mine", { is_curated: false })]),
+      meLoader: jest.fn().mockResolvedValue({ id: "user-42" }),
+    }
+
+    const data = await runAuthenticatedQuery(meQuery, context)
+
+    expect(context.itinerariesLoader).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: "user-42" })
+    )
+    expect(data.me.itinerariesConnection.edges[0].node.internalID).toEqual(
+      "mine"
+    )
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts
@@ -1,6 +1,8 @@
 import gql from "lib/gql"
 import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
 
+// Mirrors Gravity's list index (`properties: :short`), which has no
+// `sections` key; pass `sections: [...]` to opt into a detail-shaped payload.
 const itinerary = (id: string, overrides = {}) => ({
   id,
   slug: id,
@@ -20,7 +22,6 @@ const itinerary = (id: string, overrides = {}) => ({
   image_urls: null,
   created_at: "2026-08-01T09:00:00Z",
   updated_at: "2026-08-01T09:00:00Z",
-  sections: [],
   ...overrides,
 })
 
@@ -126,7 +127,7 @@ describe("itinerariesConnection (root field)", () => {
     )
   })
 
-  it("wires attachStopItems in: a returned stop's item resolves", async () => {
+  it("wires attachStopItemsToMany in: a returned stop's item resolves", async () => {
     const withStop = itinerary("a", {
       sections_count: 1,
       sections: [

--- a/src/schema/v2/itinerary/itinerariesConnection.ts
+++ b/src/schema/v2/itinerary/itinerariesConnection.ts
@@ -12,7 +12,7 @@ import {
 } from "schema/v2/fields/pagination"
 import { ResolverContext } from "types/graphql"
 import { ItineraryType } from "./itinerary"
-import { attachStopItems } from "./stopItems"
+import { attachStopItemsToMany } from "./stopItems"
 
 export const ItinerariesConnectionType = connectionWithCursorInfo({
   name: "Itineraries",
@@ -27,8 +27,6 @@ interface ItinerariesConnectionArgs extends CursorPageable {
 }
 
 interface ItinerariesConnectionOptions {
-  // Ignored when `onlyOwnedBy` is set.
-  userID?: string | null
   onlyOwnedBy?: string | null
 }
 
@@ -58,9 +56,7 @@ export const resolveItinerariesConnection = async (
 
   const totalCount = parseInt(headers["x-total-count"] || "0", 10)
 
-  await Promise.all(
-    body.map((itinerary) => attachStopItems(itinerary, context))
-  )
+  await attachStopItemsToMany(body, context)
 
   return paginationResolver({
     totalCount,
@@ -91,7 +87,7 @@ export const ItinerariesConnectionField: GraphQLFieldConfig<
     size: { type: GraphQLInt },
   }),
   resolve: (_root, args, context) =>
-    resolveItinerariesConnection(args, context, { userID: context.userID }),
+    resolveItinerariesConnection(args, context),
 }
 
 export default ItinerariesConnectionField

--- a/src/schema/v2/itinerary/itinerariesConnection.ts
+++ b/src/schema/v2/itinerary/itinerariesConnection.ts
@@ -36,10 +36,7 @@ export const resolveItinerariesConnection = async (
   context: ResolverContext,
   options: ItinerariesConnectionOptions = {}
 ) => {
-  const loader =
-    context.itinerariesLoader ??
-    context.unauthenticatedLoaders?.itinerariesLoader
-  if (!loader) return null
+  const loader = context.itinerariesLoader
 
   const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
 

--- a/src/schema/v2/itinerary/itinerariesConnection.ts
+++ b/src/schema/v2/itinerary/itinerariesConnection.ts
@@ -1,0 +1,97 @@
+import {
+  GraphQLBoolean,
+  GraphQLFieldConfig,
+  GraphQLInt,
+  GraphQLString,
+} from "graphql"
+import { CursorPageable, pageable } from "relay-cursor-paging"
+import { convertConnectionArgsToGravityArgs } from "lib/helpers"
+import {
+  connectionWithCursorInfo,
+  paginationResolver,
+} from "schema/v2/fields/pagination"
+import { ResolverContext } from "types/graphql"
+import { ItineraryType } from "./itinerary"
+import { attachStopItems } from "./stopItems"
+
+export const ItinerariesConnectionType = connectionWithCursorInfo({
+  name: "Itineraries",
+  nodeType: ItineraryType,
+}).connectionType
+
+interface ItinerariesConnectionArgs extends CursorPageable {
+  citySlug?: string
+  isCurated?: boolean
+  page?: number
+  size?: number
+}
+
+interface ItinerariesConnectionOptions {
+  // Ignored when `onlyOwnedBy` is set.
+  userID?: string | null
+  onlyOwnedBy?: string | null
+}
+
+// Shared by the root `itinerariesConnection` field and `Me.itinerariesConnection`.
+export const resolveItinerariesConnection = async (
+  args: ItinerariesConnectionArgs,
+  context: ResolverContext,
+  options: ItinerariesConnectionOptions = {}
+) => {
+  const loader =
+    context.itinerariesLoader ??
+    context.unauthenticatedLoaders?.itinerariesLoader
+  if (!loader) return null
+
+  const { page, size, offset } = convertConnectionArgsToGravityArgs(args)
+
+  const { body, headers } = await loader({
+    page,
+    size,
+    total_count: true,
+    ...(args.citySlug ? { city_slug: args.citySlug } : {}),
+    ...(typeof args.isCurated === "boolean"
+      ? { is_curated: args.isCurated }
+      : {}),
+    ...(options.onlyOwnedBy ? { user_id: options.onlyOwnedBy } : {}),
+  })
+
+  const totalCount = parseInt(headers["x-total-count"] || "0", 10)
+
+  await Promise.all(
+    body.map((itinerary) => attachStopItems(itinerary, context))
+  )
+
+  return paginationResolver({
+    totalCount,
+    offset,
+    page,
+    size,
+    body,
+    args,
+  })
+}
+
+export const ItinerariesConnectionField: GraphQLFieldConfig<
+  void,
+  ResolverContext
+> = {
+  type: ItinerariesConnectionType,
+  description: "A connection of City Guide itineraries",
+  args: pageable({
+    citySlug: {
+      type: GraphQLString,
+      description: "Only itineraries for this city",
+    },
+    isCurated: {
+      type: GraphQLBoolean,
+      description: "Only curated (editorial) or only personal itineraries",
+    },
+    page: { type: GraphQLInt },
+    size: { type: GraphQLInt },
+  }),
+  resolve: (_root, args, context) =>
+    resolveItinerariesConnection(args, context, { userID: context.userID }),
+}
+
+export default ItinerariesConnectionField

--- a/src/schema/v2/me/index.ts
+++ b/src/schema/v2/me/index.ts
@@ -69,6 +69,7 @@ import BidderStatus from "./bidder_status"
 import Bidders from "./bidders"
 import { Collection } from "./collection"
 import { CollectionsConnection } from "./collectionsConnection"
+import { MeItinerariesConnection } from "./itinerariesConnection"
 import { CreditCards } from "./credit_cards"
 import { followedProfiles } from "./followedProfiles"
 import FollowedArtists from "./followed_artists"
@@ -463,6 +464,7 @@ export const meType = new GraphQLObjectType<any, ResolverContext>({
         return introduction
       },
     },
+    itinerariesConnection: MeItinerariesConnection,
     userInterestsConnection: UserInterestsConnection,
     isCollector: {
       type: new GraphQLNonNull(GraphQLBoolean),
@@ -861,6 +863,7 @@ const MeField: GraphQLFieldConfig<void, ResolverContext> = {
       "myCollectionConnection",
       "artworkInquiriesConnection",
       "collectionsConnection",
+      "itinerariesConnection",
       "auctionResultsByFollowedArtists",
       "myCollectionAuctionResults",
       "newWorksByInterestingArtists",

--- a/src/schema/v2/me/itinerariesConnection.ts
+++ b/src/schema/v2/me/itinerariesConnection.ts
@@ -1,0 +1,35 @@
+import { GraphQLFieldConfig, GraphQLInt, GraphQLString } from "graphql"
+import { pageable } from "relay-cursor-paging"
+import { ResolverContext } from "types/graphql"
+import {
+  ItinerariesConnectionType,
+  resolveItinerariesConnection,
+} from "schema/v2/itinerary/itinerariesConnection"
+import { emptyConnection } from "schema/v2/fields/pagination"
+
+export const MeItinerariesConnection: GraphQLFieldConfig<
+  any,
+  ResolverContext
+> = {
+  type: ItinerariesConnectionType,
+  description:
+    "A connection of the current user's own City Guide itineraries, of any visibility",
+  args: pageable({
+    citySlug: {
+      type: GraphQLString,
+      description: "Only itineraries for this city",
+    },
+    page: { type: GraphQLInt },
+    size: { type: GraphQLInt },
+  }),
+  resolve: (_root, args, context) => {
+    const { userID } = context
+    if (!userID) return emptyConnection
+
+    return resolveItinerariesConnection(args, context, {
+      onlyOwnedBy: userID,
+    })
+  },
+}
+
+export default MeItinerariesConnection

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -356,6 +356,7 @@ import { ViewingRoomsConnection } from "./viewingRoomConnection"
 import { Invoice } from "./Invoice/invoice"
 import { createInvoicePaymentMutation } from "./Invoice/createInvoicePaymentMutation"
 import { Itinerary } from "./itinerary"
+import { ItinerariesConnectionField } from "./itinerary/itinerariesConnection"
 import { ackTaskMutation } from "./me/ack_task_mutation"
 import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import {
@@ -536,6 +537,7 @@ const rootFields = {
   identityVerificationsConnection,
   invoice: Invoice,
   itinerary: Itinerary,
+  itinerariesConnection: ItinerariesConnectionField,
   job,
   jobs,
   saleAgreement: SaleAgreement,


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-27

This is PR 3b of the split of #7884. It stacks on PR 3a (#7888) and adds the two listing fields for City Guide itineraries.

Files:
- `src/schema/v2/itinerary/itinerariesConnection.ts` — the root `itinerariesConnection` field and the shared resolver it calls
- `src/schema/v2/me/itinerariesConnection.ts` — `Me.itinerariesConnection`, which reuses that resolver
- `src/schema/v2/me/index.ts` — registers `itinerariesConnection` on `Me`
- `src/schema/v2/schema.ts` — registers `itinerariesConnection` as a root field
- `src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts` — tests for both fields

`_schemaV2.graphql` gains `itinerariesConnection` on `Query` and `Viewer`, `Me.itinerariesConnection`, and the `ItinerariesConnection` / `ItinerariesEdge` types. No mutation is added in this PR.

The connection resolver attaches stop items once for the whole page via `attachStopItemsToMany`, and Gravity's list payload carries no sections, so a listing costs one Gravity call.

Which itineraries a listing may contain is Gravity's decision, not ours. Gravity's predicate is "published, or the caller's own," never "public or unlisted." An unlisted itinerary is reached only by its share token, so listing one would hand out the thing the token gates. Metaphysics passes `city_slug`, `is_curated`, and `user_id` through to Gravity's loader, along with the pagination args (`page`, `size`), and re-implements no visibility check of its own. Using the authenticated `itinerariesLoader` is what makes the viewer's own itineraries show up on `Me.itinerariesConnection`; nothing in this code can widen the set Gravity returns.

Verify: `yarn jest src/schema/v2/itinerary/__tests__/itinerariesConnection.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
