### PR TITLE
fix: get artist instagram media images from the nested image payload

### DIFF
--- a/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
+++ b/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
@@ -135,6 +135,8 @@ describe("artist.instagramMedia", () => {
             image {
               url(version: ["large"])
               imageVersions
+              isProcessing
+              processingFailed
             }
           }
         }
@@ -150,10 +152,40 @@ describe("artist.instagramMedia", () => {
             image: {
               url: "https://scontent.cdninstagram.com/1.jpg",
               imageVersions: [],
+              isProcessing: false,
+              processingFailed: false,
             },
           },
         ],
       },
+    })
+  })
+
+  it("reports processing as failed once Gemini was asked and nothing arrived", async () => {
+    media[0].image.gemini_token_updated_at = new Date(
+      Date.now() - 45 * 60 * 1000
+    ).toISOString()
+    media[0].image.image_urls = null
+    media[0].image.image_versions = []
+
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            image {
+              isProcessing
+              processingFailed
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.artist.instagramMedia[0].image).toEqual({
+      isProcessing: false,
+      processingFailed: true,
     })
   })
 

--- a/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
+++ b/src/schema/v2/artist/__tests__/artistInstagramMedia.test.ts
@@ -8,18 +8,44 @@ describe("artist.instagramMedia", () => {
   beforeEach(() => {
     media = [
       {
-        id: "1",
-        media_type: "IMAGE",
-        media_url: "https://example.com/1.jpg",
+        id: "post-1",
+        external_post_id: "ig-1",
         permalink: "https://instagram.com/p/1",
         caption: "one",
+        published_at: "2026-09-02T12:00:00+00:00",
+        image: {
+          id: "image-1",
+          gemini_token: "token-1",
+          gemini_token_updated_at: "2026-09-02T12:00:01+00:00",
+          image_url: "https://d7hftxdivxxvm.cloudfront.net/abc/:version.jpg",
+          image_urls: {
+            large: "https://d7hftxdivxxvm.cloudfront.net/abc/large.jpg",
+          },
+          image_versions: ["large"],
+          original_width: 1080,
+          original_height: 1350,
+          aspect_ratio: 0.8,
+        },
       },
       {
-        id: "2",
-        media_type: "IMAGE",
-        media_url: "https://example.com/2.jpg",
+        id: "post-2",
+        external_post_id: "ig-2",
         permalink: "https://instagram.com/p/2",
         caption: "two",
+        published_at: "2026-09-01T12:00:00+00:00",
+        image: {
+          id: "image-2",
+          gemini_token: "token-2",
+          gemini_token_updated_at: "2026-09-01T12:00:01+00:00",
+          image_url: "https://d7hftxdivxxvm.cloudfront.net/def/:version.jpg",
+          image_urls: {
+            large: "https://d7hftxdivxxvm.cloudfront.net/def/large.jpg",
+          },
+          image_versions: ["large"],
+          original_width: 1080,
+          original_height: 1080,
+          aspect_ratio: 1,
+        },
       },
     ]
 
@@ -38,7 +64,10 @@ describe("artist.instagramMedia", () => {
             permalink
             caption
             image {
-              url
+              url(version: ["large"])
+              aspectRatio
+              width
+              height
             }
           }
         }
@@ -51,19 +80,157 @@ describe("artist.instagramMedia", () => {
       artist: {
         instagramMedia: [
           {
-            internalID: "1",
+            internalID: "post-1",
             permalink: "https://instagram.com/p/1",
             caption: "one",
-            image: { url: "https://example.com/1.jpg" },
+            image: {
+              url: "https://d7hftxdivxxvm.cloudfront.net/abc/large.jpg",
+              aspectRatio: 0.8,
+              width: 1080,
+              height: 1350,
+            },
           },
           {
-            internalID: "2",
+            internalID: "post-2",
             permalink: "https://instagram.com/p/2",
             caption: "two",
-            image: { url: "https://example.com/2.jpg" },
+            image: {
+              url: "https://d7hftxdivxxvm.cloudfront.net/def/large.jpg",
+              aspectRatio: 1,
+              width: 1080,
+              height: 1080,
+            },
           },
         ],
       },
+    })
+  })
+
+  it("serves the provider url until the image has been processed", async () => {
+    media = [
+      {
+        id: "post-1",
+        external_post_id: "ig-1",
+        permalink: "https://instagram.com/p/1",
+        caption: "one",
+        published_at: "2026-09-02T12:00:00+00:00",
+        image: {
+          id: null,
+          gemini_token: null,
+          gemini_token_updated_at: null,
+          image_url: "https://scontent.cdninstagram.com/1.jpg",
+          image_urls: null,
+          image_versions: [],
+          original_width: null,
+          original_height: null,
+          aspect_ratio: null,
+        },
+      },
+    ]
+
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            image {
+              url(version: ["large"])
+              imageVersions
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      artist: {
+        instagramMedia: [
+          {
+            image: {
+              url: "https://scontent.cdninstagram.com/1.jpg",
+              imageVersions: [],
+            },
+          },
+        ],
+      },
+    })
+  })
+
+  it("reports a processed image as no longer processing", async () => {
+    media[0].image.gemini_token_updated_at = new Date().toISOString()
+
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            image {
+              isProcessing
+              processingFailed
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.artist.instagramMedia[0].image).toEqual({
+      isProcessing: false,
+      processingFailed: false,
+    })
+  })
+
+  it("reports an unprocessed image as processing while within the grace period", async () => {
+    media[0].image.gemini_token_updated_at = new Date().toISOString()
+    media[0].image.image_urls = null
+    media[0].image.image_versions = []
+
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            image {
+              isProcessing
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data.artist.instagramMedia[0].image).toEqual({ isProcessing: true })
+  })
+
+  it("returns no image when the post has neither a processed nor a provider url", async () => {
+    media = [
+      {
+        id: "post-1",
+        external_post_id: "ig-1",
+        permalink: "https://instagram.com/p/1",
+        caption: "one",
+        published_at: "2026-09-02T12:00:00+00:00",
+        image: null,
+      },
+    ]
+
+    const query = gql`
+      {
+        artist(id: "artistID") {
+          instagramMedia {
+            image {
+              url
+            }
+          }
+        }
+      }
+    `
+
+    const data = await runQuery(query, context)
+
+    expect(data).toEqual({
+      artist: { instagramMedia: [{ image: null }] },
     })
   })
 
@@ -82,7 +249,7 @@ describe("artist.instagramMedia", () => {
 
     expect(data).toEqual({
       artist: {
-        instagramMedia: [{ internalID: "1" }],
+        instagramMedia: [{ internalID: "post-1" }],
       },
     })
   })

--- a/src/schema/v2/artist/artistInstagramMedia.ts
+++ b/src/schema/v2/artist/artistInstagramMedia.ts
@@ -25,7 +25,13 @@ const ArtistInstagramMediaType = new GraphQLObjectType<any, ResolverContext>({
     },
     image: {
       type: Image.type,
-      resolve: ({ media_url }) => normalizeImageData(media_url),
+      resolve: ({ image }) => {
+        if (!image) return null
+        return {
+          ...normalizeImageData(image, true),
+          gemini_template_key: "artist-social-post",
+        }
+      },
     },
   },
 })
@@ -41,8 +47,6 @@ export const InstagramMedia: GraphQLFieldConfig<any, ResolverContext> = {
   },
   resolve: async ({ id }, { first }, { artistInstagramMediaLoader }) => {
     const body = (await artistInstagramMediaLoader(id)) || []
-    return typeof first === "number"
-      ? body.slice(0, Math.max(0, first))
-      : body
+    return typeof first === "number" ? body.slice(0, Math.max(0, first)) : body
   },
 }

--- a/src/schema/v2/image/__tests__/imageHelper.test.ts
+++ b/src/schema/v2/image/__tests__/imageHelper.test.ts
@@ -215,6 +215,15 @@ describe("imageHelper", () => {
       expect(hasProcessingFailed(image)).toBe(true)
     })
 
+    it("returns false when nothing has been submitted to Gemini yet", () => {
+      const image = {
+        image_url: "https://scontent.cdninstagram.com/1.jpg",
+        image_versions: [],
+        gemini_token_updated_at: null,
+      }
+      expect(hasProcessingFailed(image)).toBe(false)
+    })
+
     it("returns true when image has some versions but not normalized and no gemini_token_updated_at", () => {
       const image = {
         image_url: "https://example.com/image.jpg",

--- a/src/schema/v2/image/imageHelper.ts
+++ b/src/schema/v2/image/imageHelper.ts
@@ -16,12 +16,14 @@ export const EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE = {
     "tall",
   ],
   "brand-kit-logo": ["logo_brand_kit"],
+  "artist-social-post": ["large"],
 } as const
 
 // The last version Gemini emits per template — its presence signals processing is complete.
 export const COMPLETION_VERSION_BY_TEMPLATE = {
   "additional-image": "normalized",
   "brand-kit-logo": "logo_brand_kit",
+  "artist-social-post": "large",
 } as const
 
 type TemplateKey = keyof typeof EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE

--- a/src/schema/v2/image/imageHelper.ts
+++ b/src/schema/v2/image/imageHelper.ts
@@ -71,6 +71,10 @@ export const isProcessingImage = (image) => {
 
 // Check if image processing has failed
 export const hasProcessingFailed = (image) => {
+  if (!image.gemini_token_updated_at && !image.image_versions?.length) {
+    return false
+  }
+
   // Processing is not failed if image is missing original or still processing
   if (isProcessingImage(image)) {
     return false


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/EMI-3391

Following https://github.com/artsy/gravity/pull/20513, each post's image is now a nested object carrying the standard `image_url` / `image_urls` / `image_versions` contract instead of a bare, expiring `media_url`. The resolver was reading a key that no longer exists and `instagramMedia[].image` resolved to null in every state.

Two changes:

- The resolver reads `{ image }` and passes `includeAll`, which keeps the object when only image_url is set — the state while Gemini is still processing. `setVersion` falls back to `image_url` when no requested version matches, so a client asking for large gets the Instagram URL before processing and the Gemini URL after, with no branching.

- Registers artist-social-post in `EXPECTED_IMAGE_VERSIONS_BY_TEMPLATE` and `COMPLETION_VERSION_BY_TEMPLATE`. 