### PR TITLE
feat: add itinerary mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23407,6 +23407,18 @@ type Itinerary {
   visibility: ItineraryVisibility!
 }
 
+type ItineraryMutationFailure {
+  mutationError: GravityMutationError
+}
+
+union ItineraryMutationResponseOrError =
+    ItineraryMutationFailure
+  | ItineraryMutationSuccess
+
+type ItineraryMutationSuccess {
+  itinerary: Itinerary
+}
+
 type ItinerarySection {
   internalID: String!
 
@@ -26370,6 +26382,11 @@ type Mutation {
   ): CreateSubmissionMutationPayload
 
   """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  copyItinerary(input: copyItineraryInput!): copyItineraryPayload
+
+  """
   Create an account request
   """
   createAccountRequest(
@@ -26575,6 +26592,11 @@ type Mutation {
   createInvoicePayment(
     input: CreateInvoicePaymentInput!
   ): CreateInvoicePaymentPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  createItinerary(input: createItineraryInput!): createItineraryPayload
 
   """
   Create a Mailchimp campaign draft for a partner from pre-rendered HTML
@@ -26872,6 +26894,11 @@ type Mutation {
   deleteInstagramAccount(
     input: DeleteInstagramAccountInput!
   ): DeleteInstagramAccountPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  deleteItinerary(input: deleteItineraryInput!): deleteItineraryPayload
 
   """
   Disconnect a Mailchimp account from a partner
@@ -27194,6 +27221,11 @@ type Mutation {
   ): MyCollectionUpdateArtworkPayload
 
   """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  publishItinerary(input: publishItineraryInput!): publishItineraryPayload
+
+  """
   Publish a draft navigation version. Accepts either a groupID (for backward compatibility) or versionID (preferred for admin workflows).
   """
   publishNavigationDraft(
@@ -27442,6 +27474,11 @@ type Mutation {
   ): UnlinkAuthenticationMutationPayload
 
   """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  unpublishItinerary(input: unpublishItineraryInput!): unpublishItineraryPayload
+
+  """
   Unpublishes a partner list's private viewing room. Does not delete the publication.
   """
   unpublishPartnerListPublication(
@@ -27603,6 +27640,11 @@ type Mutation {
   updateInstallShotForPartnerShow(
     input: UpdateInstallShotForPartnerShowMutationInput!
   ): UpdateInstallShotForPartnerShowMutationPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  updateItinerary(input: updateItineraryInput!): updateItineraryPayload
 
   """
   Updates the user's collections in batch.
@@ -44995,6 +45037,21 @@ enum contactType {
   PARTNER
 }
 
+input copyItineraryInput {
+  clientMutationId: String
+  id: String!
+
+  """
+  The share token of the itinerary being copied, required to copy an unlisted itinerary the caller does not own
+  """
+  shareToken: String
+}
+
+type copyItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
+}
+
 input createAlertInput {
   acquireable: Boolean
   additionalGeneIDs: [String]
@@ -45075,6 +45132,21 @@ union createHeroUnitResponseOrError =
 
 type createHeroUnitSuccess {
   heroUnit: HeroUnit
+}
+
+input createItineraryInput {
+  authorName: String
+  citySlug: String!
+  clientMutationId: String
+  description: String
+  isCurated: Boolean
+  subtitle: String
+  title: String!
+}
+
+type createItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
 }
 
 type createOrderedSetFailure {
@@ -45236,6 +45308,16 @@ type deleteHeroUnitSuccess {
   heroUnit: HeroUnit
 }
 
+input deleteItineraryInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
+}
+
 type deleteOrderedSetFailure {
   mutationError: GravityMutationError
 }
@@ -45373,6 +45455,16 @@ type dimensions {
 
 type partnerBiographyBlurb {
   text: String
+}
+
+input publishItineraryInput {
+  clientMutationId: String
+  id: String!
+}
+
+type publishItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
 }
 
 type purchases {
@@ -45532,6 +45624,16 @@ type submitOrderPayload {
   orderOrError: OrderMutationResponse
 }
 
+input unpublishItineraryInput {
+  clientMutationId: String
+  id: String!
+}
+
+type unpublishItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
+}
+
 input unsetOrderFulfillmentOptionInput {
   clientMutationId: String
 
@@ -45659,6 +45761,32 @@ union updateHeroUnitResponseOrError =
 
 type updateHeroUnitSuccess {
   heroUnit: HeroUnit
+}
+
+input updateItineraryInput {
+  authorName: String
+  citySlug: String
+  clientMutationId: String
+  description: String
+
+  """
+  Generate a new share token for this itinerary, replacing any existing one
+  """
+  generateShareToken: Boolean
+  id: String!
+  isCurated: Boolean
+
+  """
+  Revoke this itinerary's current share token, if any
+  """
+  revokeShareToken: Boolean
+  subtitle: String
+  title: String
+}
+
+type updateItineraryPayload {
+  clientMutationId: String
+  responseOrError: ItineraryMutationResponseOrError
 }
 
 input updateMeCollectionsMutationInput {

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -26382,7 +26382,7 @@ type Mutation {
   ): CreateSubmissionMutationPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Copy an itinerary into the caller's account. `shareToken` is needed for an unlisted source.
   """
   copyItinerary(input: copyItineraryInput!): copyItineraryPayload
 
@@ -26594,7 +26594,7 @@ type Mutation {
   ): CreateInvoicePaymentPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Create an itinerary.
   """
   createItinerary(input: createItineraryInput!): createItineraryPayload
 
@@ -26896,7 +26896,7 @@ type Mutation {
   ): DeleteInstagramAccountPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Delete an itinerary.
   """
   deleteItinerary(input: deleteItineraryInput!): deleteItineraryPayload
 
@@ -27221,7 +27221,7 @@ type Mutation {
   ): MyCollectionUpdateArtworkPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Publish an itinerary. Needs the publish ability.
   """
   publishItinerary(input: publishItineraryInput!): publishItineraryPayload
 
@@ -27474,7 +27474,7 @@ type Mutation {
   ): UnlinkAuthenticationMutationPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Unpublish an itinerary. Also revokes its share link, so it becomes private. Needs the publish ability.
   """
   unpublishItinerary(input: unpublishItineraryInput!): unpublishItineraryPayload
 
@@ -27642,7 +27642,7 @@ type Mutation {
   ): UpdateInstallShotForPartnerShowMutationPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Update an itinerary. Pass `generateShareToken` or `revokeShareToken` to manage its share link.
   """
   updateItinerary(input: updateItineraryInput!): updateItineraryPayload
 

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1448,6 +1448,32 @@ export default (accessToken, userID, opts) => {
     // Authenticated so a signed-in caller also sees their own private and unlisted itineraries.
     itineraryLoader: gravityLoader((id) => `itinerary/${id}`),
     itinerariesLoader: gravityLoader("itineraries", {}, { headers: true }),
+    createItineraryLoader: gravityLoader("itinerary", {}, { method: "POST" }),
+    updateItineraryLoader: gravityLoader(
+      (id) => `itinerary/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteItineraryLoader: gravityLoader(
+      (id) => `itinerary/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
+    publishItineraryLoader: gravityLoader(
+      (id) => `itinerary/${id}/publish`,
+      {},
+      { method: "POST" }
+    ),
+    unpublishItineraryLoader: gravityLoader(
+      (id) => `itinerary/${id}/unpublish`,
+      {},
+      { method: "POST" }
+    ),
+    copyItineraryLoader: gravityLoader(
+      (id) => `itinerary/${id}/copy`,
+      {},
+      { method: "POST" }
+    ),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     partnerShowLoader: gravityLoader<
       any,

--- a/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
@@ -1,0 +1,70 @@
+import { runAuthenticatedQuery } from "schema/v2/test/utils"
+
+// These mutations are deliberate stubs: each must throw rather than
+// return null or a fabricated success.
+
+const mutations: {
+  name: string
+  input: string
+  successFragment: string
+}[] = [
+  {
+    name: "createItinerary",
+    input: `citySlug: "new-york", title: "A day in Chelsea"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+  {
+    name: "updateItinerary",
+    input: `id: "itinerary-id", title: "Updated title"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+  {
+    name: "deleteItinerary",
+    input: `id: "itinerary-id"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+  {
+    name: "publishItinerary",
+    input: `id: "itinerary-id"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+  {
+    name: "unpublishItinerary",
+    input: `id: "itinerary-id"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+  {
+    name: "copyItinerary",
+    input: `id: "itinerary-id"`,
+    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
+  },
+]
+
+describe("Itinerary mutations (stubs)", () => {
+  mutations.forEach(({ name, input, successFragment }) => {
+    it(`${name} throws a not-implemented error`, async () => {
+      const mutation = `
+        mutation {
+          ${name}(input: { ${input} }) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `
+
+      await expect(runAuthenticatedQuery(mutation, {})).rejects.toThrow(
+        `${name} is not implemented yet`
+      )
+    })
+  })
+
+  it("exposes every itinerary mutation on the schema", () => {
+    const { schema } = require("schema/v2")
+    const mutationFields = schema.getMutationType()!.getFields()
+
+    mutations.forEach(({ name }) => {
+      expect(mutationFields[name]).toBeDefined()
+    })
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
@@ -1,69 +1,630 @@
-import { runAuthenticatedQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
 
-// These mutations are deliberate stubs: each must throw rather than
-// return null or a fabricated success.
+// Mirrors Gravity's `:all` itinerary JSON: sections with a stop pointing at
+// a `PartnerShow`, so `sections { stops { item } }` has something to resolve.
+const gravityItinerary = (overrides = {}) => ({
+  id: "itinerary-id",
+  slug: null,
+  user_id: "user-42",
+  city_slug: "new-york",
+  title: "A day in Chelsea",
+  subtitle: null,
+  description: null,
+  author_name: null,
+  is_curated: false,
+  visibility: "private",
+  published_at: null,
+  published_by_id: null,
+  share_token: null,
+  sections_count: 1,
+  sections: [
+    {
+      id: "section-id",
+      itinerary_id: "itinerary-id",
+      title: "Morning",
+      note: null,
+      position: 0,
+      stops_count: 1,
+      stops: [
+        {
+          id: "stop-id",
+          itinerary_section_id: "section-id",
+          position: 0,
+          item_type: "PartnerShow",
+          item_id: "show-id",
+          event_type: null,
+          event_id: null,
+          title: null,
+          address: null,
+          image_url: null,
+          latitude: null,
+          longitude: null,
+          start_at: null,
+          end_at: null,
+          time_zone: null,
+          note: null,
+          category: null,
+          is_free_admission: null,
+          source_url: null,
+          created_at: "2026-08-01T09:00:00Z",
+          updated_at: "2026-08-01T09:00:00Z",
+        },
+      ],
+      created_at: "2026-08-01T09:00:00Z",
+      updated_at: "2026-08-01T09:00:00Z",
+    },
+  ],
+  image_url: null,
+  image_urls: null,
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  ...overrides,
+})
 
-const mutations: {
-  name: string
-  input: string
-  successFragment: string
-}[] = [
-  {
-    name: "createItinerary",
-    input: `citySlug: "new-york", title: "A day in Chelsea"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-  {
-    name: "updateItinerary",
-    input: `id: "itinerary-id", title: "Updated title"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-  {
-    name: "deleteItinerary",
-    input: `id: "itinerary-id"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-  {
-    name: "publishItinerary",
-    input: `id: "itinerary-id"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-  {
-    name: "unpublishItinerary",
-    input: `id: "itinerary-id"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-  {
-    name: "copyItinerary",
-    input: `id: "itinerary-id"`,
-    successFragment: "... on ItineraryMutationSuccess { itinerary { title } }",
-  },
-]
+const gravityShortItinerary = (overrides = {}) => ({
+  id: "itinerary-id",
+  slug: null,
+  user_id: "user-42",
+  city_slug: "new-york",
+  title: "A day in Chelsea",
+  subtitle: null,
+  description: null,
+  author_name: null,
+  is_curated: false,
+  visibility: "private",
+  published_at: null,
+  published_by_id: null,
+  share_token: null,
+  sections_count: 0,
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  ...overrides,
+})
 
-describe("Itinerary mutations (stubs)", () => {
-  mutations.forEach(({ name, input, successFragment }) => {
-    it(`${name} throws a not-implemented error`, async () => {
-      const mutation = `
+const successFragment = gql`
+  ... on ItineraryMutationSuccess {
+    itinerary {
+      internalID
+      title
+      sections {
+        stops {
+          item {
+            __typename
+            ... on Show {
+              internalID
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const failureFragment = gql`
+  ... on ItineraryMutationFailure {
+    mutationError {
+      type
+      message
+      statusCode
+      fieldErrors {
+        name
+        message
+      }
+    }
+  }
+`
+
+const withShowsLoader = (loader: jest.Mock) => ({
+  showsLoader: jest.fn().mockResolvedValue({
+    body: [{ _id: "show-id", id: "show-id", name: "A Show" }],
+    headers: {},
+  }),
+  createItineraryLoader: loader,
+  updateItineraryLoader: loader,
+  deleteItineraryLoader: loader,
+  publishItineraryLoader: loader,
+  unpublishItineraryLoader: loader,
+  copyItineraryLoader: loader,
+})
+
+const paramError = new HTTPError("Bad Request", 400, {
+  type: "param_error",
+  message: "Title can't be blank.",
+  detail: { title: ["can't be blank"] },
+})
+
+const forbiddenError = new HTTPError("Forbidden", 403, { error: "Forbidden" })
+
+describe("createItinerary", () => {
+  const mutation = gql`
+    mutation {
+      createItinerary(input: { citySlug: "new-york", title: "A day in Chelsea" }) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith({
+      city_slug: "new-york",
+      title: "A day in Chelsea",
+    })
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      title: "A day in Chelsea",
+      sections: [
+        {
+          stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+        },
+      ],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItinerary.responseOrError.mutationError).toMatchObject({
+      message: "Forbidden",
+      statusCode: 403,
+    })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("updateItinerary", () => {
+  const mutation = gql`
+    mutation {
+      updateItinerary(input: { id: "itinerary-id", subtitle: null }) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes an explicit null through to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", { subtitle: null })
+  })
+
+  it("omits fields the client did not send", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
         mutation {
-          ${name}(input: { ${input} }) {
+          updateItinerary(input: { id: "itinerary-id", title: "New title" }) {
             responseOrError {
               ${successFragment}
             }
           }
         }
-      `
+      `,
+      context
+    )
 
-      await expect(runAuthenticatedQuery(mutation, {})).rejects.toThrow(
-        `${name} is not implemented yet`
-      )
+    expect(loader).toHaveBeenCalledWith("itinerary-id", { title: "New title" })
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.updateItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      sections: [
+        {
+          stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+        },
+      ],
     })
   })
 
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.updateItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.updateItinerary.responseOrError.mutationError).toMatchObject({
+      message: "Forbidden",
+      statusCode: 403,
+    })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("deleteItinerary", () => {
+  const mutation = gql`
+    mutation {
+      deleteItinerary(input: { id: "itinerary-id" }) {
+        responseOrError {
+          ... on ItineraryMutationSuccess {
+            itinerary {
+              internalID
+              title
+            }
+          }
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityShortItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", {})
+  })
+
+  it("returns the success payload", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityShortItinerary())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.deleteItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      title: "A day in Chelsea",
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.deleteItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.deleteItinerary.responseOrError.mutationError).toMatchObject({
+      message: "Forbidden",
+      statusCode: 403,
+    })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("publishItinerary", () => {
+  const mutation = gql`
+    mutation {
+      publishItinerary(input: { id: "itinerary-id" }) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(gravityItinerary({ visibility: "public" }))
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", {})
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(gravityItinerary({ visibility: "public" }))
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.publishItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      sections: [
+        {
+          stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+        },
+      ],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.publishItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.publishItinerary.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("unpublishItinerary", () => {
+  const mutation = gql`
+    mutation {
+      unpublishItinerary(input: { id: "itinerary-id" }) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", {})
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.unpublishItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      sections: [
+        {
+          stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+        },
+      ],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.unpublishItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.unpublishItinerary.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("copyItinerary", () => {
+  const mutation = gql`
+    mutation {
+      copyItinerary(input: { id: "itinerary-id", shareToken: "abc123" }) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the share token to Gravity", async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(gravityItinerary({ id: "copy-id" }))
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", {
+      share_token: "abc123",
+    })
+  })
+
+  it("sends no share token when the input omits one", async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(gravityItinerary({ id: "copy-id" }))
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          copyItinerary(input: { id: "itinerary-id" }) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader).toHaveBeenCalledWith("itinerary-id", {})
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest
+      .fn()
+      .mockResolvedValue(gravityItinerary({ id: "copy-id" }))
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.copyItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "copy-id",
+      sections: [
+        {
+          stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+        },
+      ],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.copyItinerary.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Title can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "title", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.copyItinerary.responseOrError.mutationError).toMatchObject({
+      message: "Forbidden",
+      statusCode: 403,
+    })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("schema exposure", () => {
   it("exposes every itinerary mutation on the schema", () => {
     const { schema } = require("schema/v2")
     const mutationFields = schema.getMutationType()!.getFields()
 
-    mutations.forEach(({ name }) => {
+    ;[
+      "createItinerary",
+      "updateItinerary",
+      "deleteItinerary",
+      "publishItinerary",
+      "unpublishItinerary",
+      "copyItinerary",
+    ].forEach((name) => {
       expect(mutationFields[name]).toBeDefined()
     })
   })

--- a/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts
@@ -161,6 +161,32 @@ describe("createItinerary", () => {
     })
   })
 
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          createItinerary(
+            input: {
+              citySlug: "new-york"
+              title: "A day in Chelsea"
+              clientMutationId: "abc"
+            }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][0]).not.toHaveProperty("client_mutation_id")
+  })
+
   it("returns the success payload with the resolved stop item", async () => {
     const loader = jest.fn().mockResolvedValue(gravityItinerary())
     const context = withShowsLoader(loader)
@@ -175,6 +201,21 @@ describe("createItinerary", () => {
           stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
         },
       ],
+    })
+  })
+
+  it("still returns success when stop-item enrichment fails", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = {
+      ...withShowsLoader(loader),
+      showsLoader: jest.fn().mockRejectedValue(new Error("Gravity is down")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItinerary.responseOrError.itinerary).toMatchObject({
+      internalID: "itinerary-id",
+      sections: [{ stops: [{ item: null }] }],
     })
   })
 
@@ -230,6 +271,28 @@ describe("updateItinerary", () => {
     await runAuthenticatedQuery(mutation, context)
 
     expect(loader).toHaveBeenCalledWith("itinerary-id", { subtitle: null })
+  })
+
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityItinerary())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          updateItinerary(
+            input: { id: "itinerary-id", subtitle: null, clientMutationId: "abc" }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][1]).not.toHaveProperty("client_mutation_id")
   })
 
   it("omits fields the client did not send", async () => {

--- a/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
@@ -1,0 +1,37 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  id: string
+  shareToken?: string
+}
+
+export const copyItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "copyItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    shareToken: {
+      description:
+        "The share token of the itinerary being copied, required to copy " +
+        "an unlisted itinerary the caller does not own",
+      type: GraphQLString,
+    },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("copyItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
@@ -1,6 +1,8 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
@@ -15,7 +17,8 @@ export const copyItineraryMutation = mutationWithClientMutationId<
 >({
   name: "copyItinerary",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Copy an itinerary into the caller's account. `shareToken` is needed " +
+    "for an unlisted source.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
     shareToken: {
@@ -31,7 +34,26 @@ export const copyItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("copyItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async ({ id, shareToken }, context) => {
+    if (!context.copyItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const itinerary = await context.copyItineraryLoader(
+        id,
+        shareToken ? { share_token: shareToken } : {}
+      )
+
+      return attachStopItems(itinerary, context)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/copyItineraryMutation.ts
@@ -39,13 +39,13 @@ export const copyItineraryMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let itinerary
+
     try {
-      const itinerary = await context.copyItineraryLoader(
+      itinerary = await context.copyItineraryLoader(
         id,
         shareToken ? { share_token: shareToken } : {}
       )
-
-      return attachStopItems(itinerary, context)
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -55,5 +55,8 @@ export const copyItineraryMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    return attachStopItems(itinerary, context).catch(() => itinerary)
   },
 })

--- a/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
@@ -7,6 +7,7 @@ import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   citySlug: string
   title: string
   subtitle?: string
@@ -36,17 +37,18 @@ export const createItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (input, context) => {
+  mutateAndGetPayload: async (
+    { clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.createItineraryLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
-    try {
-      const itinerary = await context.createItineraryLoader(
-        snakeCaseKeys(input)
-      )
+    let itinerary
 
-      return attachStopItems(itinerary, context)
+    try {
+      itinerary = await context.createItineraryLoader(snakeCaseKeys(attributes))
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -56,5 +58,8 @@ export const createItineraryMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    return attachStopItems(itinerary, context).catch(() => itinerary)
   },
 })

--- a/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
@@ -1,0 +1,40 @@
+import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  citySlug: string
+  title: string
+  subtitle?: string
+  description?: string
+  authorName?: string
+  isCurated?: boolean
+}
+
+export const createItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "createItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    citySlug: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: new GraphQLNonNull(GraphQLString) },
+    subtitle: { type: GraphQLString },
+    description: { type: GraphQLString },
+    authorName: { type: GraphQLString },
+    isCurated: { type: GraphQLBoolean },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("createItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryMutation.ts
@@ -1,6 +1,9 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
@@ -18,8 +21,7 @@ export const createItineraryMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "createItinerary",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Create an itinerary.",
   inputFields: {
     citySlug: { type: new GraphQLNonNull(GraphQLString) },
     title: { type: new GraphQLNonNull(GraphQLString) },
@@ -34,7 +36,25 @@ export const createItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("createItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async (input, context) => {
+    if (!context.createItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const itinerary = await context.createItineraryLoader(
+        snakeCaseKeys(input)
+      )
+
+      return attachStopItems(itinerary, context)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/deleteItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItineraryMutation.ts
@@ -1,0 +1,30 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  id: string
+}
+
+export const deleteItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "deleteItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("deleteItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/deleteItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItineraryMutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
@@ -13,8 +14,7 @@ export const deleteItineraryMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "deleteItinerary",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Delete an itinerary.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
   },
@@ -24,7 +24,21 @@ export const deleteItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("deleteItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async ({ id }, context) => {
+    if (!context.deleteItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await context.deleteItineraryLoader(id, {})
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/itineraryMutationResponseOrError.ts
+++ b/src/schema/v2/itinerary/mutations/itineraryMutationResponseOrError.ts
@@ -1,0 +1,41 @@
+import { GraphQLObjectType, GraphQLUnionType } from "graphql"
+import { GravityMutationErrorType } from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ItineraryType } from "../itinerary"
+
+// Shared success/failure/union types for every mutation whose successful
+// payload is a whole `Itinerary` (create, update, delete, publish,
+// unpublish, copy) — one definition instead of six near-identical copies.
+
+export const ItineraryMutationSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItineraryMutationSuccess",
+  isTypeOf: (data) => !!data && data._type !== "GravityMutationError",
+  fields: () => ({
+    itinerary: {
+      type: ItineraryType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+export const ItineraryMutationFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItineraryMutationFailure",
+  isTypeOf: (data) => !!data && data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+export const ItineraryMutationResponseOrErrorType = new GraphQLUnionType({
+  name: "ItineraryMutationResponseOrError",
+  types: [ItineraryMutationSuccessType, ItineraryMutationFailureType],
+})

--- a/src/schema/v2/itinerary/mutations/itineraryMutationResponseOrError.ts
+++ b/src/schema/v2/itinerary/mutations/itineraryMutationResponseOrError.ts
@@ -3,9 +3,8 @@ import { GravityMutationErrorType } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ItineraryType } from "../itinerary"
 
-// Shared success/failure/union types for every mutation whose successful
-// payload is a whole `Itinerary` (create, update, delete, publish,
-// unpublish, copy) — one definition instead of six near-identical copies.
+// Shared success/failure/union types for every mutation that returns a
+// whole `Itinerary`, instead of six near-identical copies.
 
 export const ItineraryMutationSuccessType = new GraphQLObjectType<
   any,

--- a/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
@@ -32,10 +32,10 @@ export const publishItineraryMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
-    try {
-      const itinerary = await context.publishItineraryLoader(id, {})
+    let itinerary
 
-      return attachStopItems(itinerary, context)
+    try {
+      itinerary = await context.publishItineraryLoader(id, {})
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -45,5 +45,8 @@ export const publishItineraryMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    return attachStopItems(itinerary, context).catch(() => itinerary)
   },
 })

--- a/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
@@ -1,6 +1,8 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
@@ -15,8 +17,7 @@ export const publishItineraryMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "publishItinerary",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Publish an itinerary. Needs the publish ability.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
   },
@@ -26,7 +27,23 @@ export const publishItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("publishItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async ({ id }, context) => {
+    if (!context.publishItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const itinerary = await context.publishItineraryLoader(id, {})
+
+      return attachStopItems(itinerary, context)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
@@ -1,0 +1,33 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  id: string
+}
+
+// Separate from `updateItinerary` because Gravity role-checks the
+// publish/unpublish transition and records who published the guide and
+// when — that's not just a field update.
+export const publishItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "publishItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("publishItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/publishItineraryMutation.ts
@@ -7,9 +7,8 @@ interface InputProps {
   id: string
 }
 
-// Separate from `updateItinerary` because Gravity role-checks the
-// publish/unpublish transition and records who published the guide and
-// when — that's not just a field update.
+// Separate from `updateItinerary`: Gravity role-checks this transition
+// and records who published and when.
 export const publishItineraryMutation = mutationWithClientMutationId<
   InputProps,
   any,

--- a/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
@@ -9,8 +9,6 @@ interface InputProps {
   id: string
 }
 
-// Separate from `updateItinerary`: Gravity role-checks this transition
-// and records who published and when.
 export const unpublishItineraryMutation = mutationWithClientMutationId<
   InputProps,
   any,
@@ -34,10 +32,10 @@ export const unpublishItineraryMutation = mutationWithClientMutationId<
       throw new Error("You need to be signed in to perform this action")
     }
 
-    try {
-      const itinerary = await context.unpublishItineraryLoader(id, {})
+    let itinerary
 
-      return attachStopItems(itinerary, context)
+    try {
+      itinerary = await context.unpublishItineraryLoader(id, {})
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -47,5 +45,8 @@ export const unpublishItineraryMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    return attachStopItems(itinerary, context).catch(() => itinerary)
   },
 })

--- a/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
@@ -1,0 +1,33 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  id: string
+}
+
+// Separate from `updateItinerary` because Gravity role-checks the
+// publish/unpublish transition and records who published the guide and
+// when — that's not just a field update.
+export const unpublishItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "unpublishItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("unpublishItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
@@ -7,9 +7,8 @@ interface InputProps {
   id: string
 }
 
-// Separate from `updateItinerary` because Gravity role-checks the
-// publish/unpublish transition and records who published the guide and
-// when — that's not just a field update.
+// Separate from `updateItinerary`: Gravity role-checks this transition
+// and records who published and when.
 export const unpublishItineraryMutation = mutationWithClientMutationId<
   InputProps,
   any,

--- a/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/unpublishItineraryMutation.ts
@@ -1,6 +1,8 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
@@ -16,7 +18,8 @@ export const unpublishItineraryMutation = mutationWithClientMutationId<
 >({
   name: "unpublishItinerary",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Unpublish an itinerary. Also revokes its share link, so it becomes " +
+    "private. Needs the publish ability.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
   },
@@ -26,7 +29,23 @@ export const unpublishItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("unpublishItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async ({ id }, context) => {
+    if (!context.unpublishItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const itinerary = await context.unpublishItineraryLoader(id, {})
+
+      return attachStopItems(itinerary, context)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
@@ -7,6 +7,7 @@ import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   id: string
   citySlug?: string
   title?: string
@@ -52,18 +53,21 @@ export const updateItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+  mutateAndGetPayload: async (
+    { id, clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.updateItineraryLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let itinerary
+
     try {
-      const itinerary = await context.updateItineraryLoader(
+      itinerary = await context.updateItineraryLoader(
         id,
         snakeCaseKeys(attributes)
       )
-
-      return attachStopItems(itinerary, context)
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -73,5 +77,8 @@ export const updateItineraryMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    return attachStopItems(itinerary, context).catch(() => itinerary)
   },
 })

--- a/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
@@ -1,0 +1,54 @@
+import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
+
+interface InputProps {
+  id: string
+  citySlug?: string
+  title?: string
+  subtitle?: string
+  description?: string
+  authorName?: string
+  isCurated?: boolean
+  generateShareToken?: boolean
+  revokeShareToken?: boolean
+}
+
+export const updateItineraryMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "updateItinerary",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    citySlug: { type: GraphQLString },
+    title: { type: GraphQLString },
+    subtitle: { type: GraphQLString },
+    description: { type: GraphQLString },
+    authorName: { type: GraphQLString },
+    isCurated: { type: GraphQLBoolean },
+    generateShareToken: {
+      description:
+        "Generate a new share token for this itinerary, replacing any " +
+        "existing one",
+      type: GraphQLBoolean,
+    },
+    revokeShareToken: {
+      description: "Revoke this itinerary's current share token, if any",
+      type: GraphQLBoolean,
+    },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error("updateItinerary is not implemented yet in Metaphysics.")
+  },
+})

--- a/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryMutation.ts
@@ -1,6 +1,9 @@
 import { GraphQLBoolean, GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachStopItems } from "../stopItems"
 import { ItineraryMutationResponseOrErrorType } from "./itineraryMutationResponseOrError"
 
 interface InputProps {
@@ -22,7 +25,8 @@ export const updateItineraryMutation = mutationWithClientMutationId<
 >({
   name: "updateItinerary",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Update an itinerary. Pass `generateShareToken` or `revokeShareToken` " +
+    "to manage its share link.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
     citySlug: { type: GraphQLString },
@@ -48,7 +52,26 @@ export const updateItineraryMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error("updateItinerary is not implemented yet in Metaphysics.")
+  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+    if (!context.updateItineraryLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const itinerary = await context.updateItineraryLoader(
+        id,
+        snakeCaseKeys(attributes)
+      )
+
+      return attachStopItems(itinerary, context)
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -357,6 +357,12 @@ import { Invoice } from "./Invoice/invoice"
 import { createInvoicePaymentMutation } from "./Invoice/createInvoicePaymentMutation"
 import { Itinerary } from "./itinerary"
 import { ItinerariesConnectionField } from "./itinerary/itinerariesConnection"
+import { copyItineraryMutation } from "./itinerary/mutations/copyItineraryMutation"
+import { createItineraryMutation } from "./itinerary/mutations/createItineraryMutation"
+import { deleteItineraryMutation } from "./itinerary/mutations/deleteItineraryMutation"
+import { publishItineraryMutation } from "./itinerary/mutations/publishItineraryMutation"
+import { unpublishItineraryMutation } from "./itinerary/mutations/unpublishItineraryMutation"
+import { updateItineraryMutation } from "./itinerary/mutations/updateItineraryMutation"
 import { ackTaskMutation } from "./me/ack_task_mutation"
 import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import {
@@ -652,6 +658,7 @@ export default new GraphQLSchema({
       bulkDeleteArtworksFromPartnerList: bulkDeleteArtworksFromPartnerListMutation,
       bulkUpdateArtworksMetadata: bulkUpdateArtworksMetadataMutation,
       confirmPassword: confirmPasswordMutation,
+      copyItinerary: copyItineraryMutation,
       createImage: createImageMutation,
       commerceOptIn: commerceOptInMutation,
       commerceOptInReport: commerceOptInReportMutation,
@@ -683,6 +690,7 @@ export default new GraphQLSchema({
       createHeroUnit: createHeroUnitMutation,
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createInvoicePayment: createInvoicePaymentMutation,
+      createItinerary: createItineraryMutation,
       createNavigationDraft: createNavigationDraftMutation,
       createNavigationItem: createNavigationItemMutation,
       createOrderedSet: createOrderedSetMutation,
@@ -751,6 +759,7 @@ export default new GraphQLSchema({
       deleteFeature: DeleteFeatureMutation,
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
+      deleteItinerary: deleteItineraryMutation,
       deletePartnerList: deletePartnerListMutation,
       deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
@@ -797,6 +806,7 @@ export default new GraphQLSchema({
       myCollectionCreateArtwork: myCollectionCreateArtworkMutation,
       myCollectionDeleteArtwork: myCollectionDeleteArtworkMutation,
       myCollectionUpdateArtwork: myCollectionUpdateArtworkMutation,
+      publishItinerary: publishItineraryMutation,
       publishNavigationDraft: publishNavigationDraftMutation,
       publishViewingRoom: publishViewingRoomMutation,
       reopenArtworkDuplicatePair: reopenArtworkDuplicatePairMutation,
@@ -829,6 +839,7 @@ export default new GraphQLSchema({
       transferMyCollection: transferMyCollectionMutation,
       triggerCampaign: triggerCampaignMutation,
       unlinkAuthentication: unlinkAuthenticationMutation,
+      unpublishItinerary: unpublishItineraryMutation,
       unpublishViewingRoom: unpublishViewingRoomMutation,
       unsetOrderFulfillmentOption: unsetOrderFulfillmentOptionMutation,
       unsetOrderPaymentMethod: unsetOrderPaymentMethodMutation,
@@ -858,6 +869,7 @@ export default new GraphQLSchema({
       updateFeature: UpdateFeatureMutation,
       updateFeaturedLink: UpdateFeaturedLinkMutation,
       updateHeroUnit: updateHeroUnitMutation,
+      updateItinerary: updateItineraryMutation,
       updateMeCollectionsMutation: updateMeCollectionsMutation,
       updateMessage: updateMessageMutation,
       updateMyPassword: updateMyPasswordMutation,


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-28

This is PR 4a of the split of #7884. It adds the six itinerary mutations, wired to Gravity's `itinerary` routes.

| Mutation | Gravity route | Notes |
| --- | --- | --- |
| `createItinerary` | `POST /itinerary` | |
| `updateItinerary` | `PUT /itinerary/:id` | `generateShareToken` / `revokeShareToken` manage the share link |
| `deleteItinerary` | `DELETE /itinerary/:id` | |
| `publishItinerary` | `POST /itinerary/:id/publish` | needs the publish ability |
| `unpublishItinerary` | `POST /itinerary/:id/unpublish` | needs the publish ability; revokes the share link |
| `copyItinerary` | `POST /itinerary/:id/copy` | `shareToken` needed for an unlisted source |

## Behaviour

- Every mutation requires a signed-in caller; otherwise it throws "You need to be signed in to perform this action".
- Inputs are mapped to Gravity's params with `snakeCaseKeys`; fields the client did not send are omitted, so a partial update only touches the fields sent.
- An explicit `null` (e.g. `subtitle: null`) reaches Gravity as `null` and clears the field.
- Gravity validation and authorization errors come back as `ItineraryMutationFailure.mutationError`, with `type`, `message`, `statusCode`, and `fieldErrors`. Any other error rethrows.
- Unpublishing an itinerary also revokes its share link (Gravity's `unpublish!` clears `share_token` along with `published_at`), so the itinerary goes back to private.
- Stop-item enrichment runs after the write, not inside the same try, so it cannot turn a committed write into a reported failure. If it fails, `item` resolves `null` for that response.

## Verified against staging

Ran all six mutations against staging Gravity through a local dev server: create, update (subtitle + share token), publish, unpublish, copy, and delete (both the copy and the original). Also sent a blank-title create, which came back as the expected `param_error` failure member with `fieldErrors`.

Verify: `yarn jest src/schema/v2/itinerary/__tests__/itineraryMutations.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
