### PR TITLE
feat: add enums for itinerary stop item and event types

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -23462,9 +23462,9 @@ type ItineraryStop {
   eventID: String
 
   """
-  PartnerShowEvent on a show stop, FairEvent on a fair stop. Null when the stop names no event.
+  SHOW_EVENT on a show stop, FAIR_EVENT on a fair stop; null when the stop names no event.
   """
-  eventType: String
+  eventType: ItineraryStopEventType
   imageURL: String
   internalID: String!
   isFreeAdmission: Boolean
@@ -23473,6 +23473,11 @@ type ItineraryStop {
   The Show, gallery location, or Fair this stop refers to, if any. A stop without an `item_id` (e.g. a café) resolves to null.
   """
   item: ItineraryStopItem
+
+  """
+  What kind of item this stop points at, if any
+  """
+  itemType: ItineraryStopItemType
   latitude: Float
   longitude: Float
   note: String
@@ -23509,7 +23514,24 @@ enum ItineraryStopCategory {
   SHOW
 }
 
+"""
+What kind of event a stop names
+"""
+enum ItineraryStopEventType {
+  FAIR_EVENT
+  SHOW_EVENT
+}
+
 union ItineraryStopItem = Fair | Location | Show
+
+"""
+What kind of item a stop points at
+"""
+enum ItineraryStopItemType {
+  FAIR
+  LOCATION
+  SHOW
+}
 
 type ItineraryStopMutationFailure {
   mutationError: GravityMutationError
@@ -45237,11 +45259,11 @@ input createItineraryStopInput {
   clientMutationId: String
   endAt: String
   eventID: String
-  eventType: String
+  eventType: ItineraryStopEventType
   imageURL: String
   isFreeAdmission: Boolean
   itemID: String
-  itemType: String
+  itemType: ItineraryStopItemType
   itinerarySectionID: String!
   latitude: Float
   longitude: Float
@@ -45948,12 +45970,12 @@ input updateItineraryStopInput {
   clientMutationId: String
   endAt: String
   eventID: String
-  eventType: String
+  eventType: ItineraryStopEventType
   id: String!
   imageURL: String
   isFreeAdmission: Boolean
   itemID: String
-  itemType: String
+  itemType: ItineraryStopItemType
   latitude: Float
   longitude: Float
   note: String

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -147,6 +147,7 @@ describe("Itinerary", () => {
               isFreeAdmission
               timeZone
               sourceURL
+              itemType
               eventType
               eventID
             }
@@ -172,11 +173,14 @@ describe("Itinerary", () => {
     const [show, gallery, custom] = section.stops
     expect(show.timeZone).toEqual("Europe/London")
     expect(show.sourceURL).toEqual("https://example.com/source")
-    expect(show.eventType).toEqual("PartnerShowEvent")
+    expect(show.itemType).toEqual("SHOW")
+    expect(show.eventType).toEqual("SHOW_EVENT")
     expect(show.eventID).toEqual("event-1")
     expect(gallery.category).toEqual("GALLERY")
     expect(custom.title).toEqual("Coffee at Monmouth")
     expect(custom.address).toEqual("2 Park Street, London SE1 9AB")
+    expect(custom.itemType).toBeNull()
+    expect(custom.eventType).toBeNull()
   })
 
   it("maps a non-public Gravity visibility value", async () => {

--- a/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itineraryStopMutations.test.ts
@@ -85,8 +85,10 @@ describe("createItineraryStop", () => {
       createItineraryStop(
         input: {
           itinerarySectionID: "section-id"
-          itemType: "PartnerShow"
+          itemType: SHOW
           itemID: "show-id"
+          eventType: SHOW_EVENT
+          eventID: "event-id"
           category: SHOW
           isFreeAdmission: true
           timeZone: "America/New_York"
@@ -110,10 +112,40 @@ describe("createItineraryStop", () => {
       itinerary_section_id: "section-id",
       item_type: "PartnerShow",
       item_id: "show-id",
+      event_type: "PartnerShowEvent",
+      event_id: "event-id",
       category: "SHOW",
       is_free_admission: true,
       time_zone: "America/New_York",
     })
+  })
+
+  it("rejects an invalid itemType before calling the loader", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await expect(
+      runAuthenticatedQuery(
+        gql`
+          mutation {
+            createItineraryStop(
+              input: {
+                itinerarySectionID: "section-id"
+                itemType: GALLERY
+                itemID: "show-id"
+              }
+            ) {
+              responseOrError {
+                ${successFragment}
+              }
+            }
+          }
+        `,
+        context
+      )
+    ).rejects.toThrow(/GALLERY/)
+
+    expect(loader).not.toHaveBeenCalled()
   })
 
   it("returns the success payload with the resolved item", async () => {
@@ -143,7 +175,7 @@ describe("createItineraryStop", () => {
           createItineraryStop(
             input: {
               itinerarySectionID: "section-id"
-              itemType: "PartnerShow"
+              itemType: SHOW
               itemID: "show-id"
               clientMutationId: "abc"
             }
@@ -213,7 +245,13 @@ describe("updateItineraryStop", () => {
   const mutation = gql`
     mutation {
       updateItineraryStop(
-        input: { id: "stop-id", position: 0, isFreeAdmission: null }
+        input: {
+          id: "stop-id"
+          position: 0
+          itemType: SHOW
+          eventType: SHOW_EVENT
+          isFreeAdmission: null
+        }
       ) {
         responseOrError {
           ${successFragment}
@@ -231,8 +269,32 @@ describe("updateItineraryStop", () => {
 
     expect(loader).toHaveBeenCalledWith("stop-id", {
       position: 0,
+      item_type: "PartnerShow",
+      event_type: "PartnerShowEvent",
       is_free_admission: null,
     })
+  })
+
+  it("rejects an invalid itemType before calling the loader", async () => {
+    const loader = jest.fn().mockResolvedValue(gravityStop())
+    const context = withShowsLoader(loader)
+
+    await expect(
+      runAuthenticatedQuery(
+        gql`
+          mutation {
+            updateItineraryStop(input: { id: "stop-id", itemType: GALLERY }) {
+              responseOrError {
+                ${successFragment}
+              }
+            }
+          }
+        `,
+        context
+      )
+    ).rejects.toThrow(/GALLERY/)
+
+    expect(loader).not.toHaveBeenCalled()
   })
 
   it("does not forward clientMutationId to Gravity", async () => {

--- a/src/schema/v2/itinerary/itineraryStop.ts
+++ b/src/schema/v2/itinerary/itineraryStop.ts
@@ -25,6 +25,25 @@ export const ItineraryStopCategory = new GraphQLEnumType({
   },
 })
 
+export const ItineraryStopItemType = new GraphQLEnumType({
+  name: "ItineraryStopItemType",
+  description: "What kind of item a stop points at",
+  values: {
+    SHOW: { value: "PartnerShow" },
+    LOCATION: { value: "PartnerLocation" },
+    FAIR: { value: "Fair" },
+  },
+})
+
+export const ItineraryStopEventType = new GraphQLEnumType({
+  name: "ItineraryStopEventType",
+  description: "What kind of event a stop names",
+  values: {
+    SHOW_EVENT: { value: "PartnerShowEvent" },
+    FAIR_EVENT: { value: "FairEvent" },
+  },
+})
+
 export const ItineraryStopItem = new GraphQLUnionType({
   name: "ItineraryStopItem",
   types: [ShowType, LocationType, FairType],
@@ -100,11 +119,16 @@ export const ItineraryStopType = new GraphQLObjectType<
       type: GraphQLBoolean,
       resolve: ({ is_free_admission }) => is_free_admission,
     },
+    itemType: {
+      description: "What kind of item this stop points at, if any",
+      type: ItineraryStopItemType,
+      resolve: ({ item_type }) => item_type,
+    },
     eventType: {
       description:
-        "PartnerShowEvent on a show stop, FairEvent on a fair stop. Null " +
-        "when the stop names no event.",
-      type: GraphQLString,
+        "SHOW_EVENT on a show stop, FAIR_EVENT on a fair stop; null when " +
+        "the stop names no event.",
+      type: ItineraryStopEventType,
       resolve: ({ event_type }) => event_type,
     },
     eventID: {

--- a/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/createItineraryStopMutation.ts
@@ -9,15 +9,20 @@ import { snakeCaseKeys } from "lib/helpers"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { attachItemsToStops } from "../stopItems"
-import { ItineraryStopCategory } from "../itineraryStop"
+import {
+  ItineraryStopCategory,
+  ItineraryStopItemType,
+  ItineraryStopEventType,
+} from "../itineraryStop"
+import { GravityItineraryStop } from "../types"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
 interface InputProps {
   clientMutationId?: string
   itinerarySectionID: string
-  itemType?: string
+  itemType?: GravityItineraryStop["item_type"]
   itemID?: string
-  eventType?: string
+  eventType?: GravityItineraryStop["event_type"]
   eventID?: string
   title?: string
   address?: string
@@ -44,9 +49,9 @@ export const createItineraryStopMutation = mutationWithClientMutationId<
     "fair, or is a custom place with its own title and coordinates.",
   inputFields: {
     itinerarySectionID: { type: new GraphQLNonNull(GraphQLString) },
-    itemType: { type: GraphQLString },
+    itemType: { type: ItineraryStopItemType },
     itemID: { type: GraphQLString },
-    eventType: { type: GraphQLString },
+    eventType: { type: ItineraryStopEventType },
     eventID: { type: GraphQLString },
     title: { type: GraphQLString },
     address: { type: GraphQLString },

--- a/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
+++ b/src/schema/v2/itinerary/mutations/updateItineraryStopMutation.ts
@@ -10,15 +10,20 @@ import { snakeCaseKeys } from "lib/helpers"
 import { formatGravityError } from "lib/gravityErrorHandler"
 import { ResolverContext } from "types/graphql"
 import { attachItemsToStops } from "../stopItems"
-import { ItineraryStopCategory } from "../itineraryStop"
+import {
+  ItineraryStopCategory,
+  ItineraryStopItemType,
+  ItineraryStopEventType,
+} from "../itineraryStop"
+import { GravityItineraryStop } from "../types"
 import { ItineraryStopMutationResponseOrErrorType } from "./itineraryStopMutationResponseOrError"
 
 interface InputProps {
   clientMutationId?: string
   id: string
-  itemType?: string
+  itemType?: GravityItineraryStop["item_type"]
   itemID?: string
-  eventType?: string
+  eventType?: GravityItineraryStop["event_type"]
   eventID?: string
   title?: string
   address?: string
@@ -46,9 +51,9 @@ export const updateItineraryStopMutation = mutationWithClientMutationId<
     "`isFreeAdmission: null` clears the override.",
   inputFields: {
     id: { type: new GraphQLNonNull(GraphQLString) },
-    itemType: { type: GraphQLString },
+    itemType: { type: ItineraryStopItemType },
     itemID: { type: GraphQLString },
-    eventType: { type: GraphQLString },
+    eventType: { type: ItineraryStopEventType },
     eventID: { type: GraphQLString },
     title: { type: GraphQLString },
     address: { type: GraphQLString },

--- a/src/schema/v2/itinerary/types.ts
+++ b/src/schema/v2/itinerary/types.ts
@@ -4,11 +4,11 @@ export interface GravityItineraryStop {
   id: string
   itinerary_section_id: string
   position: number
-  /** One of `PartnerShow`, `PartnerLocation`, `Fair`. Null for a custom stop. */
-  item_type: string | null
+  /** Null for a custom stop. */
+  item_type: "PartnerShow" | "PartnerLocation" | "Fair" | null
   item_id: string | null
-  /** `PartnerShowEvent` or `FairEvent`, and only on a show or fair stop. */
-  event_type: string | null
+  /** Only on a show or fair stop. */
+  event_type: "PartnerShowEvent" | "FairEvent" | null
   event_id: string | null
   /** Overrides the item's name. Required when there is no item. */
   title: string | null


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-31

This follows #7892 (merged) and turns `itemType` and `eventType` into enums on both the input and output side of `ItineraryStop`.

`ItineraryStopItemType`: `SHOW` → `PartnerShow`, `LOCATION` → `PartnerLocation`, `FAIR` → `Fair`.
`ItineraryStopEventType`: `SHOW_EVENT` → `PartnerShowEvent`, `FAIR_EVENT` → `FairEvent`.

Both enums use Gravity's strings as their internal values, so nothing maps: `snakeCaseKeys` passes the value straight through on the way to Gravity, and the resolvers pass Gravity's value straight through on the way out. Both live in `itineraryStop.ts`, next to `ItineraryStopCategory`.

`createItineraryStop` and `updateItineraryStop` take these enums for their `itemType` and `eventType` inputs. `ItineraryStop.itemType` is a new nullable read field (null for a custom stop). `ItineraryStop.eventType` changes from `String` to `ItineraryStopEventType` (also nullable).

**Breaking for eigen.** `ItineraryStop.eventType` now returns `SHOW_EVENT` or `FAIR_EVENT` instead of `PartnerShowEvent` or `FairEvent`. Eigen's itinerary screen selects this field; the owner will update eigen to match.

Dates stay strings. Metaphysics has no DateTime input scalar convention for this area, and Gravity already coerces ISO strings against the stop's `timeZone`.

Verified against the running local server (staging Gravity): created an itinerary, section, and a `PartnerShow` stop with `itemType: SHOW, eventType: SHOW_EVENT`; confirmed Gravity received `item_type: PartnerShow, event_type: PartnerShowEvent` and the item resolved; confirmed a custom stop reads `itemType: null, eventType: null`; confirmed `itemType: GALLERY` is rejected as a GraphQL validation error before any loader runs; confirmed the read path returns the same `itemType`/`eventType` values outside the mutation response.

Verify: `yarn jest src/schema/v2/itinerary`

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
