### PR TITLE
fix: stop logging when a Gravity error body is already parsed

### DIFF
--- a/src/lib/__tests__/gravityErrorHandler.test.ts
+++ b/src/lib/__tests__/gravityErrorHandler.test.ts
@@ -1,4 +1,5 @@
 import { formatGravityError } from "../gravityErrorHandler"
+import { HTTPError } from "../HTTPError"
 
 describe("gravityErrorHandler", () => {
   describe("formatGravityError", () => {
@@ -65,6 +66,40 @@ describe("gravityErrorHandler", () => {
       }
 
       expect(formatGravityError(unrecognizableError)).toEqual(null)
+    })
+
+    it("does not log when the HTTPError body is already an object", () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
+
+      const error = new HTTPError("Gravity error", 400, {
+        type: "param_error",
+        message: "Title can't be blank.",
+        detail: { title: ["can't be blank"] },
+      })
+
+      expect(formatGravityError(error)).toEqual({
+        fieldErrors: [{ name: "title", message: "can't be blank" }],
+        type: "param_error",
+        message: "Title can't be blank.",
+        statusCode: 400,
+      })
+      expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+      consoleErrorSpy.mockRestore()
+    })
+
+    it("still logs and returns an error when the HTTPError body is an unparsable string", () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
+
+      const error = new HTTPError("Gravity error", 400, "not json")
+
+      expect(formatGravityError(error)).toEqual({
+        type: "error",
+        message: "not json",
+      })
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+
+      consoleErrorSpy.mockRestore()
     })
   })
 })

--- a/src/lib/gravityErrorHandler.ts
+++ b/src/lib/gravityErrorHandler.ts
@@ -83,10 +83,12 @@ export const formatGravityError = (error) => {
     const freeBody: any = error.body
 
     let parsedError
-    try {
-      parsedError = JSON.parse(freeBody)
-    } catch {
-      console.error("Error parsing Gravity error", freeBody)
+    if (typeof freeBody === "string") {
+      try {
+        parsedError = JSON.parse(freeBody)
+      } catch {
+        console.error("Error parsing Gravity error", freeBody)
+      }
     }
 
     if (isObject(parsedError)) {


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-33

`formatGravityError` logged "Error parsing Gravity error" on every failed mutation, in tests and production, because `HTTPError.body` is already a parsed object for Gravity JSON errors and `JSON.parse(object)` always threw. The fix parses only when the body is a string, which is the only case that ever needs parsing. Every existing return path is unchanged; the returned objects are byte-identical to before.

Verify: yarn jest src/lib

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
