### PR TITLE
feat: resolve the event an itinerary stop names

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -19479,6 +19479,28 @@ type FairEdge {
   node: Fair
 }
 
+type FairEvent {
+  description: String
+  endAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+  internalID: ID!
+  name: String
+  startAt(
+    format: String
+
+    """
+    A tz database time zone, otherwise falls back to "X-TIMEZONE" header. See http://www.iana.org/time-zones, https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+    """
+    timezone: String
+  ): String
+}
+
 type FairExhibitor {
   """
   Exhibitor name
@@ -23459,6 +23481,11 @@ type ItineraryStop {
     """
     timezone: String
   ): String
+
+  """
+  The event this stop names inside its show or fair, when any
+  """
+  event: ItineraryStopEvent
   eventID: String
 
   """
@@ -23513,6 +23540,8 @@ enum ItineraryStopCategory {
   MUSEUM
   SHOW
 }
+
+union ItineraryStopEvent = FairEvent | ShowEventType
 
 """
 What kind of event a stop names

--- a/src/lib/loaders/loaders_with_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_with_authentication/gravity.ts
@@ -1448,6 +1448,7 @@ export default (accessToken, userID, opts) => {
     // Authenticated so a signed-in caller also sees their own private and unlisted itineraries.
     itineraryLoader: gravityLoader((id) => `itinerary/${id}`),
     itinerariesLoader: gravityLoader("itineraries", {}, { headers: true }),
+    fairEventsLoader: gravityLoader((id) => `fair/${id}/fair_events`),
     createItineraryLoader: gravityLoader("itinerary", {}, { method: "POST" }),
     updateItineraryLoader: gravityLoader(
       (id) => `itinerary/${id}`,

--- a/src/lib/loaders/loaders_without_authentication/gravity.ts
+++ b/src/lib/loaders/loaders_without_authentication/gravity.ts
@@ -337,6 +337,7 @@ export default (opts) => {
     showLoader: gravityLoader((id) => `show/${id}`),
     itineraryLoader: gravityLoader((id) => `itinerary/${id}`),
     itinerariesLoader: gravityLoader("itineraries", {}, { headers: true }),
+    fairEventsLoader: gravityLoader((id) => `fair/${id}/fair_events`),
     partnerLocationsByIdsLoader: gravityLoader("partner_locations"),
     showsLoader: gravityLoader("shows"),
     showsWithHeadersLoader: gravityLoader("shows", {}, { headers: true }),

--- a/src/schema/v2/fairEvent.ts
+++ b/src/schema/v2/fairEvent.ts
@@ -1,0 +1,28 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLID,
+} from "graphql"
+import { ResolverContext } from "types/graphql"
+import { date } from "schema/v2/fields/date"
+
+// Gravity's FairEvent JSON has no `_id`, only `id` (the raw Mongo id, not a
+// slug, unlike Fair). See app/models/domain/fair_event.rb `json_fields`.
+export const FairEventType = new GraphQLObjectType<any, ResolverContext>({
+  name: "FairEvent",
+  fields: {
+    internalID: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve: ({ id }) => id,
+    },
+    name: {
+      type: GraphQLString,
+    },
+    description: {
+      type: GraphQLString,
+    },
+    startAt: date(({ start_at }) => start_at),
+    endAt: date(({ end_at }) => end_at),
+  },
+})

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -282,6 +282,61 @@ describe("Itinerary", () => {
     expect(custom.event).toBeNull()
   })
 
+  it("resolves the event a fair stop names", async () => {
+    const fairItinerary = {
+      ...gravityItinerary,
+      sections: [
+        {
+          ...gravityItinerary.sections[0],
+          stops: [
+            {
+              ...gravityItinerary.sections[0].stops[0],
+              item_type: "Fair",
+              item_id: "fair-1",
+              event_type: "FairEvent",
+              event_id: "fair-event-1",
+            },
+          ],
+        },
+      ],
+    }
+
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          sections {
+            stops {
+              event {
+                __typename
+                ... on FairEvent { internalID name }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      ...loaders(),
+      itineraryLoader: jest.fn().mockResolvedValue(fairItinerary),
+      fairsLoader: jest
+        .fn()
+        .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} }),
+      fairEventsLoader: jest.fn().mockResolvedValue({
+        body: [{ id: "fair-event-1", name: "Booth Talk" }],
+        headers: {},
+      }),
+    }
+    const data = await runQuery(query, context)
+
+    const [stop] = data.itinerary.sections[0].stops
+    expect(stop.event).toEqual({
+      __typename: "FairEvent",
+      internalID: "fair-event-1",
+      name: "Booth Talk",
+    })
+  })
+
   it("resolves null on a Gravity 404", async () => {
     const query = `{ itinerary(id: "nope") { title } }`
 

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -322,10 +322,9 @@ describe("Itinerary", () => {
       fairsLoader: jest
         .fn()
         .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} }),
-      fairEventsLoader: jest.fn().mockResolvedValue({
-        body: [{ id: "fair-event-1", name: "Booth Talk" }],
-        headers: {},
-      }),
+      fairEventsLoader: jest
+        .fn()
+        .mockResolvedValue([{ id: "fair-event-1", name: "Booth Talk" }]),
     }
     const data = await runQuery(query, context)
 

--- a/src/schema/v2/itinerary/__tests__/itinerary.test.ts
+++ b/src/schema/v2/itinerary/__tests__/itinerary.test.ts
@@ -245,6 +245,43 @@ describe("Itinerary", () => {
     })
   })
 
+  it("resolves the event a show stop names", async () => {
+    const query = `
+      {
+        itinerary(id: "chill-vibes-only") {
+          sections {
+            stops {
+              event {
+                __typename
+                ... on ShowEventType { internalID }
+                ... on FairEvent { internalID }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    const context = {
+      ...loaders(),
+      showsLoader: jest.fn().mockResolvedValue([
+        {
+          _id: "show-1",
+          events: [{ _id: "event-1", title: "Opening Reception" }],
+        },
+      ]),
+    }
+    const data = await runQuery(query, context)
+
+    const [show, gallery, custom] = data.itinerary.sections[0].stops
+    expect(show.event).toEqual({
+      __typename: "ShowEventType",
+      internalID: "event-1",
+    })
+    expect(gallery.event).toBeNull()
+    expect(custom.event).toBeNull()
+  })
+
   it("resolves null on a Gravity 404", async () => {
     const query = `{ itinerary(id: "nope") { title } }`
 

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -315,13 +315,10 @@ describe("event resolution", () => {
     const fairsLoader = jest
       .fn()
       .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} })
-    const fairEventsLoader = jest.fn().mockResolvedValue({
-      body: [
-        { id: "fair-event-1", name: "Booth Talk" },
-        { id: "fair-event-2", name: "VIP Preview" },
-      ],
-      headers: {},
-    })
+    const fairEventsLoader = jest.fn().mockResolvedValue([
+      { id: "fair-event-1", name: "Booth Talk" },
+      { id: "fair-event-2", name: "VIP Preview" },
+    ])
 
     const stops = [
       buildStop({
@@ -381,10 +378,7 @@ describe("event resolution", () => {
   it("leaves a rejecting fair's events null and resolves the other fair's events", async () => {
     const fairEventsLoader = jest.fn().mockImplementation((fairId) => {
       if (fairId === "fair-bad") return Promise.reject(new Error("Gravity 500"))
-      return Promise.resolve({
-        body: [{ id: "fair-event-1", name: "Booth Talk" }],
-        headers: {},
-      })
+      return Promise.resolve([{ id: "fair-event-1", name: "Booth Talk" }])
     })
 
     const stops = [

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -377,6 +377,42 @@ describe("event resolution", () => {
     expect((stops[0] as any)._resolvedEvent).toBeNull()
     expect(fairEventsLoader).not.toHaveBeenCalled()
   })
+
+  it("leaves a rejecting fair's events null and resolves the other fair's events", async () => {
+    const fairEventsLoader = jest.fn().mockImplementation((fairId) => {
+      if (fairId === "fair-bad") return Promise.reject(new Error("Gravity 500"))
+      return Promise.resolve({
+        body: [{ id: "fair-event-1", name: "Booth Talk" }],
+        headers: {},
+      })
+    })
+
+    const stops = [
+      buildStop({
+        item_type: "Fair",
+        item_id: "fair-bad",
+        event_type: "FairEvent",
+        event_id: "fair-event-1",
+      }),
+      buildStop({
+        item_type: "Fair",
+        item_id: "fair-good",
+        event_type: "FairEvent",
+        event_id: "fair-event-1",
+      }),
+    ]
+
+    await expect(
+      attachItemsToStops(stops, { fairEventsLoader } as any)
+    ).resolves.toBe(stops)
+
+    expect((stops[0] as any)._resolvedEvent).toBeNull()
+    expect((stops[1] as any)._resolvedEvent).toEqual({
+      id: "fair-event-1",
+      name: "Booth Talk",
+      __typename: "FairEvent",
+    })
+  })
 })
 
 describe("attachItemsToStops", () => {

--- a/src/schema/v2/itinerary/__tests__/stopItems.test.ts
+++ b/src/schema/v2/itinerary/__tests__/stopItems.test.ts
@@ -279,6 +279,106 @@ describe("attachStopItems", () => {
   })
 })
 
+describe("event resolution", () => {
+  it("picks a show event out of the show payload with no fair loader call", async () => {
+    const showsLoader = jest.fn().mockResolvedValue([
+      {
+        _id: "show-1",
+        events: [
+          { _id: "event-1", title: "Opening Reception" },
+          { _id: "event-2", title: "Closing Reception" },
+        ],
+      },
+    ])
+    const fairEventsLoader = jest.fn()
+
+    const stops = [
+      buildStop({
+        item_type: "PartnerShow",
+        item_id: "show-1",
+        event_type: "PartnerShowEvent",
+        event_id: "event-1",
+      }),
+    ]
+
+    await attachItemsToStops(stops, { showsLoader, fairEventsLoader } as any)
+
+    expect((stops[0] as any)._resolvedEvent).toEqual({
+      _id: "event-1",
+      title: "Opening Reception",
+      __typename: "ShowEventType",
+    })
+    expect(fairEventsLoader).not.toHaveBeenCalled()
+  })
+
+  it("resolves a fair event with one fairEventsLoader call for two stops on the same fair", async () => {
+    const fairsLoader = jest
+      .fn()
+      .mockResolvedValue({ body: [{ _id: "fair-1" }], headers: {} })
+    const fairEventsLoader = jest.fn().mockResolvedValue({
+      body: [
+        { id: "fair-event-1", name: "Booth Talk" },
+        { id: "fair-event-2", name: "VIP Preview" },
+      ],
+      headers: {},
+    })
+
+    const stops = [
+      buildStop({
+        item_type: "Fair",
+        item_id: "fair-1",
+        event_type: "FairEvent",
+        event_id: "fair-event-1",
+      }),
+      buildStop({
+        item_type: "Fair",
+        item_id: "fair-1",
+        event_type: "FairEvent",
+        event_id: "fair-event-2",
+      }),
+    ]
+
+    await attachItemsToStops(stops, { fairsLoader, fairEventsLoader } as any)
+
+    expect(fairEventsLoader).toHaveBeenCalledTimes(1)
+    expect(fairEventsLoader).toHaveBeenCalledWith("fair-1")
+    expect(stops.map((stop: any) => stop._resolvedEvent)).toEqual([
+      { id: "fair-event-1", name: "Booth Talk", __typename: "FairEvent" },
+      { id: "fair-event-2", name: "VIP Preview", __typename: "FairEvent" },
+    ])
+  })
+
+  it("resolves null when the event id doesn't match any event", async () => {
+    const showsLoader = jest
+      .fn()
+      .mockResolvedValue([{ _id: "show-1", events: [] }])
+
+    const stops = [
+      buildStop({
+        item_type: "PartnerShow",
+        item_id: "show-1",
+        event_type: "PartnerShowEvent",
+        event_id: "gone",
+      }),
+    ]
+
+    await attachItemsToStops(stops, { showsLoader } as any)
+
+    expect((stops[0] as any)._resolvedEvent).toBeNull()
+  })
+
+  it("resolves null and calls no loader for a stop with no event", async () => {
+    const fairEventsLoader = jest.fn()
+
+    const stops = [buildStop({})]
+
+    await attachItemsToStops(stops, { fairEventsLoader } as any)
+
+    expect((stops[0] as any)._resolvedEvent).toBeNull()
+    expect(fairEventsLoader).not.toHaveBeenCalled()
+  })
+})
+
 describe("attachItemsToStops", () => {
   it("resolves a flat list of stops in a single batch and stamps each one", async () => {
     const showsLoader = jest.fn().mockResolvedValue([{ _id: "show-1" }])

--- a/src/schema/v2/itinerary/itineraryStop.ts
+++ b/src/schema/v2/itinerary/itineraryStop.ts
@@ -13,6 +13,8 @@ import { date } from "schema/v2/fields/date"
 import { ShowType } from "schema/v2/show"
 import { LocationType } from "schema/v2/location"
 import { FairType } from "schema/v2/fair"
+import ShowEventType from "schema/v2/show_event"
+import { FairEventType } from "schema/v2/fairEvent"
 import { StopWithResolvedItem } from "./stopItems"
 
 export const ItineraryStopCategory = new GraphQLEnumType({
@@ -58,6 +60,21 @@ export const ItineraryStopItem = new GraphQLUnionType({
         return FairType.name
       default:
         return null
+    }
+  },
+})
+
+export const ItineraryStopEvent = new GraphQLUnionType({
+  name: "ItineraryStopEvent",
+  types: [ShowEventType, FairEventType],
+  resolveType: (value) => {
+    switch (value?.__typename) {
+      case "ShowEventType":
+        return ShowEventType.name
+      case "FairEvent":
+        return FairEventType.name
+      default:
+        return undefined
     }
   },
 })
@@ -149,6 +166,12 @@ export const ItineraryStopType = new GraphQLObjectType<
       // `_resolvedItem` is filled by `attachStopItems`, which every
       // resolver returning an `Itinerary` must call first.
       resolve: ({ _resolvedItem }) => _resolvedItem ?? null,
+    },
+    event: {
+      description:
+        "The event this stop names inside its show or fair, when any",
+      type: ItineraryStopEvent,
+      resolve: ({ _resolvedEvent }) => _resolvedEvent ?? null,
     },
   },
 })

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -109,13 +109,18 @@ const loadFairEvents = async (
 
   await Promise.all(
     fairIds.map(async (fairId) => {
-      const result = await loader(fairId)
-      const events: any[] = Array.isArray(result) ? result : result.body
-      const byEventId = new Map<string, Record<string, unknown>>()
-      for (const event of events) {
-        byEventId.set(event.id, event)
+      // A fair's events are peripheral; don't fail the page for them.
+      try {
+        const result = await loader(fairId)
+        const events: any[] = Array.isArray(result) ? result : result.body
+        const byEventId = new Map<string, Record<string, unknown>>()
+        for (const event of events) {
+          byEventId.set(event.id, event)
+        }
+        byFairId.set(fairId, byEventId)
+      } catch {
+        byFairId.set(fairId, new Map())
       }
-      byFairId.set(fairId, byEventId)
     })
   )
 

--- a/src/schema/v2/itinerary/stopItems.ts
+++ b/src/schema/v2/itinerary/stopItems.ts
@@ -35,8 +35,14 @@ const mapKey = (itemType: string, itemId: string) => `${itemType}:${itemId}`
 // A resolved Show, Location, or Fair, tagged for `ItineraryStopItem.resolveType`.
 export type ResolvedStopItem = Record<string, unknown> & { __typename: string }
 
+// A resolved show or fair event, tagged for `ItineraryStopEvent.resolveType`.
+export type ResolvedStopEvent = Record<string, unknown> & {
+  __typename: "ShowEventType" | "FairEvent"
+}
+
 export type StopWithResolvedItem = GravityItineraryStop & {
   _resolvedItem?: ResolvedStopItem | null
+  _resolvedEvent?: ResolvedStopEvent | null
 }
 
 // One loader call per item type; returns a map keyed "<item_type>:<item_id>".
@@ -91,7 +97,53 @@ export const loadStopItems = async (
   return map
 }
 
-// Loads and stamps `_resolvedItem` on each stop, in place.
+// One `fairEventsLoader` call per distinct fair id; returns each fair's
+// events keyed by id.
+const loadFairEvents = async (
+  fairIds: string[],
+  context: ResolverContext
+): Promise<Map<string, Map<string, Record<string, unknown>>>> => {
+  const byFairId = new Map<string, Map<string, Record<string, unknown>>>()
+  const loader = context.fairEventsLoader
+  if (!loader || fairIds.length === 0) return byFairId
+
+  await Promise.all(
+    fairIds.map(async (fairId) => {
+      const result = await loader(fairId)
+      const events: any[] = Array.isArray(result) ? result : result.body
+      const byEventId = new Map<string, Record<string, unknown>>()
+      for (const event of events) {
+        byEventId.set(event.id, event)
+      }
+      byFairId.set(fairId, byEventId)
+    })
+  )
+
+  return byFairId
+}
+
+// The event a stop names, if any. Always null, never undefined.
+const resolveStopEvent = (
+  stop: StopWithResolvedItem,
+  fairEventsByFairId: Map<string, Map<string, Record<string, unknown>>>
+): ResolvedStopEvent | null => {
+  if (!stop.event_id) return null
+
+  if (stop.event_type === "PartnerShowEvent") {
+    const events = (stop._resolvedItem?.events as any[]) ?? []
+    const event = events.find((candidate) => candidate._id === stop.event_id)
+    return event ? { ...event, __typename: "ShowEventType" } : null
+  }
+
+  if (stop.event_type === "FairEvent" && stop.item_id) {
+    const event = fairEventsByFairId.get(stop.item_id)?.get(stop.event_id)
+    return event ? { ...event, __typename: "FairEvent" } : null
+  }
+
+  return null
+}
+
+// Loads and stamps `_resolvedItem` and `_resolvedEvent` on each stop.
 export const attachItemsToStops = async (
   stops: StopWithResolvedItem[],
   context: ResolverContext
@@ -103,6 +155,19 @@ export const attachItemsToStops = async (
       stop.item_id && isStopItemType(stop.item_type)
         ? itemsByKey.get(mapKey(stop.item_type, stop.item_id)) ?? null
         : null
+  }
+
+  const fairIds = Array.from(
+    new Set(
+      stops
+        .filter((stop) => stop.event_type === "FairEvent" && stop.item_id)
+        .map((stop) => stop.item_id as string)
+    )
+  )
+  const fairEventsByFairId = await loadFairEvents(fairIds, context)
+
+  for (const stop of stops) {
+    stop._resolvedEvent = resolveStopEvent(stop, fairEventsByFairId)
   }
 
   return stops


### PR DESCRIPTION
## Disclaimer: I have read and I have reviewed changes in this PR

Jira: https://artsyproduct.atlassian.net/browse/FIREWORKS-32

Adds `ItineraryStop.event`, a `ShowEventType | FairEvent` union naming the
event a stop points at inside its show or fair (e.g. an opening reception).

Resolution stays inside the existing stop-item batching pass in
`stopItems.ts`, after items are loaded:

- A show stop's event is picked out of the show payload's own `events` array
  (Gravity's shows index already returns each show's events, so there is no
  extra call). Matched by `_id`.
- A fair stop's event costs one `fairEventsLoader` call per distinct fair
  (`GET fair/:id/fair_events`), because Gravity has no route that fetches fair
  events by a list of ids or embeds them on the Fair payload. Matched by `id`
  (Gravity's fair event JSON has no `_id`).
- A missing or unmatched event resolves `null`, never left `undefined`.
- No per-node loader call is added: both loader calls happen once per page,
  batched by distinct fair id.
- A failing fair events fetch leaves that fair's events null instead of
  failing the whole page.

Verify: `yarn jest src/schema/v2/itinerary`

Live check against staging itinerary `mp-fixture-chelsea-gallery-day`: the
show stop with event `69ee812d534302087fe5defb` returns
`event { __typename: "ShowEventType", internalID: "69ee812d534302087fe5defb" }`;
every other stop returns `event: null`. No staging fair fixture with an event
was available, so fair event resolution is covered by unit test only.

Assisted-by: Claude:Sonnet-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
