### PR TITLE
chore: actionable insights

### DIFF
--- a/_schemaV2.graphql
+++ b/_schemaV2.graphql
@@ -1439,6 +1439,11 @@ type AnalyticsPartnerSalesStats {
   orderCount: Int!
 
   """
+  Percentage (0-100) of orders/offers the partner responded to
+  """
+  orderResponseRate: Float
+
+  """
   Order response time in seconds
   """
   orderResponseTime: Int
@@ -29523,6 +29528,11 @@ type Partner implements Node {
   initials(length: Int = 3): String
 
   """
+  Aggregate metrics for the partner's unanswered inquiries, composed from Impulse conversations and Gravity collector profiles
+  """
+  inquiryMetrics: PartnerInquiryMetrics
+
+  """
   Inquiry Request details
   """
   inquiryRequest(
@@ -30842,6 +30852,18 @@ type PartnerGenomeGenesConnectionEdge {
   The item at the end of the edge
   """
   node: PartnerGenomeGene
+}
+
+type PartnerInquiryMetrics {
+  """
+  Number of confirmed buyers whose inquiries are still awaiting a response from the partner
+  """
+  confirmedBuyersWaitingCount: Int
+
+  """
+  Number of inquiries still awaiting a response from the partner
+  """
+  unansweredCount: Int
 }
 
 type PartnerInquiryRequest {

--- a/src/data/vortex.graphql
+++ b/src/data/vortex.graphql
@@ -642,6 +642,11 @@ type PartnerSalesStats {
   orderCount: Int!
 
   """
+  Percentage (0-100) of orders/offers the partner responded to
+  """
+  orderResponseRate: Float
+
+  """
   Order response time in seconds
   """
   orderResponseTime: Int

--- a/src/schema/v2/partner/__tests__/partnerInquiryMetrics.test.ts
+++ b/src/schema/v2/partner/__tests__/partnerInquiryMetrics.test.ts
@@ -1,0 +1,115 @@
+import { runAuthenticatedQuery, runQuery } from "schema/v2/test/utils"
+import gql from "lib/gql"
+
+describe("Partner inquiry metrics", () => {
+  const query = gql`
+    {
+      partner(id: "example-partner") {
+        inquiryMetrics {
+          confirmedBuyersWaitingCount
+          unansweredCount
+        }
+      }
+    }
+  `
+
+  const partnerLoader = jest.fn().mockReturnValue(
+    Promise.resolve({
+      id: "example-partner",
+      _id: "partner-internal-id",
+    })
+  )
+
+  it("composes unanswered conversations with confirmed-buyer collector profiles", async () => {
+    const conversationsLoader = jest.fn().mockResolvedValue({
+      total_count: 7,
+      conversations: [
+        { from_id: "user-1" },
+        { from_id: "user-2" },
+        { from_id: "user-2" }, // repeat inquirer deduplicated
+        { from_id: null }, // anonymous inquirer excluded
+      ],
+    })
+
+    const partnerCollectorProfilesLoader = jest.fn().mockResolvedValue({
+      body: [
+        { collector_profile: { confirmed_buyer_at: "2024-01-01T00:00:00Z" } },
+        { collector_profile: { confirmed_buyer_at: null } },
+      ],
+      headers: {},
+    })
+
+    const { partner } = await runAuthenticatedQuery(query, {
+      partnerLoader,
+      conversationsLoader,
+      partnerCollectorProfilesLoader,
+      userID: "user-id",
+      accessToken: "access-token",
+    })
+
+    expect(conversationsLoader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to_id: "partner-internal-id",
+        to_type: "Partner",
+        has_message: true,
+        has_reply: false,
+        dismissed: false,
+        to_be_replied: true,
+      })
+    )
+    expect(partnerCollectorProfilesLoader).toHaveBeenCalledWith({
+      partner_id: "partner-internal-id",
+      user_ids: ["user-1", "user-2"],
+      size: 2,
+    })
+    expect(partner.inquiryMetrics).toEqual({
+      confirmedBuyersWaitingCount: 1,
+      unansweredCount: 7,
+    })
+  })
+
+  it("skips the collector profile lookup when there are no unanswered conversations", async () => {
+    const conversationsLoader = jest.fn().mockResolvedValue({
+      total_count: 0,
+      conversations: [],
+    })
+    const partnerCollectorProfilesLoader = jest.fn()
+
+    const { partner } = await runAuthenticatedQuery(query, {
+      partnerLoader,
+      conversationsLoader,
+      partnerCollectorProfilesLoader,
+      userID: "user-id",
+      accessToken: "access-token",
+    })
+
+    expect(partnerCollectorProfilesLoader).not.toHaveBeenCalled()
+    expect(partner.inquiryMetrics).toEqual({
+      confirmedBuyersWaitingCount: 0,
+      unansweredCount: 0,
+    })
+  })
+
+  it("returns null when a loader errors", async () => {
+    const conversationsLoader = jest
+      .fn()
+      .mockRejectedValue(new Error("Impulse unavailable"))
+    const partnerCollectorProfilesLoader = jest.fn()
+
+    const { partner } = await runAuthenticatedQuery(query, {
+      partnerLoader,
+      conversationsLoader,
+      partnerCollectorProfilesLoader,
+      userID: "user-id",
+      accessToken: "access-token",
+    })
+
+    expect(partner.inquiryMetrics).toBeNull()
+  })
+
+  it("returns null when unauthenticated (no loaders available)", async () => {
+    const { partner } = await runQuery(query, { partnerLoader })
+
+    expect(partner.inquiryMetrics).toBeNull()
+  })
+})

--- a/src/schema/v2/partner/partner.ts
+++ b/src/schema/v2/partner/partner.ts
@@ -1205,6 +1205,89 @@ export const PartnerType = new GraphQLObjectType<any, ResolverContext>({
           }
         },
       },
+      inquiryMetrics: {
+        type: new GraphQLObjectType<any, ResolverContext>({
+          name: "PartnerInquiryMetrics",
+          fields: {
+            confirmedBuyersWaitingCount: {
+              type: GraphQLInt,
+              description:
+                "Number of confirmed buyers whose inquiries are still awaiting a response from the partner",
+              resolve: ({ confirmed_buyers_waiting_count }) =>
+                confirmed_buyers_waiting_count,
+            },
+            unansweredCount: {
+              type: GraphQLInt,
+              description:
+                "Number of inquiries still awaiting a response from the partner",
+              resolve: ({ unanswered_count }) => unanswered_count,
+            },
+          },
+        }),
+        description:
+          "Aggregate metrics for the partner's unanswered inquiries, composed from Impulse conversations and Gravity collector profiles",
+        resolve: async (
+          { _id },
+          _args,
+          { conversationsLoader, partnerCollectorProfilesLoader }
+        ) => {
+          if (!conversationsLoader || !partnerCollectorProfilesLoader) {
+            return null
+          }
+
+          // Confirmed-buyer inquirers are only counted within the most
+          // recent batch of unanswered conversations.
+          const UNANSWERED_CONVERSATIONS_SCAN_LIMIT = 50
+
+          try {
+            // Same filters as the CMS unanswered-inquiries view, so counts
+            // always match what the partner sees when clicking through.
+            const { total_count, conversations } = await conversationsLoader({
+              page: 1,
+              size: UNANSWERED_CONVERSATIONS_SCAN_LIMIT,
+              deleted: false,
+              intercepted: false,
+              to_id: _id,
+              to_type: "Partner",
+              has_message: true,
+              has_reply: false,
+              dismissed: false,
+              to_be_replied: true,
+            })
+
+            const userIds = [
+              ...new Set(
+                (conversations ?? [])
+                  .map((conversation) => conversation.from_id)
+                  .filter((id): id is string => !!id)
+              ),
+            ]
+
+            let confirmedBuyersWaitingCount = 0
+            if (userIds.length > 0) {
+              const { body } = await partnerCollectorProfilesLoader({
+                partner_id: _id,
+                user_ids: userIds,
+                size: userIds.length,
+              })
+              confirmedBuyersWaitingCount = body.filter(
+                (item) => item.collector_profile?.confirmed_buyer_at
+              ).length
+            }
+
+            return {
+              unanswered_count: total_count,
+              confirmed_buyers_waiting_count: confirmedBuyersWaitingCount,
+            }
+          } catch (error) {
+            console.error(
+              "[partner/inquiryMetrics] Error fetching metrics:",
+              error
+            )
+            return null
+          }
+        },
+      },
       isLinkable: {
         type: GraphQLBoolean,
         resolve: ({ default_profile_id, default_profile_public, type }) =>


### PR DESCRIPTION
Adds `Partner.inquiryMetrics` (`unansweredCount`, `confirmedBuyersWaitingCount`), composed from Impulse unanswered conversations and Gravity collector profiles so counts always match the CMS conversations view. Also syncs the Vortex schema to expose `orderResponseRate` on `AnalyticsPartnerSalesStats`. Both power the new Actionable Insights module on the CMS homepage.

Requires that https://github.com/artsy/vortex/pull/821 be merged.

_Written with help from Claude Fable 5_