### PR TITLE
feat: add itinerary stop mutations

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -26630,7 +26630,7 @@ type Mutation {
   ): createItinerarySectionPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Add a stop to a section. A stop points at a show, a location or a fair, or is a custom place with its own title and coordinates.
   """
   createItineraryStop(
     input: createItineraryStopInput!
@@ -26946,7 +26946,7 @@ type Mutation {
   ): deleteItinerarySectionPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Delete a stop by its id.
   """
   deleteItineraryStop(
     input: deleteItineraryStopInput!
@@ -27706,7 +27706,7 @@ type Mutation {
   ): updateItinerarySectionPayload
 
   """
-  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  Update a stop. `position` moves it among its section's stops. `isFreeAdmission: null` clears the override.
   """
   updateItineraryStop(
     input: updateItineraryStopInput!

--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23511,6 +23511,18 @@ enum ItineraryStopCategory {
 
 union ItineraryStopItem = Fair | Location | Show
 
+type ItineraryStopMutationFailure {
+  mutationError: GravityMutationError
+}
+
+union ItineraryStopMutationResponseOrError =
+    ItineraryStopMutationFailure
+  | ItineraryStopMutationSuccess
+
+type ItineraryStopMutationSuccess {
+  itineraryStop: ItineraryStop
+}
+
 enum ItineraryVisibility {
   PRIVATE
   PUBLIC
@@ -26618,6 +26630,13 @@ type Mutation {
   ): createItinerarySectionPayload
 
   """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  createItineraryStop(
+    input: createItineraryStopInput!
+  ): createItineraryStopPayload
+
+  """
   Create a Mailchimp campaign draft for a partner from pre-rendered HTML
   """
   createMailchimpCampaign(
@@ -26925,6 +26944,13 @@ type Mutation {
   deleteItinerarySection(
     input: deleteItinerarySectionInput!
   ): deleteItinerarySectionPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  deleteItineraryStop(
+    input: deleteItineraryStopInput!
+  ): deleteItineraryStopPayload
 
   """
   Disconnect a Mailchimp account from a partner
@@ -27678,6 +27704,13 @@ type Mutation {
   updateItinerarySection(
     input: updateItinerarySectionInput!
   ): updateItinerarySectionPayload
+
+  """
+  Not implemented yet in Metaphysics. Calling this mutation always throws.
+  """
+  updateItineraryStop(
+    input: updateItineraryStopInput!
+  ): updateItineraryStopPayload
 
   """
   Updates the user's collections in batch.
@@ -45198,6 +45231,36 @@ type createItinerarySectionPayload {
   responseOrError: ItinerarySectionMutationResponseOrError
 }
 
+input createItineraryStopInput {
+  address: String
+  category: ItineraryStopCategory
+  clientMutationId: String
+  endAt: String
+  eventID: String
+  eventType: String
+  imageURL: String
+  isFreeAdmission: Boolean
+  itemID: String
+  itemType: String
+  itinerarySectionID: String!
+  latitude: Float
+  longitude: Float
+  note: String
+  sourceURL: String
+  startAt: String
+
+  """
+  IANA time zone identifier, e.g. Europe/London.
+  """
+  timeZone: String
+  title: String
+}
+
+type createItineraryStopPayload {
+  clientMutationId: String
+  responseOrError: ItineraryStopMutationResponseOrError
+}
+
 type createOrderedSetFailure {
   mutationError: GravityMutationError
 }
@@ -45375,6 +45438,16 @@ input deleteItinerarySectionInput {
 type deleteItinerarySectionPayload {
   clientMutationId: String
   responseOrError: ItinerarySectionMutationResponseOrError
+}
+
+input deleteItineraryStopInput {
+  clientMutationId: String
+  id: String!
+}
+
+type deleteItineraryStopPayload {
+  clientMutationId: String
+  responseOrError: ItineraryStopMutationResponseOrError
 }
 
 type deleteOrderedSetFailure {
@@ -45867,6 +45940,41 @@ input updateItinerarySectionInput {
 type updateItinerarySectionPayload {
   clientMutationId: String
   responseOrError: ItinerarySectionMutationResponseOrError
+}
+
+input updateItineraryStopInput {
+  address: String
+  category: ItineraryStopCategory
+  clientMutationId: String
+  endAt: String
+  eventID: String
+  eventType: String
+  id: String!
+  imageURL: String
+  isFreeAdmission: Boolean
+  itemID: String
+  itemType: String
+  latitude: Float
+  longitude: Float
+  note: String
+
+  """
+  Reorders the stop among its section's stops via acts_as_list's insert_at. There is no separate reposition mutation for stops.
+  """
+  position: Int
+  sourceURL: String
+  startAt: String
+
+  """
+  IANA time zone identifier, e.g. Europe/London.
+  """
+  timeZone: String
+  title: String
+}
+
+type updateItineraryStopPayload {
+  clientMutationId: String
+  responseOrError: ItineraryStopMutationResponseOrError
 }
 
 input updateMeCollectionsMutationInput {

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1489,6 +1489,21 @@ export default (accessToken, userID, opts) => {
       {},
       { method: "DELETE" }
     ),
+    createItineraryStopLoader: gravityLoader(
+      "itinerary_stop",
+      {},
+      { method: "POST" }
+    ),
+    updateItineraryStopLoader: gravityLoader(
+      (id) => `itinerary_stop/${id}`,
+      {},
+      { method: "PUT" }
+    ),
+    deleteItineraryStopLoader: gravityLoader(
+      (id) => `itinerary_stop/${id}`,
+      {},
+      { method: "DELETE" }
+    ),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     partnerShowLoader: gravityLoader<
       any,

--- a/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
@@ -1,0 +1,324 @@
+import gql from "lib/gql"
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import { HTTPError } from "lib/HTTPError"
+
+// Mirrors Gravity's single itinerary_stop JSON, pointing at a `PartnerShow`
+// so `item` has something to resolve.
+const gravityStop = (overrides = {}) => ({
+  id: "stop-id",
+  itinerary_section_id: "section-id",
+  position: 0,
+  item_type: "PartnerShow",
+  item_id: "show-id",
+  event_type: null,
+  event_id: null,
+  title: null,
+  address: null,
+  image_url: null,
+  latitude: null,
+  longitude: null,
+  start_at: null,
+  end_at: null,
+  time_zone: "America/New_York",
+  note: null,
+  category: "SHOW",
+  is_free_admission: true,
+  source_url: null,
+  created_at: "2026-08-01T09:00:00Z",
+  updated_at: "2026-08-01T09:00:00Z",
+  ...overrides,
+})
+
+const successFragment = gql`
+  ... on ItineraryStopMutationSuccess {
+    itineraryStop {
+      internalID
+      title
+      category
+      isFreeAdmission
+      timeZone
+      item {
+        __typename
+        ... on Show {
+          internalID
+        }
+      }
+    }
+  }
+`
+
+const failureFragment = gql`
+  ... on ItineraryStopMutationFailure {
+    mutationError {
+      type
+      message
+      statusCode
+      fieldErrors {
+        name
+        message
+      }
+    }
+  }
+`
+
+const withShowsLoader = (loader: jest.Mock) => ({
+  showsLoader: jest.fn().mockResolvedValue({
+    body: [{ _id: "show-id", id: "show-id", name: "A Show" }],
+    headers: {},
+  }),
+  createItineraryStopLoader: loader,
+  updateItineraryStopLoader: loader,
+  deleteItineraryStopLoader: loader,
+})
+
+const paramError = new HTTPError("Bad Request", 400, {
+  type: "param_error",
+  message: "Longitude can't be blank.",
+  detail: { longitude: ["can't be blank"] },
+})
+
+const forbiddenError = new HTTPError("Forbidden", 403, { error: "Forbidden" })
+
+describe("createItineraryStop", () => {
+  const mutation = gql`
+    mutation {
+      createItineraryStop(
+        input: {
+          itinerarySectionID: "section-id"
+          itemType: "PartnerShow"
+          itemID: "show-id"
+          category: SHOW
+          isFreeAdmission: true
+          timeZone: "America/New_York"
+        }
+      ) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith({
+      itinerary_section_id: "section-id",
+      item_type: "PartnerShow",
+      item_id: "show-id",
+      category: "SHOW",
+      is_free_admission: true,
+      time_zone: "America/New_York",
+    })
+  })
+
+  it("returns the success payload with the resolved item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItineraryStop.responseOrError.itineraryStop
+    ).toMatchObject({
+      internalID: "stop-id",
+      category: "SHOW",
+      isFreeAdmission: true,
+      timeZone: "America/New_York",
+      item: { __typename: "Show", internalID: "show-id" },
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.createItineraryStop.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Longitude can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "longitude", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItineraryStop.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("updateItineraryStop", () => {
+  const mutation = gql`
+    mutation {
+      updateItineraryStop(
+        input: { id: "stop-id", position: 0, isFreeAdmission: null }
+      ) {
+        responseOrError {
+          ${successFragment}
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("stop-id", {
+      position: 0,
+      is_free_admission: null,
+    })
+  })
+
+  it("returns the success payload with the resolved item", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.updateItineraryStop.responseOrError.itineraryStop
+    ).toMatchObject({
+      internalID: "stop-id",
+      category: "SHOW",
+      item: { __typename: "Show", internalID: "show-id" },
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.updateItineraryStop.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Longitude can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "longitude", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.updateItineraryStop.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("deleteItineraryStop", () => {
+  const mutation = gql`
+    mutation {
+      deleteItineraryStop(input: { id: "stop-id" }) {
+        responseOrError {
+          ... on ItineraryStopMutationSuccess {
+            itineraryStop {
+              internalID
+            }
+          }
+          ${failureFragment}
+        }
+      }
+    }
+  `
+
+  it("passes the right args to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(mutation, context)
+
+    expect(loader).toHaveBeenCalledWith("stop-id", {})
+  })
+
+  it("returns the success payload", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.deleteItineraryStop.responseOrError.itineraryStop
+    ).toMatchObject({
+      internalID: "stop-id",
+    })
+  })
+
+  it("returns the failure member on a Gravity validation error", async () => {
+    const loader = jest.fn().mockRejectedValue(paramError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(result.deleteItineraryStop.responseOrError.mutationError).toEqual({
+      type: "param_error",
+      message: "Longitude can't be blank.",
+      statusCode: 400,
+      fieldErrors: [{ name: "longitude", message: "can't be blank" }],
+    })
+  })
+
+  it("returns the failure member on a 403", async () => {
+    const loader = jest.fn().mockRejectedValue(forbiddenError)
+    const context = withShowsLoader(loader)
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.deleteItineraryStop.responseOrError.mutationError
+    ).toMatchObject({ message: "Forbidden", statusCode: 403 })
+  })
+
+  it("throws when signed out", async () => {
+    await expect(runQuery(mutation, {})).rejects.toThrow(
+      "You need to be signed in"
+    )
+  })
+})
+
+describe("schema exposure", () => {
+  it("exposes every itinerary stop mutation on the schema", () => {
+    const { schema } = require("schema/v2")
+    const mutationFields = schema.getMutationType()!.getFields()
+
+    ;[
+      "createItineraryStop",
+      "updateItineraryStop",
+      "deleteItineraryStop",
+    ].forEach((name) => {
+      expect(mutationFields[name]).toBeDefined()
+    })
+  })
+})

--- a/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
@@ -133,6 +133,50 @@ describe("createItineraryStop", () => {
     })
   })
 
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          createItineraryStop(
+            input: {
+              itinerarySectionID: "section-id"
+              itemType: "PartnerShow"
+              itemID: "show-id"
+              clientMutationId: "abc"
+            }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][0]).not.toHaveProperty("client_mutation_id")
+  })
+
+  it("still returns success when item enrichment fails", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = {
+      ...withShowsLoader(loader),
+      showsLoader: jest.fn().mockRejectedValue(new Error("Gravity is down")),
+    }
+
+    const result = await runAuthenticatedQuery(mutation, context)
+
+    expect(
+      result.createItineraryStop.responseOrError.itineraryStop
+    ).toMatchObject({
+      internalID: "stop-id",
+      item: null,
+    })
+  })
+
   it("returns the failure member on a Gravity validation error", async () => {
     const loader = jest.fn().mockRejectedValue(paramError)
     const context = withShowsLoader(loader)
@@ -189,6 +233,28 @@ describe("updateItineraryStop", () => {
       position: 0,
       is_free_admission: null,
     })
+  })
+
+  it("does not forward clientMutationId to Gravity", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await runAuthenticatedQuery(
+      gql`
+        mutation {
+          updateItineraryStop(
+            input: { id: "stop-id", position: 0, clientMutationId: "abc" }
+          ) {
+            responseOrError {
+              ${successFragment}
+            }
+          }
+        }
+      `,
+      context
+    )
+
+    expect(loader.mock.calls[0][1]).not.toHaveProperty("client_mutation_id")
   })
 
   it("returns the success payload with the resolved item", async () => {

--- a/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
@@ -1,0 +1,73 @@
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryStopCategory } from "../itineraryStop"
+import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
+
+interface InputProps {
+  itinerarySectionID: string
+  itemType?: string
+  itemID?: string
+  eventType?: string
+  eventID?: string
+  title?: string
+  address?: string
+  imageURL?: string
+  latitude?: number
+  longitude?: number
+  startAt?: string
+  endAt?: string
+  timeZone?: string
+  note?: string
+  category?: string
+  isFreeAdmission?: boolean
+  sourceURL?: string
+}
+
+export const createItineraryStopMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "createItineraryStop",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    itinerarySectionID: { type: new GraphQLNonNull(GraphQLString) },
+    itemType: { type: GraphQLString },
+    itemID: { type: GraphQLString },
+    eventType: { type: GraphQLString },
+    eventID: { type: GraphQLString },
+    title: { type: GraphQLString },
+    address: { type: GraphQLString },
+    imageURL: { type: GraphQLString },
+    latitude: { type: GraphQLFloat },
+    longitude: { type: GraphQLFloat },
+    startAt: { type: GraphQLString },
+    endAt: { type: GraphQLString },
+    timeZone: {
+      type: GraphQLString,
+      description: "IANA time zone identifier, e.g. Europe/London.",
+    },
+    note: { type: GraphQLString },
+    category: { type: ItineraryStopCategory },
+    isFreeAdmission: { type: GraphQLBoolean },
+    sourceURL: { type: GraphQLString },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryStopMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "createItineraryStop is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
@@ -13,6 +13,7 @@ import { ItineraryStopCategory } from "../itineraryStop"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   itinerarySectionID: string
   itemType?: string
   itemID?: string
@@ -69,17 +70,18 @@ export const createItineraryStopMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (input, context) => {
+  mutateAndGetPayload: async (
+    { clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.createItineraryStopLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let stop
+
     try {
-      const stop = await context.createItineraryStopLoader(snakeCaseKeys(input))
-
-      await attachItemsToStops([stop], context)
-
-      return stop
+      stop = await context.createItineraryStopLoader(snakeCaseKeys(attributes))
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -89,5 +91,10 @@ export const createItineraryStopMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    await attachItemsToStops([stop], context).catch(() => undefined)
+
+    return stop
   },
 })

--- a/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
@@ -5,7 +5,10 @@ import {
   GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachItemsToStops } from "../stopItems"
 import { ItineraryStopCategory } from "../itineraryStop"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
@@ -36,7 +39,8 @@ export const createItineraryStopMutation = mutationWithClientMutationId<
 >({
   name: "createItineraryStop",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Add a stop to a section. A stop points at a show, a location or a " +
+    "fair, or is a custom place with its own title and coordinates.",
   inputFields: {
     itinerarySectionID: { type: new GraphQLNonNull(GraphQLString) },
     itemType: { type: GraphQLString },
@@ -65,9 +69,25 @@ export const createItineraryStopMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "createItineraryStop is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async (input, context) => {
+    if (!context.createItineraryStopLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const stop = await context.createItineraryStopLoader(snakeCaseKeys(input))
+
+      await attachItemsToStops([stop], context)
+
+      return stop
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/deleteItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItineraryStopMutation.ts
@@ -1,0 +1,34 @@
+import { GraphQLNonNull, GraphQLString } from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
+
+interface InputProps {
+  id: string
+}
+
+// Deletes by stop id, not item id: the same show can appear twice in one
+// itinerary.
+export const deleteItineraryStopMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "deleteItineraryStop",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryStopMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "deleteItineraryStop is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/mutations/deleteItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/deleteItineraryStopMutation.ts
@@ -1,5 +1,6 @@
 import { GraphQLNonNull, GraphQLString } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
@@ -15,8 +16,7 @@ export const deleteItineraryStopMutation = mutationWithClientMutationId<
   ResolverContext
 >({
   name: "deleteItineraryStop",
-  description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  description: "Delete a stop by its id.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
   },
@@ -26,9 +26,21 @@ export const deleteItineraryStopMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "deleteItineraryStop is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async ({ id }, context) => {
+    if (!context.deleteItineraryStopLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      return await context.deleteItineraryStopLoader(id, {})
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/itinerary/mutations/itineraryStopMutationResponseOrError.ts
+++ b/src/schema/v2/itinerary/mutations/itineraryStopMutationResponseOrError.ts
@@ -1,0 +1,40 @@
+import { GraphQLObjectType, GraphQLUnionType } from "graphql"
+import { GravityMutationErrorType } from "lib/gravityErrorHandler"
+import { ResolverContext } from "types/graphql"
+import { ItineraryStopType } from "../itineraryStop"
+
+// Shared success/failure/union types for every mutation whose successful
+// payload is a single `ItineraryStop`: create, update and delete.
+
+export const ItineraryStopMutationSuccessType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItineraryStopMutationSuccess",
+  isTypeOf: (data) => !!data && data._type !== "GravityMutationError",
+  fields: () => ({
+    itineraryStop: {
+      type: ItineraryStopType,
+      resolve: (result) => result,
+    },
+  }),
+})
+
+export const ItineraryStopMutationFailureType = new GraphQLObjectType<
+  any,
+  ResolverContext
+>({
+  name: "ItineraryStopMutationFailure",
+  isTypeOf: (data) => !!data && data._type === "GravityMutationError",
+  fields: () => ({
+    mutationError: {
+      type: GravityMutationErrorType,
+      resolve: (err) => err,
+    },
+  }),
+})
+
+export const ItineraryStopMutationResponseOrErrorType = new GraphQLUnionType({
+  name: "ItineraryStopMutationResponseOrError",
+  types: [ItineraryStopMutationSuccessType, ItineraryStopMutationFailureType],
+})

--- a/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
@@ -1,0 +1,81 @@
+import {
+  GraphQLBoolean,
+  GraphQLFloat,
+  GraphQLInt,
+  GraphQLNonNull,
+  GraphQLString,
+} from "graphql"
+import { mutationWithClientMutationId } from "graphql-relay"
+import { ResolverContext } from "types/graphql"
+import { ItineraryStopCategory } from "../itineraryStop"
+import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
+
+interface InputProps {
+  id: string
+  itemType?: string
+  itemID?: string
+  eventType?: string
+  eventID?: string
+  title?: string
+  address?: string
+  imageURL?: string
+  latitude?: number
+  longitude?: number
+  startAt?: string
+  endAt?: string
+  timeZone?: string
+  note?: string
+  category?: string
+  isFreeAdmission?: boolean
+  sourceURL?: string
+  position?: number
+}
+
+export const updateItineraryStopMutation = mutationWithClientMutationId<
+  InputProps,
+  any,
+  ResolverContext
+>({
+  name: "updateItineraryStop",
+  description:
+    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+  inputFields: {
+    id: { type: new GraphQLNonNull(GraphQLString) },
+    itemType: { type: GraphQLString },
+    itemID: { type: GraphQLString },
+    eventType: { type: GraphQLString },
+    eventID: { type: GraphQLString },
+    title: { type: GraphQLString },
+    address: { type: GraphQLString },
+    imageURL: { type: GraphQLString },
+    latitude: { type: GraphQLFloat },
+    longitude: { type: GraphQLFloat },
+    startAt: { type: GraphQLString },
+    endAt: { type: GraphQLString },
+    timeZone: {
+      type: GraphQLString,
+      description: "IANA time zone identifier, e.g. Europe/London.",
+    },
+    note: { type: GraphQLString },
+    category: { type: ItineraryStopCategory },
+    isFreeAdmission: { type: GraphQLBoolean },
+    sourceURL: { type: GraphQLString },
+    position: {
+      description:
+        "Reorders the stop among its section's stops via acts_as_list's " +
+        "insert_at. There is no separate reposition mutation for stops.",
+      type: GraphQLInt,
+    },
+  },
+  outputFields: {
+    responseOrError: {
+      type: ItineraryStopMutationResponseOrErrorType,
+      resolve: (result) => result,
+    },
+  },
+  mutateAndGetPayload: async (_args, _context) => {
+    throw new Error(
+      "updateItineraryStop is not implemented yet in Metaphysics."
+    )
+  },
+})

--- a/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
@@ -14,6 +14,7 @@ import { ItineraryStopCategory } from "../itineraryStop"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
 interface InputProps {
+  clientMutationId?: string
   id: string
   itemType?: string
   itemID?: string
@@ -77,20 +78,21 @@ export const updateItineraryStopMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+  mutateAndGetPayload: async (
+    { id, clientMutationId: _clientMutationId, ...attributes },
+    context
+  ) => {
     if (!context.updateItineraryStopLoader) {
       throw new Error("You need to be signed in to perform this action")
     }
 
+    let stop
+
     try {
-      const stop = await context.updateItineraryStopLoader(
+      stop = await context.updateItineraryStopLoader(
         id,
         snakeCaseKeys(attributes)
       )
-
-      await attachItemsToStops([stop], context)
-
-      return stop
     } catch (error) {
       const formattedErr = formatGravityError(error)
 
@@ -100,5 +102,10 @@ export const updateItineraryStopMutation = mutationWithClientMutationId<
         throw error
       }
     }
+
+    // Enrichment failing must not report a committed write as failed.
+    await attachItemsToStops([stop], context).catch(() => undefined)
+
+    return stop
   },
 })

--- a/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
@@ -6,7 +6,10 @@ import {
   GraphQLString,
 } from "graphql"
 import { mutationWithClientMutationId } from "graphql-relay"
+import { snakeCaseKeys } from "lib/helpers"
+import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
+import { attachItemsToStops } from "../stopItems"
 import { ItineraryStopCategory } from "../itineraryStop"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
@@ -38,7 +41,8 @@ export const updateItineraryStopMutation = mutationWithClientMutationId<
 >({
   name: "updateItineraryStop",
   description:
-    "Not implemented yet in Metaphysics. Calling this mutation always throws.",
+    "Update a stop. `position` moves it among its section's stops. " +
+    "`isFreeAdmission: null` clears the override.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
     itemType: { type: GraphQLString },
@@ -73,9 +77,28 @@ export const updateItineraryStopMutation = mutationWithClientMutationId<
       resolve: (result) => result,
     },
   },
-  mutateAndGetPayload: async (_args, _context) => {
-    throw new Error(
-      "updateItineraryStop is not implemented yet in Metaphysics."
-    )
+  mutateAndGetPayload: async ({ id, ...attributes }, context) => {
+    if (!context.updateItineraryStopLoader) {
+      throw new Error("You need to be signed in to perform this action")
+    }
+
+    try {
+      const stop = await context.updateItineraryStopLoader(
+        id,
+        snakeCaseKeys(attributes)
+      )
+
+      await attachItemsToStops([stop], context)
+
+      return stop
+    } catch (error) {
+      const formattedErr = formatGravityError(error)
+
+      if (formattedErr) {
+        return { ...formattedErr, _type: "GravityMutationError" }
+      } else {
+        throw error
+      }
+    }
   },
 })

--- a/src/schema/v2/schema.ts
+++ b/src/schema/v2/schema.ts
@@ -360,12 +360,15 @@ import { ItinerariesConnectionField } from "./itinerary/itinerariesConnection"
 import { copyItineraryMutation } from "./itinerary/mutations/copyItineraryMutation"
 import { createItineraryMutation } from "./itinerary/mutations/createItineraryMutation"
 import { createItinerarySectionMutation } from "./itinerary/mutations/createItinerarySectionMutation"
+import { createItineraryStopMutation } from "./itinerary/mutations/createItineraryStopMutation"
 import { deleteItineraryMutation } from "./itinerary/mutations/deleteItineraryMutation"
 import { deleteItinerarySectionMutation } from "./itinerary/mutations/deleteItinerarySectionMutation"
+import { deleteItineraryStopMutation } from "./itinerary/mutations/deleteItineraryStopMutation"
 import { publishItineraryMutation } from "./itinerary/mutations/publishItineraryMutation"
 import { unpublishItineraryMutation } from "./itinerary/mutations/unpublishItineraryMutation"
 import { updateItineraryMutation } from "./itinerary/mutations/updateItineraryMutation"
 import { updateItinerarySectionMutation } from "./itinerary/mutations/updateItinerarySectionMutation"
+import { updateItineraryStopMutation } from "./itinerary/mutations/updateItineraryStopMutation"
 import { ackTaskMutation } from "./me/ack_task_mutation"
 import { DiscoverArtworks } from "./infiniteDiscovery/discoverArtworks"
 import {
@@ -695,6 +698,7 @@ export default new GraphQLSchema({
       createInvoicePayment: createInvoicePaymentMutation,
       createItinerary: createItineraryMutation,
       createItinerarySection: createItinerarySectionMutation,
+      createItineraryStop: createItineraryStopMutation,
       createNavigationDraft: createNavigationDraftMutation,
       createNavigationItem: createNavigationItemMutation,
       createOrderedSet: createOrderedSetMutation,
@@ -765,6 +769,7 @@ export default new GraphQLSchema({
       deleteHeroUnit: deleteHeroUnitMutation,
       deleteItinerary: deleteItineraryMutation,
       deleteItinerarySection: deleteItinerarySectionMutation,
+      deleteItineraryStop: deleteItineraryStopMutation,
       deletePartnerList: deletePartnerListMutation,
       deletePartnerArtist: deletePartnerArtistMutation,
       deletePartnerContact: DeletePartnerContactMutation,
@@ -876,6 +881,7 @@ export default new GraphQLSchema({
       updateHeroUnit: updateHeroUnitMutation,
       updateItinerary: updateItineraryMutation,
       updateItinerarySection: updateItinerarySectionMutation,
+      updateItineraryStop: updateItineraryStopMutation,
       updateMeCollectionsMutation: updateMeCollectionsMutation,
       updateMessage: updateMessageMutation,
       updateMyPassword: updateMyPasswordMutation,


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-30

This is PR 4c of the split of #7884. It stacks on #7891 and adds the three itinerary stop mutations, wired to Gravity's `itinerary_stop` routes.

| Mutation | Gravity route | Notes |
| --- | --- | --- |
| `createItineraryStop` | `POST /itinerary_stop` | points at a show, a location, or a fair, or is a custom place with its own title and coordinates |
| `updateItineraryStop` | `PUT /itinerary_stop/:id` | `position` reorders the stop among its section's stops |
| `deleteItineraryStop` | `DELETE /itinerary_stop/:id` | deletes by stop id, not item id, since the same show can appear twice in one itinerary |

## Behaviour

- Every mutation requires a signed-in caller; otherwise it throws "You need to be signed in to perform this action".
- Inputs are mapped to Gravity's params with `snakeCaseKeys`; fields the client did not send are omitted, so a partial update only touches the fields sent.
- An explicit `null` (e.g. `isFreeAdmission: null`) reaches Gravity as `null`, which clears the override and makes the stop inherit admission from its item.
- `position` on `updateItineraryStop` runs Gravity's `insert_at` inside the same transaction as the attribute update, the same as sections.
- `createItineraryStop` and `updateItineraryStop` return the stop with its `item` resolved through the shared `attachItemsToStops` helper.
- Gravity validation and authorization errors come back as `ItineraryStopMutationFailure.mutationError`, with `type`, `message`, `statusCode`, and `fieldErrors`. Any other error rethrows.
- Item enrichment runs after the write, not inside the same try, so it cannot turn a committed write into a reported failure. If it fails, `item` resolves `null` for that response.

## Verified against staging

Ran the full sequence against staging Gravity through a local dev server: created a stop against a real `PartnerShow` (item resolved to the show's `internalID`/`name`), created a custom stop with `title`/`latitude`/`longitude`, updated the show stop (`position` and an explicit `isFreeAdmission: null`, which came back `null`), deleted the custom stop, and sent `createItineraryStop` with only `latitude` set, which came back as the expected failure member with a `param_error` and field errors for both `base` ("latitude and longitude must be set together") and `title` ("is required for a stop with no item").

Verify: `yarn jest src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
