### PR TITLE
feat: add itinerary section mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -26611,7 +26611,7 @@ type Mutation {
   createItinerary(input: createItineraryInput!): createItineraryPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Create a section in an itinerary.
   """
   createItinerarySection(
     input: createItinerarySectionInput!
@@ -26920,7 +26920,7 @@ type Mutation {
   deleteItinerary(input: deleteItineraryInput!): deleteItineraryPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Delete a section and its stops.
   """
   deleteItinerarySection(
     input: deleteItinerarySectionInput!
@@ -27673,7 +27673,7 @@ type Mutation {
   updateItinerary(input: updateItineraryInput!): updateItineraryPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Update a section. `position` moves it among its itinerary's sections.
   """
   updateItinerarySection(
     input: updateItinerarySectionInput!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23436,6 +23436,18 @@ type ItinerarySection {
   title: String
 }
 
+type ItinerarySectionMutationFailure {
+  mutationError: GravityMutationError
+}
+
+union ItinerarySectionMutationResponseOrError =
+    ItinerarySectionMutationFailure
+  | ItinerarySectionMutationSuccess
+
+type ItinerarySectionMutationSuccess {
+  itinerarySection: ItinerarySection
+}
+
 type ItineraryStop {
   address: String
   category: ItineraryStopCategory
@@ -26599,6 +26611,13 @@ type Mutation {
   createItinerary(input: createItineraryInput!): createItineraryPayload
 
   """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  createItinerarySection(
+    input: createItinerarySectionInput!
+  ): createItinerarySectionPayload
+
+  """
   Create a Mailchimp campaign draft for a partner from pre-rendered HTML
   """
   createMailchimpCampaign(
@@ -26899,6 +26918,13 @@ type Mutation {
   Delete an itinerary.
   """
   deleteItinerary(input: deleteItineraryInput!): deleteItineraryPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  deleteItinerarySection(
+    input: deleteItinerarySectionInput!
+  ): deleteItinerarySectionPayload
 
   """
   Disconnect a Mailchimp account from a partner
@@ -27645,6 +27671,13 @@ type Mutation {
   Update an itinerary. Pass `generateShareToken` or `revokeShareToken` to manage its share link.
   """
   updateItinerary(input: updateItineraryInput!): updateItineraryPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  updateItinerarySection(
+    input: updateItinerarySectionInput!
+  ): updateItinerarySectionPayload
 
   """
   Updates the user's collections in batch.
@@ -45149,6 +45182,22 @@ type createItineraryPayload {
   responseOrError: ItineraryMutationResponseOrError
 }
 
+input createItinerarySectionInput {
+  clientMutationId: String
+  itineraryID: String!
+
+  """
+  Free-text note shown with the section.
+  """
+  note: String
+  title: String
+}
+
+type createItinerarySectionPayload {
+  clientMutationId: String
+  responseOrError: ItinerarySectionMutationResponseOrError
+}
+
 type createOrderedSetFailure {
   mutationError: GravityMutationError
 }
@@ -45316,6 +45365,16 @@ input deleteItineraryInput {
 type deleteItineraryPayload {
   clientMutationId: String
   responseOrError: ItineraryMutationResponseOrError
+}
+
+input deleteItinerarySectionInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteItinerarySectionPayload {
+  clientMutationId: String
+  responseOrError: ItinerarySectionMutationResponseOrError
 }
 
 type deleteOrderedSetFailure {
@@ -45787,6 +45846,27 @@ input updateItineraryInput {
 type updateItineraryPayload {
   clientMutationId: String
   responseOrError: ItineraryMutationResponseOrError
+}
+
+input updateItinerarySectionInput {
+  clientMutationId: String
+  id: String!
+
+  """
+  Free-text note shown with the section.
+  """
+  note: String
+
+  """
+  Reorders the section among its itinerary's sections via acts_as_list's insert_at. There is no separate reposition mutation for sections.
+  """
+  position: Int
+  title: String
+}
+
+type updateItinerarySectionPayload {
+  clientMutationId: String
+  responseOrError: ItinerarySectionMutationResponseOrError
 }
 
 input updateMeCollectionsMutationInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1474,6 +1474,21 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "POST" }
     ),
+    createItinerarySectionLoader: gravityLoader(
+      "itinerary_section",
+      {},
+      { method: "POST" }
+    ),
+    updateItinerarySectionLoader: gravityLoader(
+      (id) => `itinerary_section/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteItinerarySectionLoader: gravityLoader(
+      (id) => `itinerary_section/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     partnerShowLoader: gravityLoader<
       any,

--- a/src/schema/v2/itinerary/__tests__/itinerarySectionMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerarySectionMutations.test.ts
@@ -1,0 +1,344 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
+
+// Mirrors Gravity's `:all` itinerary_section JSON: a stop pointing at a
+// `PartnerShow`, so `stops { item }` has something to resolve.
+const gravitySection = (overrides = {}) => ({
+  id: "section-id",
+  itinerary_id: "itinerary-id",
+  title: "Morning",
+  note: null,
+  position: 0,
+  stops_count: 1,
+  stops: [
+    {
+      id: "stop-id",
+      itinerary_section_id: "section-id",
+      position: 0,
+      item_type: "PartnerShow",
+      item_id: "show-id",
+      event_type: null,
+      event_id: null,
+      title: null,
+      address: null,
+      image_url: null,
+      latitude: null,
+      longitude: null,
+      start_at: null,
+      end_at: null,
+      time_zone: null,
+      note: null,
+      category: null,
+      is_free_admission: null,
+      source_url: null,
+      created_at: "2026-08-01T09:00:00Z",
+      updated_at: "2026-08-01T09:00:00Z",
+    },
+  ],
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  ...overrides,
+})
+
+const gravityShortSection = (overrides = {}) => ({
+  id: "section-id",
+  itinerary_id: "itinerary-id",
+  title: "Morning",
+  note: null,
+  position: 0,
+  stops_count: 0,
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  ...overrides,
+})
+
+const successFragment = gql`
+  ... on ItinerarySectionMutationSuccess {
+    itinerarySection {
+      internalID
+      title
+      note
+      stops {
+        item {
+          __typename
+          ... on Show {
+            internalID
+          }
+        }
+      }
+    }
+  }
+`
+
+const failureFragment = gql`
+  ... on ItinerarySectionMutationFailure {
+    mutationError {
+      type
+      message
+      statusCode
+      fieldErrors {
+        name
+        message
+      }
+    }
+  }
+`
+
+const withShowsLoader = (loader: jest.Mock) => ({
+  showsLoader: jest.fn().mockResolvedValue({
+    body: [{ _id: "show-id", id: "show-id", name: "A Show" }],
+    headers: {},
+  }),
+  createItinerarySectionLoader: loader,
+  updateItinerarySectionLoader: loader,
+  deleteItinerarySectionLoader: loader,
+})
+
+const paramError = new HTTPError("Bad Request", 400, {
+  type: "param_error",
+  message: "Title can't be blank.",
+  detail: { title: ["can't be blank"] },
+})
+
+const forbiddenError = new HTTPError("Forbidden", 403, { error: "Forbidden" })
+
+describe("createItinerarySection", () => {
+  const mutation = gql`
+    mutation {
+      createItinerarySection(
+        input: { itineraryID: "itinerary-id", title: "Morning" }
+      ) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith({
+      itinerary_id: "itinerary-id",
+      title: "Morning",
+    })
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItinerarySection.responseOrError.itinerarySection
+    ).toMatchObject({
+      internalID: "section-id",
+      title: "Morning",
+      note: null,
+      stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItinerarySection.responseOrError.mutationError).toEqual(
+      {
+        type: "param_error",
+        message: "Title can't be blank.",
+        statusCode: 400,
+        fieldErrors: [{ name: "title", message: "can't be blank" }],
+      }
+    )
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItinerarySection.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("updateItinerarySection", () => {
+  const mutation = gql`
+    mutation {
+      updateItinerarySection(
+        input: { id: "section-id", position: 0, note: null }
+      ) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("section-id", {
+      position: 0,
+      note: null,
+    })
+  })
+
+  it("returns the success payload with the resolved stop item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.updateItinerarySection.responseOrError.itinerarySection
+    ).toMatchObject({
+      internalID: "section-id",
+      title: "Morning",
+      stops: [{ item: { __typename: "Show", internalID: "show-id" } }],
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.updateItinerarySection.responseOrError.mutationError).toEqual(
+      {
+        type: "param_error",
+        message: "Title can't be blank.",
+        statusCode: 400,
+        fieldErrors: [{ name: "title", message: "can't be blank" }],
+      }
+    )
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.updateItinerarySection.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("deleteItinerarySection", () => {
+  const mutation = gql`
+    mutation {
+      deleteItinerarySection(input: { id: "section-id" }) {
+        responseOrError {
+          ... on ItinerarySectionMutationSuccess {
+            itinerarySection {
+              internalID
+              title
+            }
+          }
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityShortSection())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("section-id", {})
+  })
+
+  it("returns the success payload", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityShortSection())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.deleteItinerarySection.responseOrError.itinerarySection
+    ).toMatchObject({
+      internalID: "section-id",
+      title: "Morning",
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.deleteItinerarySection.responseOrError.mutationError).toEqual(
+      {
+        type: "param_error",
+        message: "Title can't be blank.",
+        statusCode: 400,
+        fieldErrors: [{ name: "title", message: "can't be blank" }],
+      }
+    )
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.deleteItinerarySection.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("schema exposure", () => {
+  it("exposes every itinerary section mutation on the schema", () => {
+    const { schema } = require("schema/v2")
+    const mutationFields = schema.getMutationType()!.getFields()
+
+    ;[
+      "createItinerarySection",
+      "updateItinerarySection",
+      "deleteItinerarySection",
+    ].forEach((name) => {
+      expect(mutationFields[name]).toBeDefined()
+    })
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/itinerarySectionMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerarySectionMutations.test.ts
@@ -145,6 +145,49 @@ describe("createItinerarySection", () => {
     })
   })
 
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          createItinerarySection(
+            input: {
+              itineraryID: "itinerary-id"
+              title: "Morning"
+              clientMutationId: "abc"
+            }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][0]).not.toHaveProperty("client_mutation_id")
+  })
+
+  it("still returns success when stop-item enrichment fails", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = {
+      ...withShowsLoader(loader),
+      showsLoader: jest.fn().mockRejectedValue(new Error("Gravity is down")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItinerarySection.responseOrError.itinerarySection
+    ).toMatchObject({
+      internalID: "section-id",
+      stops: [{ item: null }],
+    })
+  })
+
   it("returns the failure member on a Gravity validation error", async () => {
     const loader = jest.fn().mockRejectedValue(paramError)
     const context = withShowsLoader(loader)
@@ -203,6 +246,28 @@ describe("updateItinerarySection", () => {
       position: 0,
       note: null,
     })
+  })
+
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravitySection())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          updateItinerarySection(
+            input: { id: "section-id", position: 0, clientMutationId: "abc" }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][1]).not.toHaveProperty("client_mutation_id")
   })
 
   it("returns the success payload with the resolved stop item", async () => {

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -1,4 +1,5 @@
 import {
+  attachItemsToStops,
   attachStopItems,
   attachStopItemsToMany,
   loadStopItems,
@@ -275,6 +276,25 @@ describe("attachStopItems", () => {
       attachStopItems(itinerary, { showsLoader } as any)
     ).resolves.toBe(itinerary)
     expect(showsLoader).not.toHaveBeenCalled()
+  })
+})
+
+describe("attachItemsToStops", () => {
+  it("resolves a flat list of stops in a single batch and stamps each one", async () => {
+    const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])
+
+    const stops = [
+      buildStop({ item_type: "PartnerShow", item_id: "show-1" }),
+      buildStop({ item_type: "PartnerShow", item_id: "show-1" }),
+    ]
+
+    await attachItemsToStops(stops, { showsLoader } as any)
+
+    expect(showsLoader).toHaveBeenCalledTimes(1)
+    expect(stops.map((stop: any) => stop._resolvedItem)).toEqual([
+      { _id: "show-1", __typename: "Show" },
+      { _id: "show-1", __typename: "Show" },
+    ])
   })
 })
 

--- a/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
@@ -7,6 +7,7 @@ import { attachItemsToStops } from "../stopItems"
 import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   itineraryID: string
   title?: string
   note?: string
@@ -33,19 +34,20 @@ export const createItinerarySectionMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (input, context) => {
+  mutateAndGetPayload: async (
+    { clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.createItinerarySectionLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let section
+
     try {
-      const section = await context.createItinerarySectionLoader(
-        snakeCaseKeys(input)
+      section = await context.createItinerarySectionLoader(
+        snakeCaseKeys(attributes)
       )
-
-      await attachItemsToStops(section.stops ?? [], context)
-
-      return section
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -55,5 +57,12 @@ export const createItinerarySectionMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    await attachItemsToStops(section.stops ?? [], context).catch(
+      () => undefined
+    )
+
+    return section
   },
 })

--- a/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
@@ -1,6 +1,9 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachItemsToStops } from "../stopItems"
 import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
 
 interface InputProps {
@@ -15,8 +18,7 @@ export const createItinerarySectionMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "createItinerarySection",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Create a section in an itinerary.",
   inputFields: {
     itineraryID: { type: new GraphQLNonNull(GraphQLString) },
     title: { type: GraphQLString },
@@ -31,9 +33,27 @@ export const createItinerarySectionMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "createItinerarySection is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async (input, context) => {
+    if (!context.createItinerarySectionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const section = await context.createItinerarySectionLoader(
+        snakeCaseKeys(input)
+      )
+
+      await attachItemsToStops(section.stops ?? [], context)
+
+      return section
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItinerarySectionMutation.ts
@@ -1,0 +1,39 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
+
+interface InputProps {
+  itineraryID: string
+  title?: string
+  note?: string
+}
+
+export const createItinerarySectionMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "createItinerarySection",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    itineraryID: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: GraphQLString },
+    note: {
+      type: GraphQLString,
+      description: "Free-text note shown with the section.",
+    },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItinerarySectionMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "createItinerarySection is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/mutations/deleteItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItinerarySectionMutation.ts
@@ -1,0 +1,32 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
+
+interface InputProps {
+  id: string
+}
+
+export const deleteItinerarySectionMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "deleteItinerarySection",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItinerarySectionMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "deleteItinerarySection is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/mutations/deleteItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItinerarySectionMutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
 
@@ -13,8 +14,7 @@ export const deleteItinerarySectionMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "deleteItinerarySection",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Delete a section and its stops.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
   },
@@ -24,9 +24,21 @@ export const deleteItinerarySectionMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "deleteItinerarySection is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async ({ id }, context) => {
+    if (!context.deleteItinerarySectionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await context.deleteItinerarySectionLoader(id, {})
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/itinerarySectionMutationResponseOrError.ts
+++ b/src/schema/v2/itinerary/mutations/itinerarySectionMutationResponseOrError.ts
@@ -1,0 +1,45 @@
+import { GraphQLObjectType, GraphQLUnionType } from "graphql"
+import { GravityMutationErrorType } from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ItinerarySectionType } from "../itinerarySection"
+
+// Shared success/failure/union types for every mutation that returns a
+// whole `ItinerarySection`, instead of three near-identical copies.
+
+export const ItinerarySectionMutationSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItinerarySectionMutationSuccess",
+  isTypeOf: (data) => !!data && data._type !== "GravityMutationError",
+  fields: () => ({
+    itinerarySection: {
+      type: ItinerarySectionType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+export const ItinerarySectionMutationFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItinerarySectionMutationFailure",
+  isTypeOf: (data) => !!data && data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+export const ItinerarySectionMutationResponseOrErrorType = new GraphQLUnionType(
+  {
+    name: "ItinerarySectionMutationResponseOrError",
+    types: [
+      ItinerarySectionMutationSuccessType,
+      ItinerarySectionMutationFailureType,
+    ],
+  }
+)

--- a/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
@@ -1,6 +1,9 @@
 import { GraphQLInt, GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachItemsToStops } from "../stopItems"
 import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
 
 interface InputProps {
@@ -17,7 +20,7 @@ export const updateItinerarySectionMutation = mutationWithClientMutationId<
 >({
   name: "updateItinerarySection",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Update a section. `position` moves it among its itinerary's sections.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
     title: { type: GraphQLString },
@@ -39,9 +42,28 @@ export const updateItinerarySectionMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "updateItinerarySection is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+    if (!context.updateItinerarySectionLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const section = await context.updateItinerarySectionLoader(
+        id,
+        snakeCaseKeys(attributes)
+      )
+
+      await attachItemsToStops(section.stops ?? [], context)
+
+      return section
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
@@ -7,6 +7,7 @@ import { attachItemsToStops } from "../stopItems"
 import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   id: string
   title?: string
   note?: string
@@ -42,20 +43,21 @@ export const updateItinerarySectionMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+  mutateAndGetPayload: async (
+    { id, clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.updateItinerarySectionLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let section
+
     try {
-      const section = await context.updateItinerarySectionLoader(
+      section = await context.updateItinerarySectionLoader(
         id,
         snakeCaseKeys(attributes)
       )
-
-      await attachItemsToStops(section.stops ?? [], context)
-
-      return section
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -65,5 +67,12 @@ export const updateItinerarySectionMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    await attachItemsToStops(section.stops ?? [], context).catch(
+      () => undefined
+    )
+
+    return section
   },
 })

--- a/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItinerarySectionMutation.ts
@@ -1,0 +1,47 @@
+import { GraphQLInt, GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItinerarySectionMutationResponseOrErrorType } from "./itinerarySectionMutationResponseOrError"
+
+interface InputProps {
+  id: string
+  title?: string
+  note?: string
+  position?: number
+}
+
+export const updateItinerarySectionMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "updateItinerarySection",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    title: { type: GraphQLString },
+    note: {
+      type: GraphQLString,
+      description: "Free-text note shown with the section.",
+    },
+    position: {
+      description:
+        "Reorders the section among its itinerary's sections via " +
+        "acts_as_list's insert_at. There is no separate reposition " +
+        "mutation for sections.",
+      type: GraphQLInt,
+    },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItinerarySectionMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "updateItinerarySection is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -91,6 +91,23 @@ export const loadStopItems = async (
   return map
 }
 
+// Loads and stamps `_resolvedItem` on each stop, in place.
+export const attachItemsToStops = async (
+  stops: StopWithResolvedItem[],
+  context: ResolverContext
+): Promise<StopWithResolvedItem[]> => {
+  const itemsByKey = await loadStopItems(stops, context)
+
+  for (const stop of stops) {
+    stop._resolvedItem =
+      stop.item_id && isStopItemType(stop.item_type)
+        ? itemsByKey.get(mapKey(stop.item_type, stop.item_id)) ?? null
+        : null
+  }
+
+  return stops
+}
+
 // Call from every resolver that returns Itinerary nodes, once per page.
 // Tolerates list payloads with no sections.
 export const attachStopItemsToMany = async <T extends GravityItinerary>(
@@ -101,14 +118,7 @@ export const attachStopItemsToMany = async <T extends GravityItinerary>(
     (itinerary.sections ?? []).flatMap((section) => section.stops ?? [])
   )
 
-  const itemsByKey = await loadStopItems(stops, context)
-
-  for (const stop of stops) {
-    stop._resolvedItem =
-      stop.item_id && isStopItemType(stop.item_type)
-        ? itemsByKey.get(mapKey(stop.item_type, stop.item_id)) ?? null
-        : null
-  }
+  await attachItemsToStops(stops, context)
 
   return itineraries
 }

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -359,10 +359,13 @@ import { Itinerary } from "./itinerary"
 import { ItinerariesConnectionField } from "./itinerary/itinerariesConnection"
 import { copyItineraryMutation } from "./itinerary/mutations/copyItineraryMutation"
 import { createItineraryMutation } from "./itinerary/mutations/createItineraryMutation"
+import { createItinerarySectionMutation } from "./itinerary/mutations/createItinerarySectionMutation"
 import { deleteItineraryMutation } from "./itinerary/mutations/deleteItineraryMutation"
+import { deleteItinerarySectionMutation } from "./itinerary/mutations/deleteItinerarySectionMutation"
 import { publishItineraryMutation } from "./itinerary/mutations/publishItineraryMutation"
 import { unpublishItineraryMutation } from "./itinerary/mutations/unpublishItineraryMutation"
 import { updateItineraryMutation } from "./itinerary/mutations/updateItineraryMutation"
+import { updateItinerarySectionMutation } from "./itinerary/mutations/updateItinerarySectionMutation"
 import { ackTaskMutation } from "./me/ack_task_mutation"
 import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import {
@@ -691,6 +694,7 @@ export default new GraphQLSchema({
       createIdentityVerificationOverride: createIdentityVerificationOverrideMutation,
       createInvoicePayment: createInvoicePaymentMutation,
       createItinerary: createItineraryMutation,
+      createItinerarySection: createItinerarySectionMutation,
       createNavigationDraft: createNavigationDraftMutation,
       createNavigationItem: createNavigationItemMutation,
       createOrderedSet: createOrderedSetMutation,
@@ -760,6 +764,7 @@ export default new GraphQLSchema({
       deleteFeaturedLink: DeleteFeaturedLinkMutation,
       deleteHeroUnit: deleteHeroUnitMutation,
       deleteItinerary: deleteItineraryMutation,
+      deleteItinerarySection: deleteItinerarySectionMutation,
       deletePartnerList: deletePartnerListMutation,
       deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
@@ -870,6 +875,7 @@ export default new GraphQLSchema({
       updateFeaturedLink: UpdateFeaturedLinkMutation,
       updateHeroUnit: updateHeroUnitMutation,
       updateItinerary: updateItineraryMutation,
+      updateItinerarySection: updateItinerarySectionMutation,
       updateMeCollectionsMutation: updateMeCollectionsMutation,
       updateMessage: updateMessageMutation,
       updateMyPassword: updateMyPasswordMutation,


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-29

This is PR 4b of the split of #7884. It stacks on #7890 and adds the three itinerary section mutations, wired to Gravity's `itinerary_section` routes.

| Mutation | Gravity route | Notes |
| --- | --- | --- |
| `createItinerarySection` | `POST /itinerary_section` | |
| `updateItinerarySection` | `PUT /itinerary_section/:id` | `position` reorders the section among its itinerary's sections |
| `deleteItinerarySection` | `DELETE /itinerary_section/:id` | deletes the section and its stops |

## Behaviour

- Every mutation requires a signed-in caller; otherwise it throws "You need to be signed in to perform this action".
- Inputs are mapped to Gravity's params with `snakeCaseKeys`; fields the client did not send are omitted, so a partial update only touches the fields sent.
- An explicit `null` (e.g. `note: null`) reaches Gravity as `null` and clears the field.
- `position` on `updateItinerarySection` runs Gravity's `insert_at` inside the same transaction as the attribute update; a negative value comes back as a 400.
- `createItinerarySection` and `updateItinerarySection` return the section's stops with their `item` resolved, batched through the same stop-item loading used for itineraries (factored into a shared `attachItemsToStops` helper).
- Gravity validation and authorization errors come back as `ItinerarySectionMutationFailure.mutationError`, with `type`, `message`, `statusCode`, and `fieldErrors`. Any other error rethrows.
- Stop-item enrichment runs after the write, not inside the same try, so it cannot turn a committed write into a reported failure. If it fails, `item` resolves `null` for that response.

## Verified against staging

Ran all three mutations against staging Gravity through a local dev server: created two sections, updated one (`position` and an explicit `note: null`), deleted one. Also sent a `createItinerarySection` against a bogus itinerary id, which came back as the expected failure member with a 404.

Verify: `yarn jest src/schema/v2/itinerary/__tests__/itinerarySectionMutations.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
